### PR TITLE
Add Vite + Storybook UI showcase for the wireframed screens

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+storybook-static
+*.log

--- a/ui/.storybook/main.ts
+++ b/ui/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from '@storybook/react-vite'
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-docs', '@storybook/addon-a11y'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
+}
+
+export default config

--- a/ui/.storybook/preview.ts
+++ b/ui/.storybook/preview.ts
@@ -1,0 +1,39 @@
+import type { Preview } from '@storybook/react-vite'
+import '../src/styles/theme.css'
+
+const preview: Preview = {
+  parameters: {
+    layout: 'centered',
+    controls: { expanded: true },
+    backgrounds: {
+      options: {
+        paper: { name: 'Paper', value: '#f4f2ee' },
+        surface: { name: 'Surface', value: '#ffffff' },
+      },
+    },
+    options: {
+      storySort: {
+        order: [
+          'Foundations',
+          ['Accent', 'Colour', 'Type'],
+          'Primitives',
+          'Screens',
+          [
+            '1 Global',
+            '2 Plan an article',
+            '3 Drafting',
+            '4 Reviews',
+            '5 Finish and submit',
+            '6 Archive and showcase',
+          ],
+        ],
+      },
+    },
+  },
+  initialGlobals: {
+    backgrounds: { value: 'paper' },
+  },
+  tags: ['autodocs'],
+}
+
+export default preview

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,0 +1,56 @@
+# Journo Harness — UI showcase
+
+A Vite 8 + React 19 component library for the writing harness, with Storybook as
+its only entry point. Every screen from the `Joarness WF` wireframes is built
+here as real components against mock data, so the interface can be reviewed,
+argued with, and eventually wired to the back end.
+
+```bash
+cd ui
+npm install
+npm run storybook     # http://localhost:6006
+```
+
+Other scripts: `npm run typecheck`, `npm run build-storybook`, `npm run build`
+(the last builds `src/index.ts` as a library so the screens can be imported into
+the real app later).
+
+## What's in here
+
+| Path | |
+|---|---|
+| `src/styles/theme.css` | Tailwind v4 `@theme` tokens — the whole palette and type scale |
+| `src/components/` | Primitives: `Frame`, `PaneRail`, `Chip`, `CoachNote`, `SourceCard`, `LengthBar`, … |
+| `src/screens/` | The 21 screens, grouped global / article / review / finish |
+| `src/mock/content.ts` | Sample content. Nothing is wired; swap for API data |
+| `src/foundations/Accent.mdx` | The accent rule, written down |
+
+Storybook is organised as **Foundations → Primitives → Screens**, and the screen
+stories are numbered to match the wireframe deck: `1(a) Desk`, `2(e) The plan on
+its own`, `4(c) Notes sent to chat`, and so on.
+
+## The one design rule worth knowing
+
+The page is paper, ink and three greys. There is exactly one colour —
+`--color-accent`, `#ffe6a3` — and it marks the single thing on a screen that
+wants a decision, or the one thing that has just changed. Selected tabs, open
+panes and progress bars are *not* that: they take ink, because where you are is
+state rather than a request. Some screens have no accent at all, on purpose.
+
+`src/foundations/Accent.mdx` has the full version, with what earns it and what
+doesn't.
+
+## Fidelity notes
+
+Everything is faithful to the wireframes' structure and behaviour; the lo-fi
+styling (hand-drawn font, grey placeholder bars) is deliberately gone, replaced
+with real type, real copy and real spacing.
+
+Two things to settle before this becomes the app proper:
+
+- **Naming.** These screens use the wireframes' vocabulary — *plan*, *voices*,
+  *adjectives*, *favourite sources*. `docs/ux-outline.md` uses *Brief*,
+  *Lexicon*, *rules*, *skills*, *samples*. They describe the same objects. A
+  rename is cheap now and expensive later.
+- **Interaction.** Screens are static compositions. Only `PaneRail` takes an
+  `onToggle`; nothing else holds state, and no data flows between panes yet.

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,0 +1,4720 @@
+{
+  "name": "journo-harness-ui",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "journo-harness-ui",
+      "version": "0.1.0",
+      "dependencies": {
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
+      },
+      "devDependencies": {
+        "@storybook/addon-a11y": "^10.5.6",
+        "@storybook/addon-docs": "^10.5.6",
+        "@storybook/react-vite": "^10.5.6",
+        "@tailwindcss/vite": "^4.3.3",
+        "@types/node": "^26.1.2",
+        "@types/react": "^19.2.18",
+        "@types/react-dom": "^19.2.4",
+        "@vitejs/plugin-react": "^6.0.5",
+        "storybook": "^10.5.6",
+        "tailwindcss": "^4.3.3",
+        "typescript": "^5.9.3",
+        "vite": "^8.2.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@joshwooding/vite-plugin-react-docgen-typescript": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@joshwooding/vite-plugin-react-docgen-typescript/-/vite-plugin-react-docgen-typescript-0.7.0.tgz",
+      "integrity": "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^13.0.1",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.3.x",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mdx-js/react": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
+      "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdx": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16",
+        "react": ">=16"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.127.0.tgz",
+      "integrity": "sha512-0LC7ye4hvqbIKxAzThzvswgHLFu2AURKzYLeSVvLdu2TBOYWQDmHnTqPLeA597BcUCxiLqLsS4CJ5uoI5WYWCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.127.0.tgz",
+      "integrity": "sha512-b5jtVTH6AU5CJXHNdj7Jj9IEiR9yVjjnwHzPJhGyHGPdcsZSzBCkS9GBbV33niRMvKthDwQRFRJfI4a+k4PvYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.127.0.tgz",
+      "integrity": "sha512-obCE8B7ISKkJidjlhv9xRGJPOSDG2Yu6PRga9Ruaz35uintHxbp1Ki/Yc71wx4rj3Edrm0a1kzG1TAwit0wFpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.127.0.tgz",
+      "integrity": "sha512-JL6Xb5IwPQT8rUzlpsX7E+AgfcdNklXNPFp8pjCQQ5MQOQo5rtEB2ui+3Hgg9Sn7Y9Egj6YOLLiHhLpdAe12Aw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.127.0.tgz",
+      "integrity": "sha512-SDQ/3MQFw58fqQz3Z1PhSKFF3JoCF4gmlNjziDm8X02tTahCw0qJbd7FGPDKw1i4VTBZene9JPyC3mHtSvi+wA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.127.0.tgz",
+      "integrity": "sha512-Av+D1MIqzV0YMGPT9we2SIZaMKD7Cxs4CvXSx/yxaWHewZjYEjScpOf5igc8IILASViw4WTnjlwUdI1KzVtDHQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.127.0.tgz",
+      "integrity": "sha512-Cs2fdJ8cPpFdeebj6p4dag8A4+56hPvZ0AhQQzlaLswGz1tz7bXt1nETLeorrM9+AMcWFFkqxcXwDGfTVidY8g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.127.0.tgz",
+      "integrity": "sha512-qdOfTcT6SY8gsJrrV92uyEUyjqMGPpIB5JZUG6QN5dukYd+7/j0kX6MwK1DgQj39jtUYixxPiaRUiEN1+0CXgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.127.0.tgz",
+      "integrity": "sha512-EoTCZneNFU/P2qrpEM+RHmQwt+CvDkyGESG6qhr7KaegXLZwePfbrkCDfAk8/rhxbDUVGsZILX+2tqPzFtoFWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.127.0.tgz",
+      "integrity": "sha512-zALjmZYgxFLHjXeudcDF0xFGNydTAtkAeXAr2EuC17ywCyFxcmQra4w0BMde0Yi/re4Bi4iwEoEXtYN7l6eBLQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.127.0.tgz",
+      "integrity": "sha512-fPP8M6zQLS7Jz7o9d5ArUSuAuSK3e+WCYVrCpdzeCOejidtZExJ9tjhDrAd3HEPqARBCPmdpqxESPFqy44vkBQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.127.0.tgz",
+      "integrity": "sha512-7IcC4Ao02oGpfnjt+X/oF4U2mllo2qoSkw5xxiXNKL9MCTsTiAC6616beOuehdxGcnz1bRoPC1RQ2f1GQDdN+g==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.127.0.tgz",
+      "integrity": "sha512-pbXIhiNFHoqWeqDNLiJ9JkpHz1IM9k4DXa66x+1GTWMG7iLxtkXgE53iiuKSXwmk3zIYmaPVfBvgcAhS583K4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.127.0.tgz",
+      "integrity": "sha512-MYCguB9RvBvlSd6gbuNI7QwiLoCCAlGnlRJFPrzLI6U1/9wkC/WK6LtBAUln55H1Ctqw45PWmqrobKoMhsYQzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.127.0.tgz",
+      "integrity": "sha512-5eY0B/bxf1xIUxb4NOTvOI3KWtBQfPWYyKAzgcrCt0mDibSZygVpO1Pz8bkeiSZ5Jj9+M09dkggG3H8I5d0Uyg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.127.0.tgz",
+      "integrity": "sha512-Gld0ajrFTUXNtdw20fVBuTQx66FA75nIVg+//pPfR3sXkuABB4mTBhl3r9JNzrJpgW//qiwxf0nWXUWGJSL3UQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.127.0.tgz",
+      "integrity": "sha512-T6KVD7rhLzFlwGRXMnxUFfkCZD8FHnb968wVXW1mXzgRFc5RNXOBY2mPPDZ77x5Ln76ltLMgtPg0cOkU1NSrEQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.127.0.tgz",
+      "integrity": "sha512-Ujvw4X+LD1CCGULcsQcvb4YNVoBGqt+JHgNNzGGaCImELiZLk477ifUH53gIbE7EKd933NdTi25JWEr9K2HwXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.127.0.tgz",
+      "integrity": "sha512-0cwxKO7KHQQQfo4Uf4B2SQrhgm+cJaP9OvFFhx52Tkg4bezsacu83GB2/In5bC415Ueeym+kXdnge/57rbSfTw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.127.0.tgz",
+      "integrity": "sha512-rOrnSQSCbhI2kowr9XxE7m9a8oQXnBHjnS6j95LxxAnEZ0+Fz20WlRXG4ondQb+ejjt2KOsa65sE6++L6kUd+w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-android-arm-eabi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.24.2.tgz",
+      "integrity": "sha512-y09e0L0SRI2OA2tUIrjBgoV3eH5hvUKXNkJqXmNo5V2WxIjyC7I7aJfRLMEVpA8yi95f90gFDvO0VMgrDw+vwA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-android-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.24.2.tgz",
+      "integrity": "sha512-cl4icWaZFnLdg8m6qtnh5rBMuGbxc/ptStFHLeCNwr+2cZjkjNwQu/jYRS0CHlnPecOJMpuS5M6/BH+0J/YkEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.24.2.tgz",
+      "integrity": "sha512-At29QEMF6HajbQvgY8K6OXnHD1x9rad74xBEfmCB6ZqCGsdq75aK7tOYcTbOanMy8qdIBrfL3SMr3p/lfSlb9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-darwin-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.24.2.tgz",
+      "integrity": "sha512-A5Kqr1EUj4oIL5CF4WRssq/o5P0Y11cwoFouMRmQ7YnC/A8V93nv1nb7aSU8HwcgmXropjLNkVTl4MN87cu28Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-freebsd-x64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.24.2.tgz",
+      "integrity": "sha512-R5xkRBRRz7ceH/P5Jrc6G7FmdUdgpLYyESFAUDVTNQ9K0sGPxcp4ljiwEwEqsvNcQ4sYbMRrWcHHBCu7ksAJVw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.24.2.tgz",
+      "integrity": "sha512-k/RuYL4L/R58IBn3wT5ma3Wh4k62bp1eYCFRWCmMsasUOqL+H6sW0VGFadEzKWXFFlz+2uIMoeMk9ySSZJHgbg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.24.2.tgz",
+      "integrity": "sha512-bnHAak3ujYfH5pKk4NieFNbvYvernfoQDgwLddbZ3OtMYrem87/qjlA+u+aKG0oZcqSLGCful/6/CEA+aeAgaA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.24.2.tgz",
+      "integrity": "sha512-vDT3KHgzYp47gmtNOqL2VNhCyl5Zv643eyxm//A68J8DeUGXrvD1pZFiaT4jSfe+RInfnn1R2yVHye4enx6RnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.24.2.tgz",
+      "integrity": "sha512-+kMlQvbzfyEYtu5FcjE4p+ttBLpKW4d/AsAsuE69BxV6V4twZJeIQZFfD8gh/wqglY0MkPSezWXQH0jBV13MUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.24.2.tgz",
+      "integrity": "sha512-shjfMhmZ3gq9fv/w7bi3PnZlgOPG+2QAOFf0BJF0EgBSIGZ6PMLN2zbGEblTUYB/NKVDRyYhE2ff3dJ1QqNPkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.24.2.tgz",
+      "integrity": "sha512-zGelwFR5oRo+b69k8Lrzun86DyUHzfKN6cnjbR9l7Z7NIRznOE/2ZvPa1IUKqAL2PzAXOdwkfVqNvO1H2RlpAw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.24.2.tgz",
+      "integrity": "sha512-qxZ1SWCXJY0eyhAlP6Lmo9F2Nrtx7EkYj9oCgL8apDPCwXwCEDA2U697bbT81JIc2IrVjxO4KX6WU2N+oN9Z4w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.24.2.tgz",
+      "integrity": "sha512-sGCecF3cx2DFlH4t/z7ApnOnXqN48p5p5mlHDEnHTAukQa2P+qMVE4CwyWE9W+q/m3QJ7kKfGrIjax31f44oFQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.24.2.tgz",
+      "integrity": "sha512-k/VlMMcSzMlahb3/fENM4rTlsJ0s3fFROA0KXPBmKggqmTSaE383sl8F3KCOXPLmVsYfW6hCitMhXCEtNeZxxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-linux-x64-musl": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.24.2.tgz",
+      "integrity": "sha512-8hbnZyNi97b/8wapYaIF9+t9GmZKBW2vunaOc3h9HGJptH7b7XpvZqOTBSm/MpTjr7H497BlgOaSfLUdhmy2bw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-openharmony-arm64": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.24.2.tgz",
+      "integrity": "sha512-MvyGik3a6pVgZ0t/kWlbmFxFLmXQJwgLsY2eYFHLpy0wGwRbfzeIGgDwQ3kXqE30z+kSXennRkCrT7TUvkptNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.24.2.tgz",
+      "integrity": "sha512-vHcssMPwO08RTvj/c0iOBz90attxyG3wQJ0dTcyEQK43LRpcdLWZlV5feBhv6Isn6ahbQIzHbCgfa81+RiML0Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.24.2.tgz",
+      "integrity": "sha512-uokJqro2iBqkFvJdKQLP7d8/BUmFwESQFVmIJUQKj1Xn1a/LysJoe1vmeECLF5b3jsV8CAL5sEMJXX6SdK9Nhg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.24.2.tgz",
+      "integrity": "sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
+      "integrity": "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/addon-a11y": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.6.tgz",
+      "integrity": "sha512-pMqbmtvkIgb7/kVE2BTNovGhSerRXWsVag62zpwQe0SwYYkgN+1Q9h4TYuIe2+npGkxgwALCjwtqkcnpOoND+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "axe-core": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.6"
+      }
+    },
+    "node_modules/@storybook/addon-docs": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-10.5.6.tgz",
+      "integrity": "sha512-zyUJBrrpC9NTrmsREaVFNr+9WW6pikJtmRvo7GgZGqthEyhjQKSarHrW0aNWkwae2ep3jp1CZi8vIUVG1Dnp0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/react": "^3.0.0",
+        "@storybook/csf-plugin": "10.5.6",
+        "@storybook/icons": "^2.0.2",
+        "@storybook/react-dom-shim": "10.5.6",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/builder-vite": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-10.5.6.tgz",
+      "integrity": "sha512-Ts8EohKPj8okDPCkueeKVN+IRGNpI3LuddsFGupqraRvK6aRWawDKA28uc0PlsLCLWbMkMsGVw+IpFXfmoLJgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/csf-plugin": "10.5.6",
+        "ts-dedent": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "storybook": "^10.5.6",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@storybook/csf-plugin": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-10.5.6.tgz",
+      "integrity": "sha512-PJLyOmcKe1OZDBw7RaGX/gjuiJuVfS5pVgc4W2RnHYOFpU6F5Bv9+9MqQwp0i7tWZBWc4fsCJudgVqwgjuTROA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "unplugin": "^2.3.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "esbuild": "*",
+        "rollup": "*",
+        "storybook": "^10.5.6",
+        "vite": "*",
+        "webpack": "*"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/global": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@storybook/global/-/global-5.0.0.tgz",
+      "integrity": "sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@storybook/icons": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-2.1.0.tgz",
+      "integrity": "sha512-Fxh9vYpX9bQqFeHRiY8h2ApeRGDzRSMLwJwNZ/AIRqnyOKHxRKL+yFe+ctEkVJmuptRE9u1Hrn8ZZNHyfDKKNg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@storybook/react": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react/-/react-10.5.6.tgz",
+      "integrity": "sha512-dXSdNoc9yAvpa4hiegQhmZPXOKunAxkPX94DxvRw/kM6+wujVFAGlZjYygKrWw357KOjPRK7SO1LRTc70mgrhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/react-dom-shim": "10.5.6",
+        "react-docgen": "^8.0.2",
+        "react-docgen-typescript": "^2.2.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.6",
+        "typescript": ">= 4.9.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-dom-shim": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-10.5.6.tgz",
+      "integrity": "sha512-dV3oOHc5ImggxEqeIiUj4vvnQO5SKScFtqAkxgIWLju1wiSZSIqQ5Q4Mp12Rhs9hQrjF039DueH7f2xJJZfvSw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.6"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@storybook/react-vite": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/@storybook/react-vite/-/react-vite-10.5.6.tgz",
+      "integrity": "sha512-DCTfNZWhQUH4Zf8LDE4zdLn6+C26QNW0KETdnFUkdrqRADlwS6oExtGWC5f/uP/GDbKb9jrGbC+/ap8nWEH/vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@joshwooding/vite-plugin-react-docgen-typescript": "^0.7.0",
+        "@rollup/pluginutils": "^5.0.2",
+        "@storybook/builder-vite": "10.5.6",
+        "@storybook/react": "10.5.6",
+        "empathic": "^2.0.0",
+        "magic-string": "^0.30.0",
+        "react-docgen": "^8.0.2",
+        "resolve": "^1.22.8",
+        "tsconfig-paths": "^4.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "storybook": "^10.5.6",
+        "typescript": ">= 4.9.x",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.3.tgz",
+      "integrity": "sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "tailwindcss": "4.3.3"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.3.tgz",
+      "integrity": "sha512-6dBq67jT8lE+JTE8Exm02Kt6ze43hz1jdiSpSJwtTZiT1xQQ6b7nZYTTQ9njdArdU8XklOwaDp/AbT/eYSKF4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/doctrine": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
+      "integrity": "sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdx": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/mdx/-/mdx-2.0.14.tgz",
+      "integrity": "sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
+      "integrity": "sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@webcontainer/env": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@webcontainer/env/-/env-1.1.1.tgz",
+      "integrity": "sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-types": {
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
+      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.401",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.401.tgz",
+      "integrity": "sha512-H6ViHN68nGYlChEvlIU67fn8O2/tpbWQPwck98yaJmh+08LSvHiydzDQ6oXNccLU3kNRVIRS9A4mA7CG+i6fLQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/oxc-parser": {
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.127.0.tgz",
+      "integrity": "sha512-bkgD4qHlN7WxLdX8bLXdaU54TtQtAIg/ZBAfm0aje/mo3MRDo3P0hZSgr4U7O3xfX+fQmR5AP04JS/TGcZLcFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.127.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.127.0",
+        "@oxc-parser/binding-android-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-arm64": "0.127.0",
+        "@oxc-parser/binding-darwin-x64": "0.127.0",
+        "@oxc-parser/binding-freebsd-x64": "0.127.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.127.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.127.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.127.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.127.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.127.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.127.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.127.0"
+      }
+    },
+    "node_modules/oxc-resolver": {
+      "version": "11.24.2",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.24.2.tgz",
+      "integrity": "sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-resolver/binding-android-arm-eabi": "11.24.2",
+        "@oxc-resolver/binding-android-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-arm64": "11.24.2",
+        "@oxc-resolver/binding-darwin-x64": "11.24.2",
+        "@oxc-resolver/binding-freebsd-x64": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.24.2",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.24.2",
+        "@oxc-resolver/binding-linux-x64-musl": "11.24.2",
+        "@oxc-resolver/binding-openharmony-arm64": "11.24.2",
+        "@oxc-resolver/binding-wasm32-wasi": "11.24.2",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.24.2",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.24.2"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-docgen": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.3.tgz",
+      "integrity": "sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/traverse": "^7.28.0",
+        "@babel/types": "^7.28.2",
+        "@types/babel__core": "^7.20.5",
+        "@types/babel__traverse": "^7.20.7",
+        "@types/doctrine": "^0.0.9",
+        "@types/resolve": "^1.20.2",
+        "doctrine": "^3.0.0",
+        "resolve": "^1.22.1",
+        "strip-indent": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.9.0 || >=22"
+      }
+    },
+    "node_modules/react-docgen-typescript": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.4.0.tgz",
+      "integrity": "sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">= 4.3.x"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/recast": {
+      "version": "0.23.19",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.19.tgz",
+      "integrity": "sha512-T98lym7kH+pnZmRaD8yDRdaNqyUbwnbEBx0MuchrzMFOEMray4AO3ZJoTUZ5r78Ao78X/OhzW0DL8GB85w/I2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.16.1",
+        "esprima": "~4.0.0",
+        "source-map": "~0.6.1",
+        "tiny-invariant": "^1.3.3",
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/redent/node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+      }
+    },
+    "node_modules/rolldown/node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/storybook": {
+      "version": "10.5.6",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.6.tgz",
+      "integrity": "sha512-VhYwqxPySa24CVXKoWD6gCZXx9//DTmo43YpusGuAoHDYj5Osjt8wuBRQVeGoaLUWnHiPWv8S+GYHrJEaBM6Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@storybook/global": "^5.0.0",
+        "@storybook/icons": "^2.0.2",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "6.9.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@vitest/expect": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@webcontainer/env": "^1.1.1",
+        "esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0 || ^0.28.0",
+        "jsonc-parser": "^3.3.1",
+        "open": "^10.2.0",
+        "oxc-parser": "^0.127.0",
+        "oxc-resolver": "^11.19.1",
+        "recast": "^0.23.5",
+        "semver": "^7.7.3",
+        "use-sync-external-store": "^1.5.0",
+        "ws": "^8.21.1"
+      },
+      "bin": {
+        "storybook": "dist/bin/dispatcher.js"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/storybook"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "prettier": "^2 || ^3",
+        "vite-plus": "^0.1.15 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "prettier": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/storybook/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
+      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.0.tgz",
+      "integrity": "sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.23",
+        "rolldown": "~1.2.0",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/vite/node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+      "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "journo-harness-ui",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Component library and screen showcase for the Journo Harness writing app.",
+  "scripts": {
+    "dev": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006",
+    "build": "vite build",
+    "build-storybook": "storybook build",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8"
+  },
+  "devDependencies": {
+    "@storybook/addon-a11y": "^10.5.6",
+    "@storybook/addon-docs": "^10.5.6",
+    "@storybook/react-vite": "^10.5.6",
+    "@tailwindcss/vite": "^4.3.3",
+    "@types/node": "^26.1.2",
+    "@types/react": "^19.2.18",
+    "@types/react-dom": "^19.2.4",
+    "@vitejs/plugin-react": "^6.0.5",
+    "storybook": "^10.5.6",
+    "tailwindcss": "^4.3.3",
+    "typescript": "^5.9.3",
+    "vite": "^8.2.0"
+  }
+}

--- a/ui/src/components/Annotation.tsx
+++ b/ui/src/components/Annotation.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface AnnotationProps {
+  children: ReactNode
+  align?: 'left' | 'right'
+  className?: string
+}
+
+/**
+ * A designer's note *about* a screen, drawn outside the window frame in the
+ * documentation voice rather than the product voice — the same convention the
+ * wireframes used. It explains intent; it is never part of the UI.
+ */
+export function Annotation({ children, align = 'left', className }: AnnotationProps) {
+  return (
+    <p
+      className={cx(
+        'flex max-w-[28rem] gap-2 pt-2.5 text-[0.75rem] leading-relaxed text-muted',
+        align === 'right' && 'ml-auto flex-row-reverse text-right',
+        className,
+      )}
+    >
+      <span aria-hidden className="shrink-0 text-faint">
+        ↑
+      </span>
+      <span>{children}</span>
+    </p>
+  )
+}

--- a/ui/src/components/ArticleBar.tsx
+++ b/ui/src/components/ArticleBar.tsx
@@ -1,0 +1,43 @@
+import { cx } from '../lib/cx'
+import { PaneRail, type PaneId } from './PaneRail'
+
+export interface ArticleBarProps {
+  title: string
+  /** Right-hand status: "draft 1", "round 2", "§3 of 4". */
+  status?: string
+  open: readonly PaneId[]
+  onToggle?: (pane: PaneId) => void
+  /** Draw the rule underneath. Off when the pane below carries its own edge. */
+  divided?: boolean
+  className?: string
+}
+
+/**
+ * The article window's own bar — quieter than {@link TitleBar} because it sits
+ * above a writing surface. Title and status recede; the pane rail is the only
+ * thing with any weight.
+ */
+export function ArticleBar({
+  title,
+  status,
+  open,
+  onToggle,
+  divided = true,
+  className,
+}: ArticleBarProps) {
+  return (
+    <header
+      className={cx(
+        'flex shrink-0 items-center gap-3 px-3 py-2',
+        divided && 'border-b border-rule',
+        className,
+      )}
+    >
+      <span className="min-w-0 flex-1 truncate text-[0.8125rem] text-faint">{title}</span>
+      <PaneRail open={open} onToggle={onToggle} />
+      <span className="min-w-0 flex-1 truncate text-right text-[0.75rem] whitespace-nowrap text-faint">
+        {status}
+      </span>
+    </header>
+  )
+}

--- a/ui/src/components/ArticleCard.tsx
+++ b/ui/src/components/ArticleCard.tsx
@@ -1,0 +1,53 @@
+import { cx } from '../lib/cx'
+import { Chip } from './Chip'
+import { ProgressBar } from './ProgressBar'
+import type { Article } from '../mock/content'
+
+export interface ArticleCardProps {
+  article: Article
+  /** `card` is the desk's active tile; `column` is the board's smaller tile. */
+  variant?: 'card' | 'column'
+  className?: string
+}
+
+/**
+ * An in-progress article. The progress bar is deliberately unlabelled — the
+ * phase word underneath is the honest signal; the bar is just a shape.
+ */
+export function ArticleCard({ article, variant = 'card', className }: ArticleCardProps) {
+  const compact = variant === 'column'
+
+  return (
+    <article
+      className={cx(
+        'flex flex-col gap-2 rounded-lg border border-edge bg-surface p-3 transition-colors hover:border-ink/25',
+        compact ? 'gap-1.5 p-2.5' : 'w-[10.5rem]',
+        className,
+      )}
+    >
+      <h3
+        className={cx(
+          'leading-snug font-semibold text-ink',
+          compact ? 'text-[0.8125rem]' : 'text-[0.875rem]',
+        )}
+      >
+        {article.title}
+      </h3>
+      {!compact ? (
+        <p className="line-clamp-2 text-[0.75rem] leading-relaxed text-muted">{article.blurb}</p>
+      ) : null}
+      <ProgressBar value={article.progress} className="mt-0.5" />
+      <p className="text-[0.6875rem] text-faint">{article.phaseLabel}</p>
+      {article.voice || article.chips?.length ? (
+        <div className="flex flex-wrap gap-1.5">
+          {article.voice ? <Chip tone="outline">{article.voice}</Chip> : null}
+          {article.chips?.map((chip) => (
+            <Chip key={chip} tone={article.needsAttention ? 'accent' : 'default'}>
+              {chip}
+            </Chip>
+          ))}
+        </div>
+      ) : null}
+    </article>
+  )
+}

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -1,0 +1,54 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export type ButtonTone = 'default' | 'accent' | 'quiet' | 'link'
+export type ButtonSize = 'sm' | 'md'
+
+export interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children'> {
+  /**
+   * `accent` is the yellow one. A screen should have at most one — it marks
+   * the single thing the app wants you to do next.
+   */
+  tone?: ButtonTone
+  size?: ButtonSize
+  children?: ReactNode
+}
+
+const toneClass: Record<ButtonTone, string> = {
+  default:
+    'border border-edge bg-surface text-ink hover:border-ink/40 hover:bg-hush',
+  accent:
+    'border border-accent-edge bg-accent text-accent-ink hover:brightness-[0.97]',
+  quiet:
+    'border border-transparent bg-transparent text-muted hover:border-edge hover:text-ink',
+  link: 'border-0 bg-transparent p-0 text-muted underline decoration-edge underline-offset-[3px] hover:text-ink hover:decoration-ink/40',
+}
+
+const sizeClass: Record<ButtonSize, string> = {
+  sm: 'h-6 gap-1.5 rounded-full px-2.5 text-[0.75rem]',
+  md: 'h-8 gap-2 rounded-full px-3.5 text-[0.8125rem]',
+}
+
+export function Button({
+  tone = 'default',
+  size = 'md',
+  className,
+  children,
+  type = 'button',
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={cx(
+        'inline-flex shrink-0 items-center justify-center whitespace-nowrap font-medium transition-[background-color,border-color,color,filter]',
+        tone === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
+        toneClass[tone],
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </button>
+  )
+}

--- a/ui/src/components/Chat.tsx
+++ b/ui/src/components/Chat.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+import { Button } from './Button'
+
+export interface ChatMessageProps {
+  from: 'me' | 'agent'
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * One turn. Yours is a bounded block; the agent's runs loose against the pane
+ * so the sources and controls it returns can sit at full width underneath it.
+ */
+export function ChatMessage({ from, children, className }: ChatMessageProps) {
+  if (from === 'me') {
+    return (
+      <div
+        className={cx(
+          'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-[0.8125rem] leading-relaxed text-ink',
+          className,
+        )}
+      >
+        {children}
+      </div>
+    )
+  }
+  return (
+    <div className={cx('max-w-[95%] text-[0.8125rem] leading-relaxed text-ink', className)}>
+      {children}
+    </div>
+  )
+}
+
+export interface ChatComposerProps {
+  placeholder?: string
+  /** Extra controls to the left of send — the ledger toggle, attachments. */
+  leading?: ReactNode
+  className?: string
+}
+
+export function ChatComposer({
+  placeholder = 'Ask, argue, or paste something in…',
+  leading,
+  className,
+}: ChatComposerProps) {
+  return (
+    <div className={cx('mt-auto flex items-center gap-2 pt-1', className)}>
+      {leading}
+      <div className="flex h-9 flex-1 items-center rounded-md border border-edge bg-surface px-2.5 text-[0.8125rem] text-faint">
+        {placeholder}
+      </div>
+      <Button size="sm">send</Button>
+    </div>
+  )
+}
+
+export interface ChatSuggestionsProps {
+  children: ReactNode
+  className?: string
+}
+
+/** The reply chips an agent turn can end with. */
+export function ChatSuggestions({ children, className }: ChatSuggestionsProps) {
+  return <div className={cx('flex flex-wrap gap-1.5', className)}>{children}</div>
+}

--- a/ui/src/components/Check.tsx
+++ b/ui/src/components/Check.tsx
@@ -1,0 +1,45 @@
+import { cx } from '../lib/cx'
+
+export interface CheckProps {
+  checked?: boolean
+  onChange?: (checked: boolean) => void
+  label?: string
+  className?: string
+}
+
+/**
+ * The square tick used for accepting a source, a finding, or a note.
+ *
+ * Checked is the accented state — accepting something is the one decision
+ * these lists are asking for, so the yellow belongs here.
+ */
+export function Check({ checked = false, onChange, label, className }: CheckProps) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange?.(!checked)}
+      disabled={!onChange}
+      className={cx(
+        'mt-[0.1875rem] grid size-[0.9375rem] shrink-0 place-items-center rounded-[0.25rem] border transition-colors',
+        checked
+          ? 'border-accent-edge bg-accent text-accent-ink'
+          : 'border-edge bg-surface text-transparent',
+        onChange && !checked && 'hover:border-ink/40',
+        className,
+      )}
+    >
+      <svg viewBox="0 0 10 10" aria-hidden className="size-[0.5rem]" fill="none">
+        <path
+          d="M1 5.2 3.6 8 9 1.8"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </button>
+  )
+}

--- a/ui/src/components/Chip.tsx
+++ b/ui/src/components/Chip.tsx
@@ -1,0 +1,53 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export type ChipTone = 'default' | 'accent' | 'outline' | 'muted' | 'solid'
+
+export interface ChipProps extends Omit<ButtonHTMLAttributes<HTMLElement>, 'children'> {
+  tone?: ChipTone
+  /** Renders as a button. Off by default — most chips are labels. */
+  interactive?: boolean
+  /** Dims the chip without changing its tone (unresolved, cut, not-yet). */
+  dimmed?: boolean
+  children?: ReactNode
+}
+
+const toneClass: Record<ChipTone, string> = {
+  default: 'border-edge bg-hush text-muted',
+  accent: 'border-accent-edge bg-accent text-accent-ink',
+  outline: 'border-edge bg-transparent text-muted',
+  muted: 'border-transparent bg-transparent text-faint',
+  // `solid` is "you are here" — a tab or filter that is currently selected.
+  // State, not a call to action, so it takes ink rather than the accent.
+  solid: 'border-ink bg-ink text-paper',
+}
+
+/**
+ * A small metadata token: word targets, adjectives, voices, statuses, filters.
+ * Chips are read-only labels unless `interactive` is set.
+ */
+export function Chip({
+  tone = 'default',
+  interactive = false,
+  dimmed = false,
+  className,
+  children,
+  ...rest
+}: ChipProps) {
+  const Tag = (interactive ? 'button' : 'span') as 'button'
+  return (
+    <Tag
+      {...(interactive ? { type: 'button' as const } : {})}
+      className={cx(
+        'inline-flex shrink-0 items-center gap-1 whitespace-nowrap rounded-full border px-2 py-[0.1875rem] text-[0.6875rem] leading-none font-medium',
+        toneClass[tone],
+        dimmed && 'opacity-45',
+        interactive && 'transition-colors hover:border-ink/30 hover:text-ink',
+        className,
+      )}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  )
+}

--- a/ui/src/components/CoachNote.tsx
+++ b/ui/src/components/CoachNote.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+import { Chip } from './Chip'
+
+export interface CoachNoteProps {
+  /** Where it points: "§3", "§2 ↔ §4". */
+  anchor?: string
+  /** How sure the coach is. `confident` notes are the ones surfaced on a pause. */
+  confidence?: 'confident' | 'tentative'
+  title: ReactNode
+  body?: ReactNode
+  /** Draws the note as the one thing asking for a decision. */
+  live?: boolean
+  accepted?: boolean
+  actions?: ReactNode
+  className?: string
+}
+
+/**
+ * A note from the coach. Notes never edit the prose — they say what they see
+ * and wait. `live` is the freshly surfaced one and gets the accent wash; every
+ * other note on screen stays quiet.
+ */
+export function CoachNote({
+  anchor,
+  confidence,
+  title,
+  body,
+  live = false,
+  accepted = false,
+  actions,
+  className,
+}: CoachNoteProps) {
+  return (
+    <article
+      className={cx(
+        'flex flex-col gap-1.5 rounded-lg border p-2.5',
+        live ? 'border-accent-edge bg-accent-soft' : 'border-edge bg-surface',
+        accepted && 'opacity-60',
+        className,
+      )}
+    >
+      {anchor || confidence ? (
+        <p className="label-meta">{[anchor, confidence].filter(Boolean).join(' · ')}</p>
+      ) : null}
+      <h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">{title}</h4>
+      {body ? <p className="text-[0.75rem] leading-relaxed text-muted">{body}</p> : null}
+      {actions ? <div className="mt-0.5 flex flex-wrap gap-1.5">{actions}</div> : null}
+      {accepted ? (
+        <Chip tone="outline" className="self-start">
+          accepted
+        </Chip>
+      ) : null}
+    </article>
+  )
+}
+
+export interface NoteDotProps {
+  count?: number
+  className?: string
+  onClick?: () => void
+}
+
+/**
+ * The only thing that interrupts a blank writing surface: a small accent dot,
+ * shown when you go idle and there is something worth reading. Clicking it
+ * opens the notes pane.
+ */
+export function NoteDot({ count, className, onClick }: NoteDotProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={count ? `${count} notes waiting` : 'Notes waiting'}
+      className={cx(
+        'inline-flex items-center gap-1.5 rounded-full border border-accent-edge bg-accent px-2 py-1 text-[0.6875rem] leading-none font-medium text-accent-ink',
+        className,
+      )}
+    >
+      <span aria-hidden className="size-1.5 rounded-full bg-accent-ink/70" />
+      {count ? count : null}
+    </button>
+  )
+}

--- a/ui/src/components/Divider.tsx
+++ b/ui/src/components/Divider.tsx
@@ -1,0 +1,40 @@
+import { cx } from '../lib/cx'
+
+export interface DividerProps {
+  /** `hair` separates rows; `strong` separates the big blocks of a screen. */
+  weight?: 'hair' | 'strong'
+  className?: string
+}
+
+export function Divider({ weight = 'hair', className }: DividerProps) {
+  return (
+    <hr
+      className={cx('border-0', weight === 'strong' ? 'h-px bg-edge' : 'h-px bg-rule', className)}
+    />
+  )
+}
+
+export interface SectionHeadingProps {
+  children: React.ReactNode
+  /** "24", "9 · 3 used" — sits after the label, always quiet. */
+  count?: React.ReactNode
+  action?: React.ReactNode
+  className?: string
+}
+
+/**
+ * A run-on heading: label, count, a hairline that eats the remaining width,
+ * then an optional link. Used for every list on the desk and in the plan.
+ */
+export function SectionHeading({ children, count, action, className }: SectionHeadingProps) {
+  return (
+    <div className={cx('flex items-center gap-2.5', className)}>
+      <span className="label-meta shrink-0">
+        {children}
+        {count !== undefined ? <span> · {count}</span> : null}
+      </span>
+      <span className="h-px min-w-4 flex-1 bg-rule" />
+      {action}
+    </div>
+  )
+}

--- a/ui/src/components/DraftSurface.tsx
+++ b/ui/src/components/DraftSurface.tsx
@@ -1,0 +1,63 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface DraftSurfaceProps {
+  paragraphs: string[]
+  /** Index of the paragraph a note is anchored to; gets a quiet left rule. */
+  anchoredIndex?: number
+  /** Show a caret after the last paragraph. */
+  caret?: boolean
+  /** Horizontal breathing room. `wide` is the draft-alone measure. */
+  measure?: 'wide' | 'narrow'
+  dimmed?: boolean
+  children?: ReactNode
+  className?: string
+  style?: CSSProperties
+}
+
+/**
+ * The writing surface. Serif, generously leaded, nothing else on it — the
+ * human is the only one who writes here, so the app puts nothing in the way.
+ */
+export function DraftSurface({
+  paragraphs,
+  anchoredIndex,
+  caret = false,
+  measure = 'wide',
+  dimmed = false,
+  children,
+  className,
+  style,
+}: DraftSurfaceProps) {
+  return (
+    <div
+      className={cx(
+        'prose-draft flex min-w-0 flex-1 flex-col bg-surface py-5',
+        measure === 'wide' ? 'px-10' : 'px-6',
+        dimmed && 'opacity-45',
+        className,
+      )}
+      style={style}
+    >
+      {paragraphs.map((text, i) => (
+        <p
+          key={i}
+          className={cx(
+            'text-[0.9375rem]',
+            i > 0 && 'mt-4',
+            i === anchoredIndex && '-ml-3 border-l-2 border-accent-edge pl-3',
+          )}
+        >
+          {text}
+          {caret && i === paragraphs.length - 1 ? (
+            <span
+              aria-hidden
+              className="ml-0.5 inline-block h-[1em] w-px translate-y-[0.15em] bg-ink"
+            />
+          ) : null}
+        </p>
+      ))}
+      {children}
+    </div>
+  )
+}

--- a/ui/src/components/ExampleBlock.tsx
+++ b/ui/src/components/ExampleBlock.tsx
@@ -1,0 +1,62 @@
+import { cx } from '../lib/cx'
+
+export interface ExampleBlockProps {
+  /** `yes` is what the rule should score highly; `no` is what it must reject. */
+  polarity: 'yes' | 'no'
+  text: string
+  /** Where the example came from: an article title, or "pasted". */
+  source?: string
+  /** Why it is on the wrong side — only ever shown on `no` examples. */
+  reason?: string
+  className?: string
+}
+
+/**
+ * A worked example under a voice or an adjective. Positive examples get a
+ * solid edge; negative ones are dashed, because "not this" is the absence of
+ * the rule rather than a rule of its own.
+ */
+export function ExampleBlock({ polarity, text, source, reason, className }: ExampleBlockProps) {
+  const yes = polarity === 'yes'
+  return (
+    <figure
+      className={cx(
+        'flex flex-col gap-1.5 rounded-md border p-2.5',
+        yes ? 'border-edge bg-surface' : 'border-dashed border-edge bg-sunk',
+        className,
+      )}
+    >
+      <blockquote className="text-[0.75rem] leading-relaxed text-ink">“{text}”</blockquote>
+      <figcaption className="flex flex-wrap items-center gap-x-1.5 text-[0.6875rem] text-faint">
+        {source ? <cite className="not-italic">{source}</cite> : null}
+        {source && reason ? <span aria-hidden>·</span> : null}
+        {reason ? <span>{reason}</span> : null}
+      </figcaption>
+    </figure>
+  )
+}
+
+export interface PolarityHeadingProps {
+  polarity: 'yes' | 'no'
+  children: React.ReactNode
+  count?: number
+}
+
+/** "SOUNDS LIKE THIS · 3" / "NOT THIS · 2", with the dot that marks polarity. */
+export function PolarityHeading({ polarity, children, count }: PolarityHeadingProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <span
+        aria-hidden
+        className={cx(
+          'size-2.5 shrink-0 rounded-full border',
+          polarity === 'yes' ? 'border-accent-edge bg-accent' : 'border-edge bg-transparent',
+        )}
+      />
+      <span className="label-meta">
+        {children}
+        {count !== undefined ? <span> · {count}</span> : null}
+      </span>
+    </div>
+  )
+}

--- a/ui/src/components/Field.tsx
+++ b/ui/src/components/Field.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface FieldProps {
+  label?: ReactNode
+  value?: ReactNode
+  placeholder?: string
+  /** Right-hand adornment: a unit, a chip, a score. */
+  suffix?: ReactNode
+  size?: 'sm' | 'md'
+  className?: string
+}
+
+/** A read-only input frame — the showcase does not wire up editing. */
+export function Field({ label, value, placeholder, suffix, size = 'md', className }: FieldProps) {
+  const empty = value === undefined || value === null || value === ''
+  return (
+    <div className={cx('flex items-center gap-2.5', className)}>
+      {label ? (
+        <span className="shrink-0 text-[0.8125rem] font-medium text-muted">{label}</span>
+      ) : null}
+      <div
+        className={cx(
+          'flex flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5',
+          size === 'sm' ? 'h-7 text-[0.75rem]' : 'h-8 text-[0.8125rem]',
+        )}
+      >
+        <span className={cx('min-w-0 flex-1 truncate', empty ? 'text-faint' : 'text-ink')}>
+          {empty ? placeholder : value}
+        </span>
+        {suffix}
+      </div>
+    </div>
+  )
+}
+
+export interface EmptySlotProps {
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * A dashed placeholder. In this design dashed always means "optional, and not
+ * filled in yet" — it is never a disabled state.
+ */
+export function EmptySlot({ children, className }: EmptySlotProps) {
+  return (
+    <div
+      className={cx(
+        'flex items-center justify-center rounded-md border border-dashed border-edge px-3 py-2.5 text-center text-[0.75rem] text-faint',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/ui/src/components/Frame.tsx
+++ b/ui/src/components/Frame.tsx
@@ -1,0 +1,48 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface FrameProps {
+  /** Width of the app window. Numbers are px. */
+  width?: number | string
+  /** Minimum height of the body area below the title bar. Numbers are px. */
+  minHeight?: number | string
+  children?: ReactNode
+  className?: string
+  style?: CSSProperties
+}
+
+/**
+ * The app window. Every screen sits inside one of these: it draws the outer
+ * border, the single elevation used in the whole system, and clips its
+ * children so panes can run edge to edge.
+ */
+export function Frame({ width = 720, minHeight, children, className, style }: FrameProps) {
+  return (
+    <div
+      className={cx(
+        'flex flex-col overflow-hidden rounded-frame border border-edge bg-surface text-ink shadow-frame',
+        className,
+      )}
+      style={{ width, minHeight, ...style }}
+    >
+      {children}
+    </div>
+  )
+}
+
+export interface FrameBodyProps {
+  children?: ReactNode
+  /** Lay the children out as horizontal panes rather than stacked blocks. */
+  row?: boolean
+  className?: string
+  style?: CSSProperties
+}
+
+/** The area under the title bar. `row` turns it into the horizontal pane rail. */
+export function FrameBody({ children, row = false, className, style }: FrameBodyProps) {
+  return (
+    <div className={cx('flex min-h-0 flex-1', row ? 'flex-row' : 'flex-col', className)} style={style}>
+      {children}
+    </div>
+  )
+}

--- a/ui/src/components/LengthBar.tsx
+++ b/ui/src/components/LengthBar.tsx
@@ -1,0 +1,70 @@
+import { cx } from '../lib/cx'
+
+export interface LengthSegment {
+  label?: string
+  words: number
+  /** `done` is drafted, `current` is where the cursor is, `planned` is ahead. */
+  state?: 'done' | 'current' | 'planned'
+}
+
+export interface LengthBarProps {
+  segments: LengthSegment[]
+  height?: number
+  /** Show each segment's word count down the right-hand side. */
+  showCounts?: boolean
+  /**
+   * Accent the `current` segment. Only turn this on when the screen has no
+   * other accented element.
+   */
+  accentCurrent?: boolean
+  className?: string
+}
+
+/**
+ * The plan's shape, as a proportional vertical bar: each section's height is
+ * its share of the target word count. It sits alongside the outline rather
+ * than aligning to it — it reads the whole piece at a glance.
+ */
+export function LengthBar({
+  segments,
+  height = 160,
+  showCounts = true,
+  accentCurrent = false,
+  className,
+}: LengthBarProps) {
+  return (
+    <div className={cx('flex items-stretch gap-2', className)} style={{ height }}>
+      <div className="flex w-3.5 flex-col overflow-hidden rounded-[0.25rem] border border-edge">
+        {segments.map((segment, i) => {
+          const state = segment.state ?? 'planned'
+          return (
+            <div
+              key={i}
+              style={{ flex: segment.words }}
+              title={`${segment.label ?? `Section ${i + 1}`} — ${segment.words.toLocaleString()} words`}
+              className={cx(
+                i > 0 && 'border-t border-edge',
+                state === 'done' && 'bg-ink/25',
+                state === 'current' && (accentCurrent ? 'bg-accent' : 'bg-ink/12'),
+                state === 'planned' && 'bg-sunk',
+              )}
+            />
+          )
+        })}
+      </div>
+      {showCounts ? (
+        <div className="flex flex-col justify-between py-px">
+          {segments.map((segment, i) => (
+            <span
+              key={i}
+              className="font-mono text-[0.6875rem] leading-none text-faint"
+              style={{ flex: segment.words, display: 'flex', alignItems: 'center' }}
+            >
+              {segment.words.toLocaleString()}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/ui/src/components/ListRow.tsx
+++ b/ui/src/components/ListRow.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface ListRowProps {
+  title: ReactNode
+  note?: ReactNode
+  /** Right-hand columns, rendered in order. */
+  trailing?: ReactNode
+  dimmed?: boolean
+  className?: string
+}
+
+/** One line of the long tail: older drafts, published pieces, table rows. */
+export function ListRow({ title, note, trailing, dimmed = false, className }: ListRowProps) {
+  return (
+    <div
+      className={cx(
+        'flex items-baseline gap-3 border-b border-rule py-2 last:border-b-0',
+        dimmed && 'opacity-60',
+        className,
+      )}
+    >
+      <span className="min-w-0 truncate text-[0.8125rem] text-ink">{title}</span>
+      {note ? <span className="min-w-0 truncate text-[0.75rem] text-faint">{note}</span> : null}
+      <span className="ml-auto flex shrink-0 items-baseline gap-3">{trailing}</span>
+    </div>
+  )
+}

--- a/ui/src/components/MetaLabel.tsx
+++ b/ui/src/components/MetaLabel.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface MetaLabelProps {
+  children: ReactNode
+  /** A trailing count: "STRUCTURE · 2". */
+  count?: number | string
+  className?: string
+}
+
+/** The small uppercase mono label that heads a list or a group. */
+export function MetaLabel({ children, count, className }: MetaLabelProps) {
+  return (
+    <div className={cx('label-meta', className)}>
+      {children}
+      {count !== undefined ? <span> · {count}</span> : null}
+    </div>
+  )
+}

--- a/ui/src/components/OutlineRow.tsx
+++ b/ui/src/components/OutlineRow.tsx
@@ -1,0 +1,59 @@
+import { cx } from '../lib/cx'
+import { Chip } from './Chip'
+import type { OutlineSection } from '../mock/content'
+
+export interface OutlineRowProps {
+  section: OutlineSection
+  /** Marks the section being written; renders a quiet "now" flag. */
+  current?: boolean
+  /** Accent the word count — used when a review has just changed it. */
+  changed?: boolean
+  /** Drop the chips and run as a single line. */
+  dense?: boolean
+  className?: string
+}
+
+/** One row of the outline: number, title, target, and any tone instructions. */
+export function OutlineRow({
+  section,
+  current = false,
+  changed = false,
+  dense = false,
+  className,
+}: OutlineRowProps) {
+  return (
+    <div className={cx('flex items-start gap-2.5', className)}>
+      <span className="mt-px w-3 shrink-0 font-mono text-[0.6875rem] text-faint">{section.n}</span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex items-baseline gap-2">
+          <span
+            className={cx(
+              'min-w-0 text-[0.8125rem] leading-snug',
+              current ? 'font-medium text-ink' : 'text-ink',
+              dense && 'truncate',
+            )}
+          >
+            {section.title}
+          </span>
+          {current ? <span className="shrink-0 text-[0.6875rem] text-faint">now</span> : null}
+          {dense ? (
+            <Chip tone={changed ? 'accent' : 'default'} className="ml-auto">
+              {section.words}w
+            </Chip>
+          ) : null}
+        </div>
+        {!dense ? (
+          <div className="flex flex-wrap gap-1.5">
+            <Chip tone={changed ? 'accent' : 'default'}>{section.words}w</Chip>
+            {section.adjectives?.map((adjective) => (
+              <Chip key={adjective} tone="outline">
+                {adjective}
+              </Chip>
+            ))}
+            {section.voice ? <Chip tone="outline">voice: {section.voice}</Chip> : null}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/Pane.tsx
+++ b/ui/src/components/Pane.tsx
@@ -1,0 +1,64 @@
+import type { CSSProperties, ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface PaneProps {
+  /** `surface` is the writing surface; `sunk` is everything that supports it. */
+  tone?: 'surface' | 'sunk'
+  /** Fixed width in px, or a flex ratio when omitted. */
+  width?: number | string
+  grow?: number
+  divider?: 'left' | 'right' | 'none'
+  padded?: boolean
+  children?: ReactNode
+  className?: string
+  style?: CSSProperties
+}
+
+/**
+ * One vertical pane in the horizontal rail. Panes never stack — they slide in
+ * and out beside each other, always in chat → plan → draft → notes order.
+ */
+export function Pane({
+  tone = 'surface',
+  width,
+  grow = 1,
+  divider = 'none',
+  padded = true,
+  children,
+  className,
+  style,
+}: PaneProps) {
+  return (
+    <section
+      className={cx(
+        'flex min-w-0 flex-col',
+        tone === 'sunk' ? 'bg-sunk' : 'bg-surface',
+        divider === 'left' && 'border-l border-edge',
+        divider === 'right' && 'border-r border-edge',
+        padded && 'gap-3.5 p-3.5',
+        className,
+      )}
+      style={{ width, flex: width ? '0 0 auto' : grow, ...style }}
+    >
+      {children}
+    </section>
+  )
+}
+
+export interface PaneHeaderProps {
+  title: ReactNode
+  meta?: ReactNode
+  actions?: ReactNode
+  className?: string
+}
+
+/** A pane's own header row: name on the left, counts and controls after it. */
+export function PaneHeader({ title, meta, actions, className }: PaneHeaderProps) {
+  return (
+    <div className={cx('flex items-baseline gap-2.5', className)}>
+      <h3 className="text-[0.875rem] font-semibold text-ink">{title}</h3>
+      {meta ? <span className="text-[0.75rem] text-faint">{meta}</span> : null}
+      {actions ? <div className="ml-auto flex items-center gap-2">{actions}</div> : null}
+    </div>
+  )
+}

--- a/ui/src/components/PaneRail.tsx
+++ b/ui/src/components/PaneRail.tsx
@@ -1,0 +1,52 @@
+import { cx } from '../lib/cx'
+
+export const PANES = ['chat', 'plan', 'draft', 'notes'] as const
+export type PaneId = (typeof PANES)[number]
+
+export interface PaneRailProps {
+  /** Which panes are on screen. Order is always chat → plan → draft → notes. */
+  open: readonly PaneId[]
+  /** Omit to render the rail as a static indicator. */
+  onToggle?: (pane: PaneId) => void
+  className?: string
+}
+
+/**
+ * The four-pane toggle: chat · plan · draft · notes.
+ *
+ * Deliberately *not* accented. Which panes are open is state, not a call to
+ * action, so the active pill is solid ink and the yellow stays free for the
+ * one thing on screen that actually wants a decision.
+ */
+export function PaneRail({ open, onToggle, className }: PaneRailProps) {
+  return (
+    <div
+      className={cx(
+        'flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5',
+        className,
+      )}
+      role={onToggle ? 'group' : undefined}
+      aria-label={onToggle ? 'Visible panes' : undefined}
+    >
+      {PANES.map((pane) => {
+        const isOpen = open.includes(pane)
+        const Tag = (onToggle ? 'button' : 'span') as 'button'
+        return (
+          <Tag
+            key={pane}
+            {...(onToggle
+              ? { type: 'button' as const, onClick: () => onToggle(pane), 'aria-pressed': isOpen }
+              : {})}
+            className={cx(
+              'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
+              isOpen ? 'bg-ink text-paper' : 'text-faint',
+              onToggle && !isOpen && 'hover:bg-hush hover:text-muted',
+            )}
+          >
+            {pane}
+          </Tag>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/src/components/Primitives.stories.tsx
+++ b/ui/src/components/Primitives.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
+import { Button } from './Button'
+import { Check } from './Check'
+import { Chip } from './Chip'
+import { CoachNote, NoteDot } from './CoachNote'
+import { EmptySlot, Field } from './Field'
+import { LengthBar } from './LengthBar'
+import { PaneRail, type PaneId } from './PaneRail'
+import { ProgressBar } from './ProgressBar'
+import { QuoteRow } from './QuoteRow'
+import { SourceCard } from './SourceCard'
+import { ExampleBlock, PolarityHeading } from './ExampleBlock'
+import { OutlineRow } from './OutlineRow'
+import { outline, quotes, sources } from '../mock/content'
+
+const meta = {
+  title: 'Primitives/Overview',
+  parameters: { layout: 'padded' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Row({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2 border-b border-rule py-4 last:border-b-0">
+      <p className="label-meta">{label}</p>
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </div>
+  )
+}
+
+export const Buttons: Story = {
+  render: () => (
+    <div className="w-[40rem]">
+      <Row label="Button tones">
+        <Button tone="accent">start drafting →</Button>
+        <Button>download</Button>
+        <Button tone="quiet">cut</Button>
+        <Button tone="link">see all drafts</Button>
+      </Row>
+      <Row label="Chips">
+        <Chip tone="accent">review ready</Chip>
+        <Chip>700w</Chip>
+        <Chip tone="outline">well researched</Chip>
+        <Chip tone="muted">—</Chip>
+        <Chip dimmed>cut</Chip>
+      </Row>
+      <Row label="Check — accepting is the decision these lists ask for">
+        <Check />
+        <Check checked />
+      </Row>
+      <Row label="Fields">
+        <Field label="Length" value="2,400 words" className="w-64" />
+        <Field label="Length" placeholder="words —" className="w-64" />
+      </Row>
+      <Row label="Empty slot — dashed always means optional and unfilled">
+        <EmptySlot className="w-72">Tick a source in the chat</EmptySlot>
+      </Row>
+    </div>
+  ),
+}
+
+export const PaneToggle: Story = {
+  render: function PaneToggleStory() {
+    const [open, setOpen] = useState<PaneId[]>(['plan', 'draft'])
+    return (
+      <div className="flex w-[40rem] flex-col gap-4">
+        <PaneRail
+          open={open}
+          onToggle={(pane) =>
+            setOpen((current) =>
+              current.includes(pane) ? current.filter((p) => p !== pane) : [...current, pane],
+            )
+          }
+        />
+        <p className="text-[0.8125rem] text-muted">
+          Open: {open.length ? open.join(' · ') : 'nothing — the app would keep the draft up'}
+        </p>
+      </div>
+    )
+  },
+}
+
+export const Progress: Story = {
+  render: () => (
+    <div className="w-[24rem]">
+      <Row label="Quiet — under target">
+        <ProgressBar value={0.62} className="w-full" />
+      </Row>
+      <Row label="Attention — over target">
+        <ProgressBar value={1.18} className="w-full" />
+      </Row>
+      <Row label="Length bar — the shape of the piece">
+        <LengthBar
+          segments={outline.map((s) => ({ label: s.title, words: s.words, state: s.state }))}
+          height={160}
+          accentCurrent
+        />
+      </Row>
+    </div>
+  ),
+}
+
+export const Research: Story = {
+  render: () => (
+    <div className="flex w-[34rem] flex-col gap-4">
+      <SourceCard source={sources[0]} />
+      <SourceCard source={sources[2]} variant="ledger" />
+      <SourceCard source={sources[4]} variant="ledger" compact />
+      <QuoteRow quote={quotes[0]} showUsage />
+      <QuoteRow quote={quotes[2]} showUsage />
+    </div>
+  ),
+}
+
+export const Notes: Story = {
+  render: () => (
+    <div className="flex w-[16rem] flex-col gap-3">
+      <CoachNote
+        anchor="§3"
+        confidence="confident"
+        live
+        title="You're restating §2"
+        body="You're supposed to be moving into the human cost."
+        actions={
+          <>
+            <Chip tone="outline" interactive>
+              accept
+            </Chip>
+            <Chip tone="muted" interactive>
+              dismiss
+            </Chip>
+          </>
+        }
+      />
+      <CoachNote
+        anchor="whole piece"
+        confidence="tentative"
+        title="220 words over target"
+        body="With §4 still to write, something in §3 has to give."
+      />
+      <CoachNote title="Attribute the £4,100 figure in-sentence" accepted />
+      <NoteDot count={3} className="self-start" />
+    </div>
+  ),
+}
+
+export const PlanPieces: Story = {
+  render: () => (
+    <div className="flex w-[26rem] flex-col gap-4">
+      <OutlineRow section={outline[1]} />
+      <OutlineRow section={outline[2]} current />
+      <OutlineRow section={outline[3]} dense />
+      <div className="flex flex-col gap-2 pt-2">
+        <PolarityHeading polarity="yes" count={3}>
+          Sounds like this
+        </PolarityHeading>
+        <ExampleBlock
+          polarity="yes"
+          text="In 2006 the number was thirty-one. Last spring it was four."
+          source="Why Cities Stopped Building, §1"
+        />
+        <PolarityHeading polarity="no" count={2}>
+          Not this
+        </PolarityHeading>
+        <ExampleBlock
+          polarity="no"
+          text="The situation is, frankly, an absolute disaster!"
+          reason="just loud"
+        />
+      </div>
+    </div>
+  ),
+}

--- a/ui/src/components/ProgressBar.tsx
+++ b/ui/src/components/ProgressBar.tsx
@@ -1,0 +1,45 @@
+import { cx } from '../lib/cx'
+
+export interface ProgressBarProps {
+  /** 0–1. Values above 1 clamp the fill but flip the tone to `attention`. */
+  value: number
+  /** `attention` is the accented state — used when you are over target. */
+  tone?: 'quiet' | 'attention'
+  thickness?: number
+  label?: string
+  className?: string
+}
+
+/**
+ * Progress against a word target, shown as a bar rather than a number.
+ * The secondary user wants "some sense of completion… a subtle bar someplace,
+ * not numbers that change" — so this never renders a percentage.
+ */
+export function ProgressBar({
+  value,
+  tone = 'quiet',
+  thickness = 3,
+  label,
+  className,
+}: ProgressBarProps) {
+  const over = value > 1
+  const filled = Math.max(0, Math.min(1, value))
+  const accented = tone === 'attention' || over
+
+  return (
+    <div
+      className={cx('w-full overflow-hidden rounded-full bg-rule', className)}
+      style={{ height: thickness }}
+      role="progressbar"
+      aria-valuenow={Math.round(filled * 100)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-label={label}
+    >
+      <div
+        className={cx('h-full rounded-full', accented ? 'bg-accent-edge' : 'bg-ink/30')}
+        style={{ width: `${filled * 100}%` }}
+      />
+    </div>
+  )
+}

--- a/ui/src/components/QuoteRow.tsx
+++ b/ui/src/components/QuoteRow.tsx
@@ -1,0 +1,41 @@
+import { cx } from '../lib/cx'
+import { Chip } from './Chip'
+import type { Quote } from '../mock/content'
+
+export interface QuoteRowProps {
+  quote: Quote
+  /** Show a used/ready marker instead of the bare section chip. */
+  showUsage?: boolean
+  dimmed?: boolean
+  className?: string
+}
+
+/**
+ * A saved quote, tagged with the section it belongs to. An em dash in place of
+ * a section number means it is kept but not placed yet.
+ */
+export function QuoteRow({ quote, showUsage = false, dimmed = false, className }: QuoteRowProps) {
+  return (
+    <div className={cx('flex items-start gap-2.5', dimmed && 'opacity-50', className)}>
+      <Chip tone={quote.section ? 'default' : 'muted'} className="mt-px">
+        {quote.section ?? '—'}
+      </Chip>
+      <blockquote
+        className={cx(
+          'min-w-0 flex-1 border-l-2 pl-2.5',
+          quote.used ? 'border-accent-edge' : 'border-rule',
+        )}
+      >
+        <p className="text-[0.8125rem] leading-relaxed text-ink">“{quote.text}”</p>
+        <footer className="mt-1 flex items-center gap-2 text-[0.6875rem] text-faint">
+          <cite className="not-italic">{quote.attribution}</cite>
+          {showUsage ? (
+            <span className={quote.used ? 'text-accent-ink' : undefined}>
+              · {quote.used ? 'used' : 'ready'}
+            </span>
+          ) : null}
+        </footer>
+      </blockquote>
+    </div>
+  )
+}

--- a/ui/src/components/SourceCard.tsx
+++ b/ui/src/components/SourceCard.tsx
@@ -1,0 +1,93 @@
+import { cx } from '../lib/cx'
+import { Button } from './Button'
+import { Check } from './Check'
+import { Chip } from './Chip'
+import type { Source } from '../mock/content'
+
+export interface SourceCardProps {
+  source: Source
+  /**
+   * `offer` is how a source arrives in the chat (keep / cut).
+   * `ledger` is the same source once it has a state (tick to accept).
+   */
+  variant?: 'offer' | 'ledger'
+  /** Hide the summary line — the ledger runs tighter than the chat. */
+  compact?: boolean
+  className?: string
+}
+
+/** The star that marks a source as coming from your favourites. */
+function FavouriteMark({ kind }: { kind: 'author' | 'publication' }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-accent-ink">
+      <span aria-hidden>★</span>
+      <span>favourite {kind}</span>
+    </span>
+  )
+}
+
+/**
+ * A research result. The same row appears in the chat when it is offered, in
+ * the ledger while you decide, and in the plan once it is accepted — the state
+ * changes, the row does not.
+ */
+export function SourceCard({ source, variant = 'offer', compact = false, className }: SourceCardProps) {
+  const cut = source.state === 'cut'
+
+  return (
+    <article
+      className={cx(
+        'flex gap-2.5 rounded-lg border border-edge bg-surface p-2.5',
+        cut && 'opacity-50',
+        className,
+      )}
+    >
+      {variant === 'ledger' && !cut ? (
+        <Check checked={source.state === 'accepted'} label={`Accept ${source.title}`} />
+      ) : null}
+      {variant === 'ledger' && cut ? <span className="label-meta mt-0.5 shrink-0">cut</span> : null}
+
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">{source.title}</h4>
+        <p className="flex flex-wrap items-center gap-x-1.5 text-[0.6875rem] text-faint">
+          {source.favourite ? <FavouriteMark kind={source.favourite} /> : null}
+          {[source.author, source.outlet, source.year].filter(Boolean).map((part, i) => (
+            <span key={part as string}>
+              {i > 0 || source.favourite ? <span aria-hidden>· </span> : null}
+              {part}
+            </span>
+          ))}
+        </p>
+        {!compact && source.summary ? (
+          <p className="text-[0.75rem] leading-relaxed text-muted">{source.summary}</p>
+        ) : null}
+        {source.quotes ? (
+          <div className="mt-0.5 flex flex-wrap gap-1.5">
+            {Array.from({ length: source.quotes }, (_, i) => (
+              <Chip key={i} tone="outline" interactive>
+                quote {i + 1}
+              </Chip>
+            ))}
+          </div>
+        ) : null}
+        {variant === 'ledger' && source.state === 'undecided' ? (
+          <span className="text-[0.6875rem] text-faint">undecided</span>
+        ) : null}
+      </div>
+
+      {variant === 'offer' ? (
+        <div className="flex shrink-0 flex-col gap-1.5">
+          <Button size="sm">keep</Button>
+          <Button size="sm" tone="quiet">
+            cut
+          </Button>
+        </div>
+      ) : null}
+      {variant === 'ledger' && cut ? (
+        <Button size="sm" tone="link" className="self-start">
+          restore
+        </Button>
+      ) : null}
+    </article>
+  )
+}

--- a/ui/src/components/TitleBar.tsx
+++ b/ui/src/components/TitleBar.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+import { cx } from '../lib/cx'
+
+export interface TitleBarProps {
+  /** Renders a back affordance ahead of the title. */
+  back?: string
+  onBack?: () => void
+  title: ReactNode
+  /** Quiet text after the title — "· board", "· all articles". */
+  subtitle?: ReactNode
+  /** Right-hand side: buttons, pane pills, filters. */
+  actions?: ReactNode
+  className?: string
+}
+
+/**
+ * The window's title bar. Back on the left, then the title, with actions
+ * pushed right. The rule underneath is the heavier of the two hairline
+ * weights — it separates chrome from content.
+ */
+export function TitleBar({ back, onBack, title, subtitle, actions, className }: TitleBarProps) {
+  return (
+    <header
+      className={cx(
+        'flex shrink-0 items-center gap-2.5 border-b border-edge bg-sunk px-4 py-2.5',
+        className,
+      )}
+    >
+      {back ? (
+        <button
+          type="button"
+          onClick={onBack}
+          className="-ml-1 flex items-center gap-1.5 rounded px-1 py-0.5 text-[0.8125rem] text-muted transition-colors hover:text-ink"
+        >
+          <span aria-hidden className="text-[0.9em] leading-none">
+            ←
+          </span>
+          <span className="max-w-[16rem] truncate">{back}</span>
+        </button>
+      ) : null}
+      <h2 className="truncate text-[0.9375rem] leading-tight font-medium text-ink">{title}</h2>
+      {subtitle ? <span className="truncate text-[0.8125rem] text-faint">{subtitle}</span> : null}
+      <div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>
+    </header>
+  )
+}

--- a/ui/src/foundations/Accent.mdx
+++ b/ui/src/foundations/Accent.mdx
@@ -1,0 +1,96 @@
+import { Meta } from '@storybook/addon-docs/blocks'
+
+<Meta title="Foundations/Accent" />
+
+# The accent
+
+The page is paper, ink and three greys. There is exactly one colour in the
+system — `--color-accent`, a light yellow, `#ffe6a3` — and it is the only thing
+on a screen that asks for attention.
+
+<div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
+  {[
+    ['--color-accent', '#ffe6a3', 'The highlight itself'],
+    ['--color-accent-soft', '#fff6df', 'Wash behind an accented block'],
+    ['--color-accent-edge', '#e3c471', 'Borders, filled progress'],
+    ['--color-accent-ink', '#6a5312', 'Text sitting on accent'],
+  ].map(([token, hex, use]) => (
+    <div key={token} style={{ width: '11rem' }}>
+      <div
+        style={{
+          height: '3.5rem',
+          background: hex,
+          borderRadius: '0.5rem',
+          border: '1px solid #cdc7bc',
+        }}
+      />
+      <p style={{ font: '600 0.75rem ui-monospace, monospace', margin: '0.5rem 0 0.125rem' }}>
+        {token}
+      </p>
+      <p style={{ font: '0.75rem system-ui', color: '#6b665e', margin: 0 }}>{hex} — {use}</p>
+    </div>
+  ))}
+</div>
+
+## What earns it
+
+A thing gets the accent when it is **the one decision the screen is waiting
+on**, or **the one item that has changed and you might not have noticed**.
+
+- The primary action, where there is one — `start drafting →`, `mark published`.
+- The state of an accepted decision — a ticked `Check`, a kept source.
+- Something the app just did to your work — a reference that has crossed over
+  from the chat, a word target a review has revised.
+- The note surfaced after a pause, and only that note.
+- The item in a master/detail list that is also filling the panel — in settings
+  the highlight is a location marker for the thing you are editing.
+
+## What does not
+
+- **Which panes, tabs or filters are selected.** The `PaneRail`'s active pill and
+  `Chip tone="solid"` are ink. Where you are is state, not a request.
+- **Progress.** Bars are ink at 30% — a shape, not an alarm. The exception is
+  going *over* target, which flips to `accent-edge` because it is genuinely news.
+- **Ordinary emphasis.** Headings are weight and size. Metadata is `--color-faint`.
+- **Errors or destructive actions.** The design has none yet; when it does they
+  will need their own colour, and it will not be this one.
+
+## The count
+
+Most screens have **one** accented element. Some have **none** — 2(a), the blank
+plan, is deliberately unaccented, because an empty plan is not asking you for
+anything yet. If you find yourself putting a second yellow thing on a screen,
+one of the two is not really asking for a decision.
+
+## Everything else
+
+<div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
+  {[
+    ['--color-paper', '#f4f2ee'],
+    ['--color-surface', '#ffffff'],
+    ['--color-sunk', '#faf8f5'],
+    ['--color-hush', '#f0ede7'],
+    ['--color-ink', '#1b1a17'],
+    ['--color-muted', '#6b665e'],
+    ['--color-faint', '#9b958a'],
+    ['--color-rule', '#e3dfd7'],
+    ['--color-edge', '#cdc7bc'],
+  ].map(([token, hex]) => (
+    <div key={token} style={{ width: '8.5rem' }}>
+      <div
+        style={{
+          height: '2.5rem',
+          background: hex,
+          borderRadius: '0.375rem',
+          border: '1px solid #cdc7bc',
+        }}
+      />
+      <p style={{ font: '0.6875rem ui-monospace, monospace', margin: '0.375rem 0 0' }}>{token}</p>
+      <p style={{ font: '0.6875rem ui-monospace, monospace', color: '#9b958a', margin: 0 }}>{hex}</p>
+    </div>
+  ))}
+</div>
+
+Type is three families: `--font-sans` for the interface, `--font-serif` for the
+writing surface and anything quoted from it, `--font-mono` for the small
+uppercase labels and counts.

--- a/ui/src/index.ts
+++ b/ui/src/index.ts
@@ -1,0 +1,79 @@
+// Primitives
+export { Annotation } from './components/Annotation'
+export { ArticleBar } from './components/ArticleBar'
+export { ArticleCard } from './components/ArticleCard'
+export { Button } from './components/Button'
+export { ChatComposer, ChatMessage, ChatSuggestions } from './components/Chat'
+export { Check } from './components/Check'
+export { Chip } from './components/Chip'
+export { CoachNote, NoteDot } from './components/CoachNote'
+export { Divider, SectionHeading } from './components/Divider'
+export { DraftSurface } from './components/DraftSurface'
+export { ExampleBlock, PolarityHeading } from './components/ExampleBlock'
+export { EmptySlot, Field } from './components/Field'
+export { Frame, FrameBody } from './components/Frame'
+export { LengthBar } from './components/LengthBar'
+export { ListRow } from './components/ListRow'
+export { MetaLabel } from './components/MetaLabel'
+export { Pane, PaneHeader } from './components/Pane'
+export { PANES, PaneRail } from './components/PaneRail'
+export { ProgressBar } from './components/ProgressBar'
+export { QuoteRow } from './components/QuoteRow'
+export { SourceCard } from './components/SourceCard'
+export { TitleBar } from './components/TitleBar'
+export type { PaneId } from './components/PaneRail'
+
+// Composed article pieces
+export {
+  PlanBlock,
+  PlanLength,
+  PlanOutline,
+  PlanQuotes,
+  PlanReferences,
+} from './screens/article/PlanBlocks'
+export { PlanRail } from './screens/article/PlanRail'
+export {
+  RuleBlock,
+  ScoreTest,
+  SettingsDetailHeader,
+  SettingsShell,
+} from './screens/global/SettingsShell'
+
+// Screens — 1 global
+export { BoardScreen } from './screens/global/BoardScreen'
+export { DeskScreen } from './screens/global/DeskScreen'
+export { TableScreen } from './screens/global/TableScreen'
+export { VoicesScreen } from './screens/global/VoicesScreen'
+export { AdjectivesScreen } from './screens/global/AdjectivesScreen'
+export { FavouriteSourcesScreen } from './screens/global/FavouriteSourcesScreen'
+
+// Screens — 2 plan an article
+export { BlankPlanScreen } from './screens/article/BlankPlanScreen'
+export { MidConversationScreen } from './screens/article/MidConversationScreen'
+export { ReadyToDraftScreen } from './screens/article/ReadyToDraftScreen'
+export { ChatWithSourcesScreen } from './screens/article/ChatWithSourcesScreen'
+export { PlanSheetScreen } from './screens/article/PlanSheetScreen'
+export { LedgerDrawerScreen } from './screens/article/LedgerDrawerScreen'
+export { LedgerPopoverScreen } from './screens/article/LedgerPopoverScreen'
+
+// Screens — 3 drafting
+export { PlanAndDraftScreen } from './screens/article/PlanAndDraftScreen'
+export { DraftOnlyScreen } from './screens/article/DraftOnlyScreen'
+export { ChatAndDraftScreen } from './screens/article/ChatAndDraftScreen'
+export { MarginNotesScreen } from './screens/article/MarginNotesScreen'
+export { NotesRailScreen } from './screens/article/NotesRailScreen'
+
+// Screens — 4 reviews
+export { FullReviewScreen } from './screens/review/FullReviewScreen'
+export { ReviewRailScreen } from './screens/review/ReviewRailScreen'
+export { NotesToChatScreen } from './screens/review/NotesToChatScreen'
+export { PhoneNotesScreen } from './screens/review/PhoneNotesScreen'
+export { PaneCombosScreen } from './screens/review/PaneCombosScreen'
+export { LayersRecapScreen } from './screens/review/LayersRecapScreen'
+
+// Screens — 5 & 6 finish, archive
+export { FinishScreen } from './screens/finish/FinishScreen'
+export { ArchiveScreen } from './screens/finish/ArchiveScreen'
+export { ShowcaseScreen } from './screens/finish/ShowcaseScreen'
+
+export type { Article, OutlineSection, Quote, Source } from './mock/content'

--- a/ui/src/lib/cx.ts
+++ b/ui/src/lib/cx.ts
@@ -1,0 +1,4 @@
+/** Tiny class-name joiner. Falsy values are dropped. */
+export function cx(...parts: Array<string | false | null | undefined>): string {
+  return parts.filter(Boolean).join(' ')
+}

--- a/ui/src/mock/content.ts
+++ b/ui/src/mock/content.ts
@@ -1,0 +1,245 @@
+/**
+ * Sample content for the showcase.
+ *
+ * None of this is wired to anything — it exists so the components can be read
+ * as a real product rather than as grey boxes. Swap it for API data when the
+ * back end lands; the shapes here are a reasonable first sketch of it.
+ */
+
+export interface Article {
+  id: string
+  title: string
+  blurb: string
+  phase: 'planning' | 'drafting' | 'self-edit' | 'submitted' | 'published'
+  phaseLabel: string
+  progress: number
+  voice?: string
+  chips?: string[]
+  needsAttention?: boolean
+}
+
+export const activeArticles: Article[] = [
+  {
+    id: 'batteries',
+    title: 'The Long Tail of Batteries',
+    blurb: 'What happens to a cell after the warranty runs out, and who is counting.',
+    phase: 'drafting',
+    phaseLabel: 'drafting',
+    progress: 0.62,
+    voice: 'wry',
+    chips: ['3 notes'],
+  },
+  {
+    id: 'cities',
+    title: 'Why Cities Stopped Building',
+    blurb: 'Permitting is not a queue. It is a series of small, reasonable refusals.',
+    phase: 'planning',
+    phaseLabel: 'planning chat',
+    progress: 0.2,
+    chips: ['12 refs'],
+  },
+  {
+    id: 'slow-software',
+    title: 'Notes on Slow Software',
+    blurb: 'In praise of programs that do one thing and then stop.',
+    phase: 'self-edit',
+    phaseLabel: 'self-edit · round 2',
+    progress: 0.95,
+    chips: ['review ready'],
+    needsAttention: true,
+  },
+]
+
+export const olderDrafts = [
+  { id: 'd1', title: 'The Quiet Part of the Grid', note: 'stalled at §2', touched: '4 mar' },
+  { id: 'd2', title: 'Everyone Is a Logistics Company', note: 'plan only', touched: '19 feb' },
+  { id: 'd3', title: 'A Short History of the Loading Dock', note: 'draft 1', touched: '30 jan' },
+  { id: 'd4', title: 'Against the Roadmap', note: 'plan only', touched: '12 jan' },
+]
+
+export const publishedArticles = [
+  {
+    id: 'p1',
+    title: 'Notes on Slow Software',
+    outlet: 'the Quarterly',
+    date: 'apr 2026',
+    url: 'quarterly.example/slow-software',
+  },
+  {
+    id: 'p2',
+    title: 'The Long Tail of Batteries',
+    outlet: 'Field Notes',
+    date: 'feb 2026',
+    url: 'fieldnotes.example/long-tail',
+  },
+]
+
+export const portfolioBacklist = [
+  { id: 'b1', title: 'The Quiet Part of the Grid', outlet: 'Field Notes', year: '2025' },
+  { id: 'b2', title: 'Everyone Is a Logistics Company', outlet: 'the Quarterly', year: '2025' },
+  { id: 'b3', title: 'A Short History of the Loading Dock', outlet: 'Municipal Review', year: '2024' },
+]
+
+/* -------------------------------------------------------------------------- */
+/* The article under construction: "Why Cities Stopped Building"               */
+/* -------------------------------------------------------------------------- */
+
+export const ARTICLE_TITLE = 'Why Cities Stopped Building'
+
+export interface OutlineSection {
+  n: number
+  title: string
+  words: number
+  adjectives?: string[]
+  voice?: string
+  state?: 'done' | 'current' | 'planned'
+}
+
+export const outline: OutlineSection[] = [
+  {
+    n: 1,
+    title: 'The year the cranes stopped',
+    words: 300,
+    adjectives: ['high energy'],
+    state: 'done',
+  },
+  {
+    n: 2,
+    title: 'How review became the process',
+    words: 700,
+    adjectives: ['well researched'],
+    voice: 'Explainer',
+    state: 'done',
+  },
+  { n: 3, title: 'Who actually pays for the delay', words: 900, state: 'current' },
+  {
+    n: 4,
+    title: 'What a faster city would look like',
+    words: 500,
+    adjectives: ['unhurried'],
+    state: 'planned',
+  },
+]
+
+export const outlineRevised: OutlineSection[] = [
+  { n: 1, title: 'The year the cranes stopped', words: 300 },
+  { n: 2, title: 'How review became the process', words: 700 },
+  { n: 3, title: 'Who actually pays for the delay', words: 700 },
+  { n: 4, title: 'What a faster city would look like — and the argument for it', words: 700 },
+]
+
+export interface Source {
+  id: string
+  title: string
+  author?: string
+  outlet?: string
+  year?: string
+  favourite?: 'author' | 'publication'
+  summary?: string
+  quotes?: number
+  state: 'undecided' | 'accepted' | 'cut'
+  section?: string
+  used?: boolean
+}
+
+export const sources: Source[] = [
+  {
+    id: 's1',
+    title: 'Permit throughput in six mid-sized cities',
+    author: 'R. Okonkwo',
+    outlet: 'the Quarterly',
+    year: '2023',
+    favourite: 'publication',
+    summary:
+      'Median approval time tripled between 2004 and 2021 while application volume stayed flat.',
+    quotes: 2,
+    state: 'accepted',
+    section: '§2',
+    used: true,
+  },
+  {
+    id: 's2',
+    title: 'Zoning and the missing middle',
+    author: 'A. Weill',
+    outlet: 'Field Notes',
+    year: '2019',
+    favourite: 'author',
+    summary: 'The four-to-twelve-unit building has effectively been legislated out of existence.',
+    quotes: 1,
+    state: 'accepted',
+    section: '§3',
+    used: false,
+  },
+  {
+    id: 's3',
+    title: 'The cost of discretionary review',
+    outlet: 'Municipal Review',
+    year: '2021',
+    summary: 'Estimates the carrying cost of a stalled mid-rise at £4,100 a week.',
+    quotes: 1,
+    state: 'undecided',
+  },
+  {
+    id: 's4',
+    title: 'Housing starts, quarterly series',
+    outlet: 'Office for Statistics',
+    year: '2024',
+    summary: 'Primary data. Useful for the opening figure, dry on its own.',
+    state: 'undecided',
+  },
+  {
+    id: 's5',
+    title: 'Why nobody builds anymore (opinion)',
+    outlet: 'The Evening Ledger',
+    year: '2022',
+    summary: 'Assertive, unsourced. Covers ground we already have better evidence for.',
+    state: 'cut',
+  },
+]
+
+export interface Quote {
+  id: string
+  text: string
+  attribution: string
+  section?: string
+  used?: boolean
+}
+
+export const quotes: Quote[] = [
+  {
+    id: 'q1',
+    text: 'We did not decide to stop building. We decided, forty separate times, that this particular building could wait.',
+    attribution: 'Permit throughput in six mid-sized cities',
+    section: '§2',
+    used: true,
+  },
+  {
+    id: 'q2',
+    text: 'Every objection was reasonable. The sum of them was not.',
+    attribution: 'Zoning and the missing middle',
+    section: '§3',
+    used: false,
+  },
+  {
+    id: 'q3',
+    text: 'The meter runs on an empty lot exactly as fast as it runs on a finished one.',
+    attribution: 'The cost of discretionary review',
+    used: false,
+  },
+]
+
+/* -------------------------------------------------------------------------- */
+/* Prose                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export const draftParagraphs = [
+  'The crane index is a silly measure and everybody in the trade uses it anyway. You stand on a roof somewhere central, you turn slowly, and you count. In 2006 the number for this city was thirty-one. Last spring it was four, and one of those was taking another crane down.',
+  'What replaced the cranes was not a decision. Nobody voted to stop building. Instead the city acquired, one reasonable amendment at a time, a review process with eleven separate points at which a single objection can reset the clock — and a culture in which resetting the clock costs the objector nothing at all.',
+  'The developers I spoke to had all learned the same lesson, and none of them would say it on the record: the cheapest way to survive the process is to submit fewer, larger, blander applications and price the delay in from the start. The mid-rise infill that the plan says it wants is precisely the project that cannot absorb that cost.',
+  'Which brings us to the question nobody at the hearing is asked to answer.',
+]
+
+export const draftShort = [
+  'The crane index is a silly measure and everybody in the trade uses it anyway. In 2006 the number for this city was thirty-one. Last spring it was four.',
+  'What replaced the cranes was not a decision. Nobody voted to stop building.',
+]

--- a/ui/src/screens/article/BlankPlanScreen.tsx
+++ b/ui/src/screens/article/BlankPlanScreen.tsx
@@ -1,0 +1,51 @@
+import { ChatComposer, ChatMessage } from '../../components/Chat'
+import { EmptySlot } from '../../components/Field'
+import { Frame, FrameBody } from '../../components/Frame'
+import { Pane } from '../../components/Pane'
+import { ArticleBar } from '../../components/ArticleBar'
+import { ARTICLE_TITLE } from '../../mock/content'
+import { PlanBlock, PlanLength } from './PlanBlocks'
+
+/**
+ * 2(a) — First message. The plan is already on screen, empty and touchable.
+ * There is no triage step and nothing to "finish": the draft pill is available
+ * from the first second, it just has nothing in it yet.
+ */
+export function BlankPlanScreen() {
+  return (
+    <Frame width={760}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="new" />
+      <FrameBody row className="min-h-[20rem]">
+        <Pane divider="right" className="gap-3">
+          <ChatMessage from="me">
+            I want to write about why permitting got so slow, using this city as the case. Roughly
+            feature length. Start by finding me the numbers.
+          </ChatMessage>
+          <ChatMessage from="agent">
+            Before I search — is this the story of the process, or the story of the people stuck in
+            it? That changes which sources are worth your time.
+          </ChatMessage>
+          <ChatComposer />
+        </Pane>
+
+        <Pane tone="sunk">
+          <PlanLength />
+          <PlanBlock title="Outline" meta="empty">
+            <EmptySlot className="min-h-[3.5rem]">
+              Sections appear as you agree on them — and you can type your own straight in here
+            </EmptySlot>
+          </PlanBlock>
+          <PlanBlock title="References" meta="0">
+            <EmptySlot>Tick a source in the chat</EmptySlot>
+          </PlanBlock>
+          <PlanBlock title="Quotes" meta="0">
+            <EmptySlot>Or paste your own</EmptySlot>
+          </PlanBlock>
+          <p className="mt-auto text-[0.6875rem] text-faint">
+            Scrolls. Nothing here is locked, and nothing has to be finished before you write.
+          </p>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/ChatAndDraftScreen.tsx
+++ b/ui/src/screens/article/ChatAndDraftScreen.tsx
@@ -1,0 +1,41 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { ChatComposer, ChatMessage, ChatSuggestions } from '../../components/Chat'
+import { Chip } from '../../components/Chip'
+import { DraftSurface } from '../../components/DraftSurface'
+import { Frame, FrameBody } from '../../components/Frame'
+import { Pane } from '../../components/Pane'
+import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
+
+/**
+ * 3(c) — Chat beside the draft, for when you hit something mid-sentence that
+ * needs looking up. The chat pane never takes more than half the window, and
+ * whatever it produces lands in the plan rather than in the prose.
+ */
+export function ChatAndDraftScreen() {
+  return (
+    <Frame width={760}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat', 'draft']} status="§3" />
+      <FrameBody row className="min-h-[19rem]">
+        <Pane tone="sunk" divider="right" width="40%" className="gap-3">
+          <ChatMessage from="me">
+            Is there a number for what a stalled mid-rise costs per week?
+          </ChatMessage>
+          <ChatMessage from="agent">
+            Municipal Review put it at £4,100 in 2021 — it's already in your ledger, undecided. Two
+            more recent estimates exist if you want them.
+          </ChatMessage>
+          <ChatSuggestions>
+            <Chip tone="accent" interactive>
+              add to plan
+            </Chip>
+            <Chip tone="outline" interactive>
+              not now
+            </Chip>
+          </ChatSuggestions>
+          <ChatComposer placeholder="Ask without leaving the sentence…" />
+        </Pane>
+        <DraftSurface paragraphs={draftParagraphs.slice(0, 3)} measure="narrow" caret />
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/ChatWithSourcesScreen.tsx
+++ b/ui/src/screens/article/ChatWithSourcesScreen.tsx
@@ -1,0 +1,48 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { ChatComposer, ChatMessage } from '../../components/Chat'
+import { Frame, FrameBody } from '../../components/Frame'
+import { Pane } from '../../components/Pane'
+import { SectionHeading } from '../../components/Divider'
+import { SourceCard } from '../../components/SourceCard'
+import { ARTICLE_TITLE, sources } from '../../mock/content'
+
+/**
+ * 2(d) — A turn that returned a lot, with the chat pane at full width. Keeping
+ * one sends it straight across into the plan; nothing waits in a holding pen.
+ */
+export function ChatWithSourcesScreen() {
+  return (
+    <Frame width={700}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat']} status="research" />
+      <FrameBody>
+        <Pane className="gap-3">
+          <ChatMessage from="me">
+            Find me everything on approval times in comparable cities. Cast wide, I'll cut.
+          </ChatMessage>
+          <ChatMessage from="agent">
+            Seventeen worth showing you. Two are from your favourites, and I've ranked those first.
+          </ChatMessage>
+
+          <SectionHeading
+            count="17 found"
+            action={<span className="text-[0.6875rem] text-faint">keep 9 · cut 5 · undecided 3</span>}
+          >
+            Sources
+          </SectionHeading>
+
+          <div className="flex flex-col gap-2">
+            <SourceCard source={sources[0]} />
+            <SourceCard source={sources[1]} />
+            <SourceCard source={sources[2]} />
+            <SourceCard source={sources[4]} />
+          </div>
+
+          <p className="text-[0.6875rem] text-faint">
+            Keeping one sends it straight to the plan — the ledger keeps the whole list either way.
+          </p>
+          <ChatComposer placeholder="More like the throughput study, but for transit…" />
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/DraftOnlyScreen.tsx
+++ b/ui/src/screens/article/DraftOnlyScreen.tsx
@@ -1,0 +1,24 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { DraftSurface } from '../../components/DraftSurface'
+import { Frame, FrameBody } from '../../components/Frame'
+import { NoteDot } from '../../components/CoachNote'
+import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
+
+/**
+ * 3(b) — The draft alone, which is where the default user spends almost all of
+ * their time. Nothing on screen but the prose; the accent dot in the corner is
+ * the app's entire vocabulary for "there is something to read when you stop".
+ */
+export function DraftOnlyScreen() {
+  return (
+    <Frame width={640}>
+      <ArticleBar title={ARTICLE_TITLE} open={['draft']} status="esc" divided={false} />
+      <FrameBody className="min-h-[19rem]">
+        <DraftSurface paragraphs={draftParagraphs} caret />
+        <div className="flex justify-end px-5 pb-4">
+          <NoteDot count={3} />
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/Drafting.stories.tsx
+++ b/ui/src/screens/article/Drafting.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Annotation } from '../../components/Annotation'
+import { ChatAndDraftScreen } from './ChatAndDraftScreen'
+import { DraftOnlyScreen } from './DraftOnlyScreen'
+import { MarginNotesScreen } from './MarginNotesScreen'
+import { NotesRailScreen } from './NotesRailScreen'
+import { PlanAndDraftScreen } from './PlanAndDraftScreen'
+
+const meta = {
+  title: 'Screens/3 Drafting',
+  parameters: { layout: 'centered' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const A_PlanAndDraft: Story = {
+  name: '3(a) Plan + draft',
+  render: () => (
+    <div className="flex flex-col">
+      <PlanAndDraftScreen />
+      <Annotation>
+        For the writer who wants a sense of completion without watching a counter. Bars only — no
+        numbers that change on every keystroke.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const B_DraftOnly: Story = {
+  name: '3(b) Draft alone',
+  render: () => (
+    <div className="flex flex-col">
+      <DraftOnlyScreen />
+      <Annotation align="right">
+        The default state, and where most of the time goes. The dot appears only when you have gone
+        idle and there is something worth reading — an urgent note after ~20 seconds, an ordinary
+        one after minutes.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const C_ChatAndDraft: Story = {
+  name: '3(c) Chat + draft',
+  render: () => (
+    <div className="flex flex-col">
+      <ChatAndDraftScreen />
+      <Annotation>
+        The chat pane never takes more than half. Anything it produces lands in the plan, not in the
+        prose — the writing stays yours.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const D_MarginNotes: Story = {
+  name: '3(d) Notes in the margin',
+  render: () => <MarginNotesScreen />,
+}
+
+export const E_NotesRail: Story = {
+  name: '3(e) Draft + notes rail',
+  render: () => (
+    <div className="flex flex-col">
+      <NotesRailScreen />
+      <Annotation>
+        Accepting a note moves it out of the stack and into the checklist underneath, which is the
+        list you actually work through.
+      </Annotation>
+    </div>
+  ),
+}

--- a/ui/src/screens/article/LedgerDrawerScreen.tsx
+++ b/ui/src/screens/article/LedgerDrawerScreen.tsx
@@ -1,0 +1,93 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Chip } from '../../components/Chip'
+import { EmptySlot } from '../../components/Field'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { Pane } from '../../components/Pane'
+import { QuoteRow } from '../../components/QuoteRow'
+import { SourceCard } from '../../components/SourceCard'
+import { ARTICLE_TITLE, quotes, sources } from '../../mock/content'
+
+/**
+ * 2(f) — The ledger, as two equal halves. Left is what has been offered and
+ * nothing else; right is the plan, with accepted items sitting under the
+ * section they belong to and marked used or ready.
+ *
+ * It is the same list at every stage — early on most rows read "offered",
+ * later most read "used". That is why there is no separate triage screen.
+ */
+export function LedgerDrawerScreen() {
+  return (
+    <Frame width={820}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="ledger" />
+      <FrameBody row className="min-h-[22rem]">
+        <Pane divider="right" padded={false}>
+          <header className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
+            <h3 className="text-[0.875rem] font-semibold text-ink">Offered</h3>
+            <span className="text-[0.75rem] text-faint">17 · 9 accepted</span>
+            <button type="button" className="ml-auto text-[0.75rem] text-faint hover:text-ink">
+              close ×
+            </button>
+          </header>
+          <div className="flex flex-col gap-2.5 p-3.5">
+            <div className="flex flex-wrap gap-1.5">
+              <Chip tone="solid" interactive>
+                all
+              </Chip>
+              <Chip tone="outline" interactive>
+                undecided
+              </Chip>
+              <Chip tone="outline" interactive>
+                accepted
+              </Chip>
+              <Chip tone="outline" interactive>
+                cut
+              </Chip>
+            </div>
+            <SourceCard source={sources[0]} variant="ledger" compact />
+            <SourceCard source={sources[1]} variant="ledger" compact />
+            <SourceCard source={sources[2]} variant="ledger" compact />
+            <SourceCard source={sources[4]} variant="ledger" compact />
+            <p className="text-[0.6875rem] text-faint">
+              + 13 more · accepting one sends it across →
+            </p>
+          </div>
+        </Pane>
+
+        <Pane tone="sunk" padded={false}>
+          <header className="flex items-center gap-2.5 border-b border-edge px-3.5 py-2.5">
+            <h3 className="text-[0.875rem] font-semibold text-ink">In the plan</h3>
+            <span className="text-[0.75rem] text-faint">9 accepted · 3 used</span>
+          </header>
+          <div className="flex flex-col gap-4 p-3.5">
+            <div className="flex flex-col gap-2">
+              <MetaLabel>§2 · How review became the process</MetaLabel>
+              <div className="flex flex-col gap-2.5 pl-2">
+                <QuoteRow quote={quotes[0]} showUsage />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <MetaLabel count="1 unused">§3 · Who actually pays for the delay</MetaLabel>
+              <div className="flex flex-col gap-2.5 pl-2">
+                <QuoteRow quote={quotes[1]} showUsage />
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-2">
+              <MetaLabel>§4 · What a faster city would look like</MetaLabel>
+              <EmptySlot className="ml-2">Drop an accepted source here</EmptySlot>
+            </div>
+
+            <div className="flex flex-col gap-1.5">
+              <MetaLabel count={4}>Accepted, no section yet</MetaLabel>
+              <p className="text-[0.75rem] text-muted">
+                Housing starts, quarterly series · The cost of discretionary review · two more
+              </p>
+            </div>
+          </div>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/LedgerPopoverScreen.tsx
+++ b/ui/src/screens/article/LedgerPopoverScreen.tsx
@@ -1,0 +1,84 @@
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { cx } from '../../lib/cx'
+
+interface Group {
+  label: string
+  count: number
+  items: Array<{ text: string; section?: string }>
+  tone?: 'used' | 'plain' | 'cut'
+}
+
+const groups: Group[] = [
+  {
+    label: 'Used in the draft',
+    count: 3,
+    tone: 'used',
+    items: [
+      { section: '§2', text: 'Permit throughput in six mid-sized cities' },
+      { section: '§2', text: '“We did not decide to stop building…”' },
+      { section: '§1', text: 'Housing starts, quarterly series' },
+    ],
+  },
+  {
+    label: 'In the plan, not yet used',
+    count: 2,
+    items: [
+      { section: '§3', text: 'Zoning and the missing middle' },
+      { section: '§4', text: 'The cost of discretionary review' },
+    ],
+  },
+  {
+    label: 'Kept, unassigned',
+    count: 4,
+    items: [
+      { text: 'Review board minutes, 2019–2024' },
+      { text: 'Interview — M. Sze, planning officer' },
+    ],
+  },
+  { label: 'Offered, undecided', count: 3, items: [{ text: 'Transit-adjacent density pilot' }] },
+  {
+    label: 'Cut',
+    count: 5,
+    tone: 'cut',
+    items: [{ text: 'Why nobody builds anymore (opinion)' }],
+  },
+]
+
+/**
+ * 2(g) — The ledger opened from the composer, as a popover. The groups *are*
+ * the lifecycle and their order is fixed, so the undecided pile visibly
+ * shrinks as you work.
+ */
+export function LedgerPopoverScreen() {
+  return (
+    <Frame width={340}>
+      <div className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
+        <h3 className="text-[0.875rem] font-semibold text-ink">Ledger</h3>
+        <span className="text-[0.75rem] text-faint">17</span>
+        <button type="button" className="ml-auto text-[0.75rem] text-faint hover:text-ink">
+          ⌄
+        </button>
+      </div>
+      <FrameBody className="gap-4 p-3.5">
+        {groups.map((group) => (
+          <section
+            key={group.label}
+            className={cx('flex flex-col gap-1.5', group.tone === 'cut' && 'opacity-50')}
+          >
+            <MetaLabel count={group.count}>{group.label}</MetaLabel>
+            {group.items.map((item) => (
+              <div key={item.text} className="flex items-start gap-2">
+                {item.section ? (
+                  <Chip tone={group.tone === 'used' ? 'accent' : 'outline'}>{item.section}</Chip>
+                ) : null}
+                <p className="min-w-0 flex-1 truncate text-[0.75rem] text-muted">{item.text}</p>
+              </div>
+            ))}
+          </section>
+        ))}
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/MarginNotesScreen.tsx
+++ b/ui/src/screens/article/MarginNotesScreen.tsx
@@ -1,0 +1,59 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Chip } from '../../components/Chip'
+import { CoachNote } from '../../components/CoachNote'
+import { Frame, FrameBody } from '../../components/Frame'
+import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
+
+/**
+ * 3(d) — Notes anchored in the margin, beside the paragraph they are about.
+ * The rule down the left of that paragraph is the anchor; the note is the only
+ * accented thing on the page.
+ */
+export function MarginNotesScreen() {
+  return (
+    <Frame width={720}>
+      <ArticleBar title={ARTICLE_TITLE} open={['draft', 'notes']} status="§3" />
+      <FrameBody className="min-h-[19rem] gap-5 px-5 py-5">
+        <div className="flex gap-5">
+          <div className="prose-draft min-w-0 flex-1">
+            <p className="text-[0.9375rem]">{draftParagraphs[0]}</p>
+          </div>
+          <div className="w-[11rem] shrink-0" />
+        </div>
+
+        <div className="flex gap-5">
+          <div className="prose-draft min-w-0 flex-1 border-l-2 border-accent-edge pl-4">
+            <p className="text-[0.9375rem]">{draftParagraphs[1]}</p>
+          </div>
+          <CoachNote
+            anchor="§3"
+            confidence="confident"
+            live
+            title="You're restating §2 here"
+            body="The permit-process argument already landed. §3 is meant to be the cost of the delay to people."
+            actions={
+              <>
+                <Chip tone="outline" interactive>
+                  accept
+                </Chip>
+                <Chip tone="muted" interactive>
+                  ×
+                </Chip>
+              </>
+            }
+            className="w-[11rem] shrink-0 self-start"
+          />
+        </div>
+
+        <div className="flex gap-5">
+          <div className="prose-draft min-w-0 flex-1">
+            <p className="text-[0.9375rem]">{draftParagraphs[2]}</p>
+          </div>
+          <p className="flex w-[11rem] shrink-0 items-center text-[0.6875rem] text-faint">
+            Notes hold their place beside the paragraph they're about, and scroll with it.
+          </p>
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/MidConversationScreen.tsx
+++ b/ui/src/screens/article/MidConversationScreen.tsx
@@ -1,0 +1,55 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { ChatComposer, ChatMessage } from '../../components/Chat'
+import { Frame, FrameBody } from '../../components/Frame'
+import { Pane } from '../../components/Pane'
+import { SourceCard } from '../../components/SourceCard'
+import { ARTICLE_TITLE, outline, quotes, sources } from '../../mock/content'
+import { PlanBlock, PlanLength, PlanOutline, PlanQuotes, PlanReferences } from './PlanBlocks'
+
+/**
+ * 2(b) — Mid-conversation. Ticking a source in the chat sends it straight into
+ * References; there is no interstitial approval screen. Meanwhile section 3 is
+ * being typed by hand in the plan, which is equally allowed.
+ */
+export function MidConversationScreen() {
+  return (
+    <Frame width={800}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
+      <FrameBody row className="min-h-[24rem]">
+        <Pane divider="right" className="gap-3">
+          <ChatMessage from="me">
+            The process, then — but I want one developer in it so it isn't all spreadsheets.
+          </ChatMessage>
+          <ChatMessage from="agent">
+            Two that carry the argument, both from your favourites:
+          </ChatMessage>
+          <div className="flex flex-col gap-2">
+            <SourceCard source={sources[0]} variant="ledger" />
+            <SourceCard source={sources[3]} variant="ledger" compact />
+          </div>
+          <ChatMessage from="agent">
+            The throughput study has a line that would open §2 well. I've pulled it into quotes.
+          </ChatMessage>
+          <ChatComposer />
+        </Pane>
+
+        <Pane tone="sunk">
+          <PlanLength words={2400} voice="Reported feature" />
+          <PlanBlock title="Outline" meta="3 of ~4">
+            <PlanOutline
+              sections={outline.slice(0, 2)}
+              typing="Who actually pays for the delay"
+              showAdd
+            />
+          </PlanBlock>
+          <PlanBlock title="References" meta="5">
+            <PlanReferences sources={[sources[0], sources[1]]} justAddedId={sources[0].id} />
+          </PlanBlock>
+          <PlanBlock title="Quotes" meta="3">
+            <PlanQuotes quotes={[quotes[0], quotes[2]]} />
+          </PlanBlock>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/NotesRailScreen.tsx
+++ b/ui/src/screens/article/NotesRailScreen.tsx
@@ -1,0 +1,71 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Button } from '../../components/Button'
+import { Check } from '../../components/Check'
+import { Chip } from '../../components/Chip'
+import { CoachNote } from '../../components/CoachNote'
+import { DraftSurface } from '../../components/DraftSurface'
+import { Frame, FrameBody } from '../../components/Frame'
+import { PaneHeader } from '../../components/Pane'
+import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
+
+/**
+ * 3(e) — The notes rail: a quiet stack on the right. Accepted notes drop into
+ * a checklist underneath, which is what you actually work through.
+ */
+export function NotesRailScreen() {
+  return (
+    <Frame width={720}>
+      <ArticleBar title={ARTICLE_TITLE} open={['draft', 'notes']} status="§3 of 4" />
+      <FrameBody row className="min-h-[19rem]">
+        <DraftSurface paragraphs={draftParagraphs} measure="narrow" caret />
+
+        <aside className="flex w-[13rem] shrink-0 flex-col gap-3 border-l border-edge bg-sunk p-3.5">
+          <PaneHeader title="Notes" meta="3 new" />
+          <CoachNote
+            anchor="§3"
+            confidence="confident"
+            live
+            title="You're restating §2"
+            body="You're supposed to be moving into the human cost."
+            actions={
+              <>
+                <Chip tone="outline" interactive>
+                  accept
+                </Chip>
+                <Chip tone="muted" interactive>
+                  dismiss
+                </Chip>
+              </>
+            }
+          />
+          <CoachNote
+            anchor="whole piece"
+            confidence="tentative"
+            title="220 words over target"
+            body="With §4 still to write, something in §3 has to give."
+          />
+
+          <PaneHeader title="Accepted" meta="2" className="mt-1" />
+          <ul className="flex flex-col gap-2">
+            <li className="flex items-start gap-2">
+              <Check />
+              <span className="text-[0.75rem] leading-snug text-ink">
+                Cut the second crane-index callback
+              </span>
+            </li>
+            <li className="flex items-start gap-2 opacity-55">
+              <Check checked />
+              <span className="text-[0.75rem] leading-snug text-ink line-through">
+                Attribute the £4,100 figure in-sentence
+              </span>
+            </li>
+          </ul>
+
+          <Button size="sm" tone="quiet" className="mt-auto self-start">
+            hide notes
+          </Button>
+        </aside>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/PlanAnArticle.stories.tsx
+++ b/ui/src/screens/article/PlanAnArticle.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Annotation } from '../../components/Annotation'
+import { BlankPlanScreen } from './BlankPlanScreen'
+import { ChatWithSourcesScreen } from './ChatWithSourcesScreen'
+import { LedgerDrawerScreen } from './LedgerDrawerScreen'
+import { LedgerPopoverScreen } from './LedgerPopoverScreen'
+import { MidConversationScreen } from './MidConversationScreen'
+import { PlanSheetScreen } from './PlanSheetScreen'
+import { ReadyToDraftScreen } from './ReadyToDraftScreen'
+
+const meta = {
+  title: 'Screens/2 Plan an article',
+  parameters: { layout: 'centered' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const A_BlankPlan: Story = {
+  name: '2(a) Blank page',
+  render: () => (
+    <div className="flex flex-col">
+      <BlankPlanScreen />
+      <Annotation>
+        Nothing on this screen is accented, and that is the point: an empty plan is not asking you
+        for a decision yet. The plan is live from the first message so it can never feel like a
+        gate you have to pass.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const B_MidConversation: Story = {
+  name: '2(b) Mid-conversation',
+  render: () => (
+    <div className="flex flex-col">
+      <MidConversationScreen />
+      <Annotation>
+        Ticking a source in the chat sends it across into References immediately — the wash on the
+        newly added reference is the only thing marking the change. Section 3 is being typed by
+        hand at the same time, which is equally allowed.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const C_ReadyToDraft: Story = {
+  name: '2(c) Ready to draft',
+  render: () => (
+    <div className="flex flex-col">
+      <ReadyToDraftScreen />
+      <Annotation>
+        The button is a suggestion, not a gate — it appears once the plan has a length and at least
+        one section, and the draft pill was clickable long before it showed up.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const D_ChatWithSources: Story = {
+  name: '2(d) A turn that returned a lot',
+  render: () => <ChatWithSourcesScreen />,
+}
+
+export const E_PlanSheet: Story = {
+  name: '2(e) The plan on its own',
+  render: () => (
+    <div className="flex flex-col">
+      <PlanSheetScreen />
+      <Annotation>
+        Outline, references and quotes are stacked, never columned: inside a phase the eye should
+        only have to travel one way. The bar beside the outline is the shape of the piece — 300 /
+        700 / 900 / 500 of 2,400.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const F_LedgerDrawer: Story = {
+  name: '2(f) Source ledger',
+  render: () => (
+    <div className="flex flex-col">
+      <LedgerDrawerScreen />
+      <Annotation>
+        The same list at every stage — early on most rows read "offered", later most read "used".
+        That is precisely why there is no separate triage screen.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const G_LedgerPopover: Story = {
+  name: '2(g) Ledger from the composer',
+  render: () => (
+    <div className="flex flex-col">
+      <LedgerPopoverScreen />
+      <Annotation>
+        The groups are the lifecycle and their order is fixed, so the undecided pile at the bottom
+        visibly shrinks as you work.
+      </Annotation>
+    </div>
+  ),
+}

--- a/ui/src/screens/article/PlanAndDraftScreen.tsx
+++ b/ui/src/screens/article/PlanAndDraftScreen.tsx
@@ -1,0 +1,25 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { DraftSurface } from '../../components/DraftSurface'
+import { Frame, FrameBody } from '../../components/Frame'
+import { ARTICLE_TITLE, draftParagraphs, outline } from '../../mock/content'
+import { PlanRail } from './PlanRail'
+
+/**
+ * 3(a) — Checking myself against the plan. The outline sits in a rail with a
+ * quiet bar per section; the draft keeps the room.
+ */
+export function PlanAndDraftScreen() {
+  return (
+    <Frame width={720}>
+      <ArticleBar title={ARTICLE_TITLE} open={['plan', 'draft']} status="draft 1" />
+      <FrameBody row className="min-h-[19rem]">
+        <PlanRail
+          sections={outline}
+          written={[300, 700, 520, 0]}
+          counts={['refs 2/12', 'quotes 4/6', 'notes 1/3']}
+        />
+        <DraftSurface paragraphs={draftParagraphs} measure="narrow" caret />
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/PlanBlocks.tsx
+++ b/ui/src/screens/article/PlanBlocks.tsx
@@ -1,0 +1,142 @@
+import type { ReactNode } from 'react'
+import { Chip } from '../../components/Chip'
+import { EmptySlot, Field } from '../../components/Field'
+import { OutlineRow } from '../../components/OutlineRow'
+import { PaneHeader } from '../../components/Pane'
+import { QuoteRow } from '../../components/QuoteRow'
+import { cx } from '../../lib/cx'
+import type { OutlineSection, Quote, Source } from '../../mock/content'
+
+export interface PlanLengthProps {
+  words?: number
+  voice?: string
+}
+
+/** The target. Empty until you or the agent puts a number in it. */
+export function PlanLength({ words, voice }: PlanLengthProps) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <Field
+        label="Length"
+        size="sm"
+        value={words ? `${words.toLocaleString()} words` : undefined}
+        placeholder="words —"
+      />
+      {voice ? <Chip tone="outline">voice: {voice}</Chip> : null}
+    </div>
+  )
+}
+
+export interface PlanBlockProps {
+  title: string
+  meta?: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+export function PlanBlock({ title, meta, children, className }: PlanBlockProps) {
+  return (
+    <div className={cx('flex flex-col gap-2', className)}>
+      <PaneHeader title={title} meta={meta} />
+      {children}
+    </div>
+  )
+}
+
+export interface PlanOutlineProps {
+  sections: OutlineSection[]
+  /** A section still being typed in by hand. */
+  typing?: string
+  dense?: boolean
+  changedFrom?: number
+  showAdd?: boolean
+  className?: string
+}
+
+export function PlanOutline({
+  sections,
+  typing,
+  dense = false,
+  changedFrom,
+  showAdd = false,
+  className,
+}: PlanOutlineProps) {
+  return (
+    <div className={cx('flex flex-col gap-2.5', className)}>
+      {sections.map((section) => (
+        <OutlineRow
+          key={section.n}
+          section={section}
+          dense={dense}
+          current={section.state === 'current'}
+          changed={changedFrom !== undefined && section.n >= changedFrom}
+        />
+      ))}
+      {typing ? (
+        <div className="flex items-start gap-2.5">
+          <span className="mt-px w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
+            {sections.length + 1}
+          </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="rounded-md border border-edge bg-surface px-2 py-1 text-[0.8125rem] text-ink">
+              {typing}
+              <span
+                aria-hidden
+                className="ml-0.5 inline-block h-[1em] w-px translate-y-[0.15em] bg-ink"
+              />
+            </div>
+            <p className="text-[0.6875rem] text-faint">typing here yourself</p>
+          </div>
+        </div>
+      ) : null}
+      {showAdd ? <EmptySlot className="py-1.5">+ section</EmptySlot> : null}
+    </div>
+  )
+}
+
+export interface PlanReferencesProps {
+  sources: Source[]
+  /** Marks the source that has just crossed over from the chat. */
+  justAddedId?: string
+}
+
+export function PlanReferences({ sources, justAddedId }: PlanReferencesProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {sources.map((source) => (
+        <div
+          key={source.id}
+          className={cx(
+            'flex flex-col gap-0.5 rounded-md border p-2',
+            source.id === justAddedId
+              ? 'border-accent-edge bg-accent-soft'
+              : 'border-edge bg-surface',
+          )}
+        >
+          {source.id === justAddedId ? <p className="label-meta">★ just added</p> : null}
+          <p className="text-[0.75rem] leading-snug font-medium text-ink">{source.title}</p>
+          <p className="text-[0.6875rem] text-faint">
+            {[source.outlet, source.year, source.section].filter(Boolean).join(' · ')}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export interface PlanQuotesProps {
+  quotes: Quote[]
+  showUsage?: boolean
+  footer?: ReactNode
+}
+
+export function PlanQuotes({ quotes, showUsage = false, footer }: PlanQuotesProps) {
+  return (
+    <div className="flex flex-col gap-2.5">
+      {quotes.map((quote) => (
+        <QuoteRow key={quote.id} quote={quote} showUsage={showUsage} />
+      ))}
+      {footer ? <p className="text-[0.6875rem] text-faint">{footer}</p> : null}
+    </div>
+  )
+}

--- a/ui/src/screens/article/PlanRail.tsx
+++ b/ui/src/screens/article/PlanRail.tsx
@@ -1,0 +1,71 @@
+import { Chip } from '../../components/Chip'
+import { ProgressBar } from '../../components/ProgressBar'
+import { cx } from '../../lib/cx'
+import type { OutlineSection } from '../../mock/content'
+
+export interface PlanRailProps {
+  sections: OutlineSection[]
+  /** Written words per section, in the same order. */
+  written: number[]
+  /** Chips at the foot of the rail: refs, quotes, notes. */
+  counts?: string[]
+  className?: string
+}
+
+/**
+ * The plan collapsed to a rail beside the draft. Section titles, one quiet bar
+ * each, and a whole-piece bar at the bottom — the secondary user wants a sense
+ * of completion without a number that twitches on every keystroke.
+ */
+export function PlanRail({ sections, written, counts, className }: PlanRailProps) {
+  const target = sections.reduce((sum, section) => sum + section.words, 0)
+  const done = written.reduce((sum, n) => sum + n, 0)
+
+  return (
+    <aside
+      className={cx(
+        'flex w-[11rem] shrink-0 flex-col gap-3.5 border-r border-edge bg-sunk p-3.5',
+        className,
+      )}
+    >
+      {sections.map((section, i) => {
+        const current = section.state === 'current'
+        return (
+          <div key={section.n} className="flex flex-col gap-1.5">
+            <div className="flex items-baseline gap-1.5">
+              <p
+                className={cx(
+                  'min-w-0 flex-1 text-[0.75rem] leading-snug',
+                  current ? 'font-medium text-ink' : 'text-muted',
+                )}
+              >
+                {section.title}
+              </p>
+              {current ? <span className="text-[0.625rem] text-faint">now</span> : null}
+            </div>
+            <ProgressBar
+              value={written[i] / section.words}
+              label={`${section.title} progress`}
+              tone={written[i] / section.words > 1 ? 'attention' : 'quiet'}
+            />
+          </div>
+        )
+      })}
+
+      <div className="mt-auto flex flex-col gap-1.5">
+        <ProgressBar value={done / target} thickness={5} label="Whole piece" />
+        <p className="text-[0.6875rem] text-faint">whole piece</p>
+      </div>
+
+      {counts?.length ? (
+        <div className="flex flex-wrap gap-1.5">
+          {counts.map((count) => (
+            <Chip key={count} tone="outline">
+              {count}
+            </Chip>
+          ))}
+        </div>
+      ) : null}
+    </aside>
+  )
+}

--- a/ui/src/screens/article/PlanSheetScreen.tsx
+++ b/ui/src/screens/article/PlanSheetScreen.tsx
@@ -1,0 +1,90 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Button } from '../../components/Button'
+import { Chip } from '../../components/Chip'
+import { Divider } from '../../components/Divider'
+import { Frame, FrameBody } from '../../components/Frame'
+import { LengthBar } from '../../components/LengthBar'
+import { Pane, PaneHeader } from '../../components/Pane'
+import { QuoteRow } from '../../components/QuoteRow'
+import { ARTICLE_TITLE, outline, quotes, sources } from '../../mock/content'
+import { PlanOutline } from './PlanBlocks'
+
+/**
+ * 2(e) — The plan on its own, full width. Outline, references and quotes are
+ * stacked rather than columned: within a phase the eye should only travel
+ * down. The bar beside the outline is the shape of the piece — each section's
+ * height is its share of the 2,400 words.
+ */
+export function PlanSheetScreen() {
+  return (
+    <Frame width={680}>
+      <ArticleBar title={ARTICLE_TITLE} open={['plan']} status="draft 1" />
+      <FrameBody>
+        <Pane className="gap-5 p-5">
+          <section className="flex flex-col gap-3">
+            <PaneHeader
+              title="Outline"
+              meta="2,400 words target"
+              actions={<Chip tone="outline">voice: Reported feature</Chip>}
+            />
+            <div className="flex items-start gap-5">
+              <PlanOutline sections={outline} className="flex-1" />
+              <LengthBar
+                segments={outline.map((section) => ({
+                  label: section.title,
+                  words: section.words,
+                  state: section.state,
+                }))}
+                height={188}
+              />
+            </div>
+            <p className="text-[0.6875rem] text-faint">
+              Edit it by hand, or go back to the chat and argue about it — either way the advice you
+              get while drafting changes to match.
+            </p>
+          </section>
+
+          <Divider weight="strong" />
+
+          <section className="flex flex-col gap-3">
+            <PaneHeader title="References" meta="12 · 9 kept" />
+            <div className="grid grid-cols-3 gap-2.5">
+              {[sources[0], sources[1], sources[3]].map((source) => (
+                <div
+                  key={source.id}
+                  className="flex flex-col gap-1 rounded-md border border-edge bg-sunk p-2.5"
+                >
+                  <p className="text-[0.75rem] leading-snug font-medium text-ink">{source.title}</p>
+                  <p className="text-[0.6875rem] text-faint">
+                    {[source.outlet, source.year].filter(Boolean).join(' · ')}
+                  </p>
+                  <p className="mt-auto pt-1 text-[0.6875rem] text-muted">
+                    {source.section ?? 'unassigned'}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <Divider weight="strong" />
+
+          <section className="flex flex-col gap-3">
+            <PaneHeader title="Quotes" meta="8 saved" />
+            <div className="flex flex-col gap-3">
+              {quotes.map((quote) => (
+                <QuoteRow key={quote.id} quote={quote} />
+              ))}
+              <p className="text-[0.6875rem] text-faint">
+                + 5 more · drag a quote onto a section to place it
+              </p>
+            </div>
+          </section>
+
+          <div className="flex items-center gap-3 pt-1">
+            <Button tone="accent">start writing →</Button>
+          </div>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/article/ReadyToDraftScreen.tsx
+++ b/ui/src/screens/article/ReadyToDraftScreen.tsx
@@ -1,0 +1,48 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Button } from '../../components/Button'
+import { ChatComposer, ChatMessage } from '../../components/Chat'
+import { Frame, FrameBody } from '../../components/Frame'
+import { Pane } from '../../components/Pane'
+import { ARTICLE_TITLE, outline } from '../../mock/content'
+import { PlanBlock, PlanLength, PlanOutline } from './PlanBlocks'
+
+/**
+ * 2(c) — Scrolled to the end of the conversation. "Start drafting" appears
+ * once the plan has a length and at least one section. It is a suggestion, not
+ * a gate: the draft pill was available all along.
+ */
+export function ReadyToDraftScreen() {
+  return (
+    <Frame width={780}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
+      <FrameBody row className="min-h-[21rem]">
+        <Pane divider="right" className="gap-3">
+          <p className="text-center text-[0.6875rem] text-faint">↑ earlier in this conversation</p>
+          <ChatMessage from="agent">
+            That gives §3 the human cost and keeps the numbers in §2 where they belong.
+          </ChatMessage>
+          <ChatMessage from="me">Good. Leave §4 short — I don't want to write a manifesto.</ChatMessage>
+          <ChatMessage from="agent">
+            Four sections, 2,400 words, thirteen references and eight quotes saved. Ready when you
+            are.
+          </ChatMessage>
+          <ChatComposer />
+        </Pane>
+
+        <Pane tone="sunk" padded={false}>
+          <div className="flex flex-1 flex-col gap-3.5 p-3.5">
+            <PlanLength words={2400} />
+            <PlanBlock title="Outline" meta="4 sections">
+              <PlanOutline sections={outline} dense />
+            </PlanBlock>
+            <p className="text-[0.75rem] text-muted">13 references · 8 quotes</p>
+          </div>
+          <div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
+            <Button tone="accent">start drafting →</Button>
+            <span className="text-[0.75rem] text-faint">or keep talking</span>
+          </div>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/finish/ArchiveScreen.tsx
+++ b/ui/src/screens/finish/ArchiveScreen.tsx
@@ -1,0 +1,89 @@
+import { Button } from '../../components/Button'
+import { Field } from '../../components/Field'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { SectionHeading } from '../../components/Divider'
+import { TitleBar } from '../../components/TitleBar'
+import { publishedArticles } from '../../mock/content'
+
+/**
+ * 6(a) — Submitted → published. Marking a piece published asks for the text as
+ * it actually ran, which is what feeds the comparison underneath.
+ */
+export function ArchiveScreen() {
+  return (
+    <Frame width={520}>
+      <TitleBar
+        back="Desk"
+        title="Submitted & published"
+        actions={<span className="text-[0.75rem] text-faint">9 published</span>}
+      />
+      <FrameBody className="gap-4 p-4">
+        <section className="flex flex-col gap-2.5">
+          <SectionHeading count={2}>Submitted</SectionHeading>
+          <div className="flex flex-col gap-2.5 rounded-lg border border-edge p-3">
+            <div className="flex items-baseline gap-2.5">
+              <h3 className="text-[0.875rem] font-semibold text-ink">Why Cities Stopped Building</h3>
+              <span className="text-[0.6875rem] text-faint">sent 12 jul · chase due in 2 days</span>
+            </div>
+            <div className="flex items-center gap-2.5">
+              <Button tone="accent" size="sm">
+                mark published
+              </Button>
+              <Field size="sm" placeholder="where it ran (url)" className="flex-1" />
+            </div>
+            <p className="text-[0.6875rem] leading-relaxed text-faint">
+              Marking it published asks for the text as it ran, which is what the comparison below
+              reads from.
+            </p>
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-2.5">
+          <SectionHeading count={9}>Published</SectionHeading>
+          <div className="grid grid-cols-2 gap-2.5">
+            {publishedArticles.map((article) => (
+              <article
+                key={article.id}
+                className="flex flex-col gap-1.5 rounded-lg border border-edge p-3"
+              >
+                <div
+                  aria-hidden
+                  className="h-11 rounded-md border border-dashed border-edge bg-hush"
+                />
+                <h3 className="text-[0.8125rem] leading-snug font-semibold text-ink">
+                  {article.title}
+                </h3>
+                <p className="text-[0.6875rem] text-faint">
+                  {article.outlet} · {article.date} ↗
+                </p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="flex flex-col gap-2.5 rounded-lg border border-edge bg-sunk p-3">
+          <div className="flex items-baseline gap-2.5">
+            <h3 className="text-[0.875rem] font-semibold text-ink">Self-edit final vs published</h3>
+            <span className="text-[0.6875rem] text-faint">stub</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1.5">
+              <MetaLabel>Mine</MetaLabel>
+              <p className="text-[0.75rem] leading-relaxed text-muted">
+                “Nobody voted to stop building. It happened one reasonable amendment at a time.”
+              </p>
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <MetaLabel>As published</MetaLabel>
+              <p className="text-[0.75rem] leading-relaxed text-muted">
+                “Nobody voted to stop building.{' '}
+                <mark className="bg-accent text-accent-ink">It happened by increments.</mark>”
+              </p>
+            </div>
+          </div>
+        </section>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/finish/Finish.stories.tsx
+++ b/ui/src/screens/finish/Finish.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Annotation } from '../../components/Annotation'
+import { ArchiveScreen } from './ArchiveScreen'
+import { FinishScreen } from './FinishScreen'
+import { ShowcaseScreen } from './ShowcaseScreen'
+
+const meta = {
+  title: 'Screens/5 Finish and archive',
+  parameters: { layout: 'centered' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const A_Finish: Story = {
+  name: '5(a) Finish, export, chase',
+  render: () => (
+    <div className="flex flex-col">
+      <FinishScreen />
+      <Annotation>
+        Called "finish" rather than "export" on purpose — the last steps might include another
+        review or a round of twenty-five candidate titles. This is the start of a checkout process,
+        not the end of the piece.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const B_Archive: Story = {
+  name: '6(a) Submitted → published',
+  render: () => <ArchiveScreen />,
+}
+
+export const C_Showcase: Story = {
+  name: '6(b) Public showcase',
+  render: () => (
+    <div className="flex flex-col">
+      <ShowcaseScreen />
+      <Annotation>
+        Off by default; switched on per person in settings. Pieces appear only once marked
+        published, and you choose which ones show.
+      </Annotation>
+    </div>
+  ),
+}

--- a/ui/src/screens/finish/FinishScreen.tsx
+++ b/ui/src/screens/finish/FinishScreen.tsx
@@ -1,0 +1,97 @@
+import { Button } from '../../components/Button'
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { Pane } from '../../components/Pane'
+import { TitleBar } from '../../components/TitleBar'
+import { ARTICLE_TITLE } from '../../mock/content'
+
+/**
+ * 5(a) — Finish, not "export". The last steps might include a review, or
+ * twenty-five candidate titles — this is the start of a checkout process, not
+ * the end of the piece.
+ */
+export function FinishScreen() {
+  return (
+    <Frame width={560}>
+      <TitleBar back={ARTICLE_TITLE} title="Finish" />
+      <FrameBody>
+        <Pane className="gap-4 p-4">
+          <div className="flex items-center gap-2">
+            <Chip tone="solid" interactive>
+              markdown
+            </Chip>
+            <Chip tone="outline" interactive>
+              html
+            </Chip>
+            <Chip tone="outline" interactive>
+              docx
+            </Chip>
+            <span className="ml-1 text-[0.75rem] text-faint">footnotes included</span>
+          </div>
+
+          <section className="flex flex-col gap-2">
+            <MetaLabel>House style — footnote template</MetaLabel>
+            <div className="flex flex-col gap-2 rounded-md border border-edge bg-sunk p-2.5">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Chip tone="default">author</Chip>
+                <span className="text-[0.75rem] text-muted">,</span>
+                <Chip tone="default">title</Chip>
+                <span className="text-[0.75rem] text-muted">,</span>
+                <Chip tone="default">publication</Chip>
+                <span className="text-[0.75rem] text-muted">(</span>
+                <Chip tone="default">date</Chip>
+                <span className="text-[0.75rem] text-muted">),</span>
+                <Chip tone="default">url</Chip>
+              </div>
+              <p className="text-[0.6875rem] text-faint">
+                Drag the fields into order; type literal text between them.
+              </p>
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <MetaLabel>Preview</MetaLabel>
+            <ol className="flex flex-col gap-1.5 text-[0.75rem] leading-relaxed text-muted">
+              <li>
+                1. R. Okonkwo, “Permit throughput in six mid-sized cities”, the Quarterly (2023),
+                quarterly.example/permit-throughput
+              </li>
+              <li>
+                2. A. Weill, “Zoning and the missing middle”, Field Notes (2019),
+                fieldnotes.example/missing-middle
+              </li>
+            </ol>
+          </section>
+
+          <div className="flex flex-wrap gap-2">
+            <Button>download</Button>
+            <Button>copy</Button>
+            <Button tone="accent">mark as sent →</Button>
+          </div>
+
+          <div className="flex items-center gap-3 rounded-md border border-edge bg-sunk p-2.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <MetaLabel>Remind me to chase it</MetaLabel>
+              <div className="flex flex-wrap gap-1.5">
+                <Chip tone="outline" interactive>
+                  3 days
+                </Chip>
+                <Chip tone="default" interactive>
+                  1 week
+                </Chip>
+                <Chip tone="outline" interactive>
+                  2 weeks
+                </Chip>
+                <Chip tone="outline" interactive>
+                  a date…
+                </Chip>
+              </div>
+            </div>
+            <Button size="sm">set</Button>
+          </div>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/finish/ShowcaseScreen.tsx
+++ b/ui/src/screens/finish/ShowcaseScreen.tsx
@@ -1,0 +1,59 @@
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { ListRow } from '../../components/ListRow'
+import { portfolioBacklist, publishedArticles } from '../../mock/content'
+
+/**
+ * 6(b) — The public showcase. Off by default; switched on per person in
+ * settings, and you choose which published pieces appear.
+ */
+export function ShowcaseScreen() {
+  return (
+    <Frame width={560}>
+      <div className="flex flex-col gap-2 bg-ink px-6 py-7">
+        <h1 className="font-serif text-[1.75rem] leading-tight text-paper">Emmy Joarness</h1>
+        <p className="max-w-[22rem] text-[0.8125rem] leading-relaxed text-paper/60">
+          Reported features and essays on cities, energy and the things that quietly stopped
+          working. Selected work, 2024—2026.
+        </p>
+      </div>
+
+      <FrameBody className="gap-5 p-4">
+        <div className="grid grid-cols-2 gap-4">
+          {publishedArticles.map((article) => (
+            <article key={article.id} className="flex flex-col gap-2">
+              <div
+                aria-hidden
+                className="h-14 rounded-md border border-dashed border-edge bg-hush"
+              />
+              <h2 className="text-[0.875rem] leading-snug font-semibold text-ink">
+                {article.title}
+              </h2>
+              <p className="text-[0.6875rem] text-faint">
+                {article.outlet} · {article.date} ↗
+              </p>
+            </article>
+          ))}
+        </div>
+
+        <div className="flex flex-col">
+          {portfolioBacklist.map((item) => (
+            <ListRow
+              key={item.id}
+              title={item.title}
+              note={item.outlet}
+              trailing={<span className="text-[0.6875rem] text-faint">{item.year}</span>}
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2.5 border-t border-edge pt-3">
+          <span className="text-[0.75rem] text-muted">joarness.app/em</span>
+          <Chip tone="accent" className="ml-auto">
+            public · on
+          </Chip>
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/global/AdjectivesScreen.tsx
+++ b/ui/src/screens/global/AdjectivesScreen.tsx
@@ -1,0 +1,70 @@
+import { ExampleBlock, PolarityHeading } from '../../components/ExampleBlock'
+import { RuleBlock, ScoreTest, SettingsDetailHeader, SettingsShell } from './SettingsShell'
+
+/**
+ * 1(e) — Settings · adjectives. Fuzzier than a voice: you say a section should
+ * be "high energy", and this is where you have already defined what you mean.
+ */
+export function AdjectivesScreen() {
+  return (
+    <SettingsShell
+      tab="adjectives"
+      selectedId="high-energy"
+      addLabel="+ adjective"
+      listWidth={152}
+      items={[
+        { id: 'high-energy', label: 'high energy' },
+        { id: 'well-researched', label: 'well researched' },
+        { id: 'unhurried', label: 'unhurried' },
+        { id: 'concrete', label: 'concrete' },
+        { id: 'unfussy', label: 'unfussy' },
+      ]}
+    >
+      <SettingsDetailHeader title="high energy" usage="9 sections use it" />
+
+      <RuleBlock label="What I mean by it">
+        Short sentences carrying real information, one after another, with no throat-clearing
+        between them. Verbs do the work. A paragraph earns the label if you could read it aloud
+        without losing your place — not if it merely has exclamation marks.
+      </RuleBlock>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <PolarityHeading polarity="yes" count={3}>
+            Yes
+          </PolarityHeading>
+          <ExampleBlock
+            polarity="yes"
+            text="In 2006 the number was thirty-one. Last spring it was four, and one of those was taking another crane down."
+            source="Why Cities Stopped Building, §1"
+          />
+          <ExampleBlock
+            polarity="yes"
+            text="Nobody voted for this. It happened one reasonable amendment at a time."
+            source="pasted"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <PolarityHeading polarity="no" count={2}>
+            No
+          </PolarityHeading>
+          <ExampleBlock
+            polarity="no"
+            text="The situation is, frankly, an absolute disaster — and it's getting worse every single day!"
+            reason="just loud"
+          />
+          <ExampleBlock
+            polarity="no"
+            text="There are, it must be said, a number of factors at play here worth considering."
+            reason="throat-clearing"
+          />
+        </div>
+      </div>
+
+      <ScoreTest
+        score="7/10"
+        paragraph="What replaced the cranes was not a decision. Nobody voted to stop building…"
+      />
+    </SettingsShell>
+  )
+}

--- a/ui/src/screens/global/BoardScreen.tsx
+++ b/ui/src/screens/global/BoardScreen.tsx
@@ -1,0 +1,61 @@
+import { ArticleCard } from '../../components/ArticleCard'
+import { Button } from '../../components/Button'
+import { EmptySlot } from '../../components/Field'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { TitleBar } from '../../components/TitleBar'
+import { activeArticles, publishedArticles } from '../../mock/content'
+
+const columns = [
+  { key: 'planning', label: 'Planning' },
+  { key: 'drafting', label: 'Draft 1' },
+  { key: 'self-edit', label: 'Self-edit' },
+] as const
+
+/**
+ * 1(b) — Board by phase. A familiar layout for the same articles; the only
+ * thing it adds over the desk is where each piece sits in the loop.
+ */
+export function BoardScreen() {
+  return (
+    <Frame width={640}>
+      <TitleBar
+        back="Desk"
+        title="Board"
+        subtitle="by phase"
+        actions={<Button size="sm">+ new</Button>}
+      />
+      <FrameBody row className="gap-3 p-4">
+        {columns.map((column) => {
+          const items = activeArticles.filter((article) => article.phase === column.key)
+          return (
+            <div key={column.key} className="flex min-w-0 flex-1 flex-col gap-2">
+              <MetaLabel count={items.length}>{column.label}</MetaLabel>
+              {items.map((article) => (
+                <ArticleCard key={article.id} article={article} variant="column" />
+              ))}
+              <EmptySlot className="min-h-[3rem]">drop here</EmptySlot>
+            </div>
+          )
+        })}
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <MetaLabel count={9}>Sent / done</MetaLabel>
+          {publishedArticles.map((article) => (
+            <div
+              key={article.id}
+              className="flex flex-col gap-1 rounded-lg border border-edge bg-sunk p-2.5"
+            >
+              <h3 className="text-[0.8125rem] leading-snug font-semibold text-ink">
+                {article.title}
+              </h3>
+              <p className="text-[0.6875rem] text-faint">
+                {article.outlet} · {article.date}
+              </p>
+            </div>
+          ))}
+          <p className="text-[0.6875rem] text-faint">+ 21 archived</p>
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/global/DeskScreen.tsx
+++ b/ui/src/screens/global/DeskScreen.tsx
@@ -1,0 +1,97 @@
+import { ArticleCard } from '../../components/ArticleCard'
+import { Button } from '../../components/Button'
+import { Frame, FrameBody } from '../../components/Frame'
+import { ListRow } from '../../components/ListRow'
+import { SectionHeading } from '../../components/Divider'
+import { TitleBar } from '../../components/TitleBar'
+import { activeArticles, olderDrafts, publishedArticles } from '../../mock/content'
+
+/**
+ * 1(a) — Desk. The root screen: what you are working on now, above the fold,
+ * and then the long tail. Board and table hang off this; both back-button here.
+ */
+export function DeskScreen() {
+  return (
+    <Frame width={660}>
+      <TitleBar
+        title="Desk"
+        actions={
+          <>
+            <Button tone="quiet" size="sm">
+              settings
+            </Button>
+            <Button size="sm">+ new article</Button>
+          </>
+        }
+      />
+      <FrameBody className="gap-6 p-4">
+        <div className="flex flex-col gap-3">
+          <SectionHeading
+            count={activeArticles.length}
+            action={
+              <Button tone="quiet" size="sm">
+                board view
+              </Button>
+            }
+          >
+            In progress
+          </SectionHeading>
+          <div className="flex flex-wrap gap-3">
+            {activeArticles.map((article) => (
+              <ArticleCard key={article.id} article={article} />
+            ))}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <SectionHeading
+            count={24}
+            action={
+              <Button tone="link" size="sm">
+                see all drafts
+              </Button>
+            }
+            className="mb-1.5"
+          >
+            Older drafts
+          </SectionHeading>
+          {olderDrafts.map((draft) => (
+            <ListRow
+              key={draft.id}
+              title={draft.title}
+              note={draft.note}
+              trailing={<span className="text-[0.6875rem] text-faint">{draft.touched}</span>}
+            />
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <SectionHeading
+            count={9}
+            action={
+              <span className="flex items-center gap-3">
+                <Button tone="link" size="sm">
+                  portfolio
+                </Button>
+                <Button tone="link" size="sm">
+                  see all
+                </Button>
+              </span>
+            }
+            className="mb-1.5"
+          >
+            Published
+          </SectionHeading>
+          {publishedArticles.map((article) => (
+            <ListRow
+              key={article.id}
+              title={article.title}
+              note={article.outlet}
+              trailing={<span className="text-[0.6875rem] text-faint">{article.date}</span>}
+            />
+          ))}
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/global/FavouriteSourcesScreen.tsx
+++ b/ui/src/screens/global/FavouriteSourcesScreen.tsx
@@ -1,0 +1,62 @@
+import { Chip } from '../../components/Chip'
+import { ExampleBlock, PolarityHeading } from '../../components/ExampleBlock'
+import { MetaLabel } from '../../components/MetaLabel'
+import { RuleBlock, SettingsDetailHeader, SettingsShell } from './SettingsShell'
+
+/**
+ * 1(f) — Settings · favourite sources. Publications, authors and thinkers to
+ * rank first during research. Ranking, not filtering.
+ */
+export function FavouriteSourcesScreen() {
+  return (
+    <SettingsShell
+      tab="sources"
+      selectedId="field-notes"
+      addLabel="+ source"
+      items={[
+        { id: 'field-notes', label: 'Field Notes', group: 'Publications · 7' },
+        { id: 'quarterly', label: 'the Quarterly' },
+        { id: 'municipal', label: 'Municipal Review' },
+        { id: 'weill', label: 'A. Weill', group: 'People · 11' },
+        { id: 'okonkwo', label: 'R. Okonkwo' },
+        { id: 'sze', label: 'M. Sze' },
+      ]}
+    >
+      <SettingsDetailHeader title="Field Notes" usage="cited in 6 articles" />
+
+      <RuleBlock label="Why we prefer it">
+        Reports its own numbers and prints its method. Corrections are dated and visible. When it
+        is wrong it is wrong in a way you can check.
+      </RuleBlock>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <PolarityHeading polarity="yes">Prefer for</PolarityHeading>
+          <div className="flex flex-wrap gap-1.5">
+            <Chip tone="outline">policy</Chip>
+            <Chip tone="outline">primary data</Chip>
+            <Chip tone="outline">interviews</Chip>
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <PolarityHeading polarity="no">Not for</PolarityHeading>
+          <ExampleBlock
+            polarity="no"
+            text="Opinion columns and the weekend essay."
+            reason="house view leaks into the reporting"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <MetaLabel count="14 times">Pulled in research</MetaLabel>
+        <div className="flex items-center gap-2.5">
+          <Chip tone="accent">★ rank first</Chip>
+          <p className="text-[0.75rem] text-muted">
+            Ahead of equally relevant results, never instead of better ones.
+          </p>
+        </div>
+      </div>
+    </SettingsShell>
+  )
+}

--- a/ui/src/screens/global/Global.stories.tsx
+++ b/ui/src/screens/global/Global.stories.tsx
@@ -1,0 +1,81 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Annotation } from '../../components/Annotation'
+import { AdjectivesScreen } from './AdjectivesScreen'
+import { BoardScreen } from './BoardScreen'
+import { DeskScreen } from './DeskScreen'
+import { FavouriteSourcesScreen } from './FavouriteSourcesScreen'
+import { TableScreen } from './TableScreen'
+import { VoicesScreen } from './VoicesScreen'
+
+const meta = {
+  title: 'Screens/1 Global',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const A_Desk: Story = {
+  name: '1(a) Desk',
+  render: () => (
+    <div className="flex flex-col">
+      <DeskScreen />
+      <Annotation>
+        The root screen. Board and table both back-button here, so this is the only page that needs
+        a "board view" button — the table is reached from the quiet "see all" links, with the filter
+        already set, because it is a fallback utility rather than an attraction.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const B_Board: Story = {
+  name: '1(b) Board',
+  render: () => <BoardScreen />,
+}
+
+export const C_Table: Story = {
+  name: '1(c) Table',
+  render: () => <TableScreen />,
+}
+
+export const D_Voices: Story = {
+  name: '1(d) Settings · voices',
+  render: () => (
+    <div className="flex flex-col">
+      <VoicesScreen />
+      <Annotation>
+        The test row at the bottom takes a pasted paragraph and scores it. An exemplary paragraph
+        should score very high — if it doesn't, the rule above is the thing that needs rewriting.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const E_Adjectives: Story = {
+  name: '1(e) Settings · adjectives',
+  render: () => (
+    <div className="flex flex-col">
+      <AdjectivesScreen />
+      <Annotation>
+        Same shell as voices, deliberately. An adjective is just a fuzzier voice: you define what
+        "high energy" means once, and then any section can be marked with it.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const F_FavouriteSources: Story = {
+  name: '1(f) Settings · favourite sources',
+  render: () => (
+    <div className="flex flex-col">
+      <FavouriteSourcesScreen />
+      <Annotation>
+        Ranking, not filtering — a non-favourite still shows up when it is the best evidence
+        available.
+      </Annotation>
+    </div>
+  ),
+}

--- a/ui/src/screens/global/SettingsShell.tsx
+++ b/ui/src/screens/global/SettingsShell.tsx
@@ -1,0 +1,137 @@
+import type { ReactNode } from 'react'
+import { Button } from '../../components/Button'
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { TitleBar } from '../../components/TitleBar'
+import { cx } from '../../lib/cx'
+
+export type SettingsTab = 'voices' | 'adjectives' | 'sources'
+
+const TABS: SettingsTab[] = ['voices', 'adjectives', 'sources']
+
+export interface SettingsListItem {
+  id: string
+  label: string
+  /** A quiet group heading rendered above this item. */
+  group?: string
+}
+
+export interface SettingsShellProps {
+  tab: SettingsTab
+  items: SettingsListItem[]
+  selectedId: string
+  addLabel: string
+  listWidth?: number
+  children: ReactNode
+  /** Width of the whole window. */
+  width?: number
+}
+
+/**
+ * One shell, three lists. Writer settings is a master/detail: the thing you
+ * are editing is highlighted in the rail because it is also what fills the
+ * panel — the highlight is a location marker, not a call to action.
+ */
+export function SettingsShell({
+  tab,
+  items,
+  selectedId,
+  addLabel,
+  listWidth = 168,
+  children,
+  width = 700,
+}: SettingsShellProps) {
+  return (
+    <Frame width={width}>
+      <TitleBar
+        back="Desk"
+        title="Writer settings"
+        actions={TABS.map((name) => (
+          <Chip key={name} tone={name === tab ? 'solid' : 'outline'} interactive>
+            {name}
+          </Chip>
+        ))}
+      />
+      <FrameBody row className="min-h-[19rem]">
+        <nav
+          className="flex shrink-0 flex-col gap-1 border-r border-edge bg-sunk p-3"
+          style={{ width: listWidth }}
+        >
+          {items.map((item) => (
+            <div key={item.id} className="flex flex-col gap-1">
+              {item.group ? <p className="label-meta pt-2 first:pt-0">{item.group}</p> : null}
+              <button
+                type="button"
+                aria-current={item.id === selectedId ? 'true' : undefined}
+                className={cx(
+                  '-mx-1.5 rounded-md px-1.5 py-1 text-left text-[0.8125rem] transition-colors',
+                  item.id === selectedId
+                    ? 'bg-accent font-medium text-accent-ink'
+                    : 'text-muted hover:bg-hush hover:text-ink',
+                )}
+              >
+                {item.label}
+              </button>
+            </div>
+          ))}
+          <Button size="sm" className="mt-2 self-start">
+            {addLabel}
+          </Button>
+        </nav>
+        <div className="flex min-w-0 flex-1 flex-col gap-3.5 p-4">{children}</div>
+      </FrameBody>
+    </Frame>
+  )
+}
+
+export interface SettingsDetailHeaderProps {
+  title: string
+  usage: string
+}
+
+export function SettingsDetailHeader({ title, usage }: SettingsDetailHeaderProps) {
+  return (
+    <div className="flex items-baseline gap-2.5">
+      <h3 className="text-[1rem] font-semibold text-ink">{title}</h3>
+      <span className="text-[0.75rem] text-faint">{usage}</span>
+    </div>
+  )
+}
+
+export interface RuleBlockProps {
+  label: string
+  children: ReactNode
+}
+
+/** The prompt / definition box: what the agent is actually handed. */
+export function RuleBlock({ label, children }: RuleBlockProps) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="label-meta">{label}</p>
+      <p className="rounded-md border border-edge bg-sunk p-2.5 text-[0.8125rem] leading-relaxed text-ink">
+        {children}
+      </p>
+    </div>
+  )
+}
+
+export interface ScoreTestProps {
+  score: string
+  paragraph: string
+}
+
+/**
+ * Paste a paragraph, get a score out of ten. This is how you check that your
+ * own rule says what you think it says.
+ */
+export function ScoreTest({ score, paragraph }: ScoreTestProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-md border border-edge bg-sunk p-2.5">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="label-meta">Paste to test a paragraph</p>
+        <p className="truncate text-[0.75rem] text-muted">{paragraph}</p>
+      </div>
+      <Chip tone="accent">{score}</Chip>
+    </div>
+  )
+}

--- a/ui/src/screens/global/TableScreen.tsx
+++ b/ui/src/screens/global/TableScreen.tsx
@@ -1,0 +1,81 @@
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { TitleBar } from '../../components/TitleBar'
+
+interface Row {
+  title: string
+  status: string
+  words: string
+  touched: string
+  attention?: boolean
+}
+
+const rows: Row[] = [
+  { title: 'The Long Tail of Batteries', status: 'drafting', words: '1,480', touched: '2h' },
+  { title: 'Why Cities Stopped Building', status: 'planning', words: '—', touched: '1d' },
+  {
+    title: 'Notes on Slow Software',
+    status: 'self-edit',
+    words: '2,610',
+    touched: '3d',
+    attention: true,
+  },
+  { title: 'The Quiet Part of the Grid', status: 'sent', words: '3,100', touched: '1w' },
+  { title: 'Everyone Is a Logistics Company', status: 'draft', words: '640', touched: '2mo' },
+  { title: 'A Short History of the Loading Dock', status: 'published', words: '2,240', touched: '4mo' },
+]
+
+/**
+ * 1(c) — All articles, as a table. Not an attraction: a familiar fallback
+ * utility view, reached from "see all" links with the filter already set.
+ */
+export function TableScreen() {
+  return (
+    <Frame width={620}>
+      <TitleBar
+        back="Desk"
+        title="All articles"
+        actions={
+          <>
+            <Chip tone="solid" interactive>
+              open
+            </Chip>
+            <Chip tone="outline" interactive>
+              drafts
+            </Chip>
+            <Chip tone="outline" interactive>
+              published
+            </Chip>
+          </>
+        }
+      />
+      <FrameBody className="gap-0 px-4 py-3">
+        <div className="flex items-baseline gap-3 border-b border-edge pb-2">
+          <span className="label-meta flex-1">Title</span>
+          <span className="label-meta w-20">Status</span>
+          <span className="label-meta w-14 text-right">Words</span>
+          <span className="label-meta w-10 text-right">Touch</span>
+        </div>
+        {rows.map((row) => (
+          <div key={row.title} className="flex items-baseline gap-3 border-b border-rule py-2.5">
+            <span className="min-w-0 flex-1 truncate text-[0.8125rem] text-ink">{row.title}</span>
+            <span className="w-20">
+              {row.attention ? (
+                <Chip tone="accent">{row.status}</Chip>
+              ) : (
+                <span className="text-[0.75rem] text-muted">{row.status}</span>
+              )}
+            </span>
+            <span className="w-14 text-right font-mono text-[0.6875rem] text-faint">
+              {row.words}
+            </span>
+            <span className="w-10 text-right font-mono text-[0.6875rem] text-faint">
+              {row.touched}
+            </span>
+          </div>
+        ))}
+        <p className="pt-3 text-[0.6875rem] text-faint">+ 18 more · sorted by last touched</p>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/global/VoicesScreen.tsx
+++ b/ui/src/screens/global/VoicesScreen.tsx
@@ -1,0 +1,76 @@
+import { ExampleBlock, PolarityHeading } from '../../components/ExampleBlock'
+import {
+  RuleBlock,
+  ScoreTest,
+  SettingsDetailHeader,
+  SettingsShell,
+} from './SettingsShell'
+
+/**
+ * 1(d) — Settings · voices. A voice is a tiny prompt that tells an agent how
+ * to assess a piece of writing. An article has a dominant one; sections can
+ * override it.
+ */
+export function VoicesScreen() {
+  return (
+    <SettingsShell
+      tab="voices"
+      selectedId="reported"
+      addLabel="+ voice"
+      items={[
+        { id: 'house', label: 'House plain' },
+        { id: 'reported', label: 'Reported feature' },
+        { id: 'newsletter', label: 'Newsletter aside' },
+        { id: 'explainer', label: 'Explainer' },
+        { id: 'obit', label: 'Short obituary' },
+      ]}
+    >
+      <SettingsDetailHeader title="Reported feature" usage="4 articles · 2 sections" />
+
+      <RuleBlock label="Prompt — how an agent assesses this style">
+        Reported, not argued. Every claim is attributed in the sentence that makes it. Scene before
+        analysis. Sentences average under twenty-five words; no more than one subordinate clause
+        deep. First person is allowed but rationed — roughly once a section, and only where the
+        reporter was actually in the room.
+      </RuleBlock>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div className="flex flex-col gap-2">
+          <PolarityHeading polarity="yes" count={3}>
+            Sounds like this
+          </PolarityHeading>
+          <ExampleBlock
+            polarity="yes"
+            text="The crane index is a silly measure and everybody in the trade uses it anyway."
+            source="The Long Tail of Batteries"
+          />
+          <ExampleBlock
+            polarity="yes"
+            text="Okonkwo showed me the spreadsheet on his phone, in the car park, because the office had already closed."
+            source="pasted"
+          />
+        </div>
+        <div className="flex flex-col gap-2">
+          <PolarityHeading polarity="no" count={2}>
+            Not this
+          </PolarityHeading>
+          <ExampleBlock
+            polarity="no"
+            text="So here's the thing about permits — and honestly, you're going to love this."
+            reason="too breezy, reads like the newsletter"
+          />
+          <ExampleBlock
+            polarity="no"
+            text="It is arguably the case that discretionary review has, on balance, proven suboptimal."
+            reason="argued, not reported"
+          />
+        </div>
+      </div>
+
+      <ScoreTest
+        score="8/10"
+        paragraph="The developers I spoke to had all learned the same lesson, and none of them would say it on the record…"
+      />
+    </SettingsShell>
+  )
+}

--- a/ui/src/screens/review/FullReviewScreen.tsx
+++ b/ui/src/screens/review/FullReviewScreen.tsx
@@ -1,0 +1,107 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Button } from '../../components/Button'
+import { Check } from '../../components/Check'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { Pane, PaneHeader } from '../../components/Pane'
+import { ARTICLE_TITLE } from '../../mock/content'
+
+interface Finding {
+  id: string
+  text: string
+  anchor: string
+  accepted?: boolean
+}
+
+const structure: Finding[] = [
+  {
+    id: 'f1',
+    text: 'The crane-index image carries §1 and then carries §4 again. The second use costs you the ending.',
+    anchor: '§1 ↔ §4',
+  },
+  {
+    id: 'f2',
+    text: 'The human cost arrives 600 words later than the plan puts it.',
+    anchor: '§3',
+    accepted: true,
+  },
+]
+
+const other: Finding[] = [
+  {
+    id: 'f3',
+    text: '§3 drifts into Newsletter aside — three asides in four paragraphs, where the piece is marked Reported feature.',
+    anchor: 'voice',
+  },
+  {
+    id: 'f4',
+    text: 'Two of five planned quotes are unused, both in §3.',
+    anchor: 'citations',
+  },
+]
+
+function FindingRow({ finding }: { finding: Finding }) {
+  return (
+    <li className="flex items-start gap-2.5">
+      <Check checked={finding.accepted} label={`Accept: ${finding.text}`} />
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <p className="text-[0.8125rem] leading-relaxed text-ink">{finding.text}</p>
+        <p className="text-[0.6875rem] text-faint">
+          {finding.anchor}
+          {finding.accepted ? ' · accepted' : ''}
+        </p>
+      </div>
+    </li>
+  )
+}
+
+/**
+ * 4(a) — The in-depth review, full screen. This is the only pass that takes
+ * the whole window: you asked for it, so it gets your attention once. What you
+ * accept then lives in the notes rail while you write.
+ */
+export function FullReviewScreen() {
+  return (
+    <Frame width={720}>
+      <ArticleBar title={ARTICLE_TITLE} open={['notes']} status="round 2" />
+      <FrameBody>
+        <Pane className="gap-4 p-5">
+          <PaneHeader title="Review of draft 2" meta="2,610 words · 6 findings" />
+
+          <div className="flex flex-col gap-1.5">
+            <MetaLabel>The shape of it</MetaLabel>
+            <p className="text-[0.8125rem] leading-relaxed text-muted">
+              The reporting is doing its job and the middle is the strongest it has been. The piece
+              is 210 words over target and the overrun is entirely in §3, which is also where the
+              plan says the argument should be tightest.
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-5">
+            <section className="flex flex-col gap-2.5">
+              <MetaLabel count={2}>Structure</MetaLabel>
+              <ul className="flex flex-col gap-2.5">
+                {structure.map((finding) => (
+                  <FindingRow key={finding.id} finding={finding} />
+                ))}
+              </ul>
+            </section>
+            <section className="flex flex-col gap-2.5">
+              <MetaLabel>Voice · 1 · Citations · 3</MetaLabel>
+              <ul className="flex flex-col gap-2.5">
+                {other.map((finding) => (
+                  <FindingRow key={finding.id} finding={finding} />
+                ))}
+              </ul>
+            </section>
+          </div>
+
+          <div className="flex items-center gap-2.5 border-t border-edge pt-3.5">
+            <Button tone="accent">keep 3, back to the draft →</Button>
+            <Button>send notes to chat</Button>
+          </div>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/review/LayersRecapScreen.tsx
+++ b/ui/src/screens/review/LayersRecapScreen.tsx
@@ -1,0 +1,113 @@
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { TitleBar } from '../../components/TitleBar'
+import { cx } from '../../lib/cx'
+import { ARTICLE_TITLE } from '../../mock/content'
+
+const layers = [
+  {
+    n: 1,
+    name: 'Chat',
+    body: 'Research and suggestions. Nothing it produces reaches the prose directly.',
+    flex: 1,
+    accent: false,
+  },
+  {
+    n: 2,
+    name: 'Plan & sources',
+    body: 'Outline, targets, voices, references, quotes. Editable by hand at any time.',
+    flex: 1.15,
+    accent: false,
+  },
+  { n: 3, name: 'Draft', body: 'The human writes. Only the human writes.', flex: 1, accent: false },
+  {
+    n: 4,
+    name: 'Coach',
+    body: 'Reads 3 against 2 and returns notes, which feed back into 2.',
+    flex: 1,
+    accent: true,
+  },
+]
+
+const arrows = ['builds', 'guides', 'feeds back']
+
+const states: Array<{ label: string; on: number[] }> = [
+  { label: 'Planning — chat, approving into the plan as you go', on: [1, 2] },
+  { label: '"I\'m done" — the plan alone, zoomed, fill in the blanks', on: [2] },
+  { label: 'Drafting — most of the time, this alone', on: [3] },
+  { label: 'Checking myself against the plan', on: [2, 3] },
+  { label: 'Drafting + coach — after a pause, or on demand', on: [3, 4] },
+  { label: 'Review round — back to chat, the self-crit lands in layer 2', on: [1, 2] },
+]
+
+/**
+ * 4(f) — Recap: what moves between the four panes. One horizontal rail; layers
+ * slide in and out beside each other and never stack.
+ */
+export function LayersRecapScreen() {
+  return (
+    <Frame width={800}>
+      <TitleBar title={ARTICLE_TITLE} subtitle="one horizontal rail · layers slide, never stack" />
+      <FrameBody className="gap-5 p-4">
+        <div className="flex items-stretch">
+          {layers.map((layer, i) => (
+            <div key={layer.n} className="flex items-stretch" style={{ flex: layer.flex }}>
+              {i > 0 ? (
+                <div className="flex w-14 shrink-0 flex-col items-center justify-center gap-1 px-1">
+                  <span className="text-center text-[0.5625rem] leading-tight text-faint">
+                    {arrows[i - 1]}
+                  </span>
+                  <span aria-hidden className="text-[0.75rem] text-faint">
+                    →
+                  </span>
+                </div>
+              ) : null}
+              <div
+                className={cx(
+                  'flex min-w-0 flex-1 flex-col gap-1.5 rounded-lg border p-2.5',
+                  layer.accent ? 'border-accent-edge bg-accent-soft' : 'border-edge bg-sunk',
+                )}
+              >
+                <MetaLabel>Layer {layer.n}</MetaLabel>
+                <h3 className="text-[0.875rem] font-semibold text-ink">{layer.name}</h3>
+                <p className="text-[0.6875rem] leading-relaxed text-muted">{layer.body}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <MetaLabel>What's on screen, when</MetaLabel>
+          {states.map((state) => (
+            <div key={state.label} className="flex items-center gap-3">
+              <div className="flex w-[8.5rem] shrink-0 gap-0.5">
+                {layers.map((layer) => (
+                  <span
+                    key={layer.n}
+                    style={{ flex: layer.flex }}
+                    className={cx(
+                      'h-2.5 rounded-sm',
+                      state.on.includes(layer.n) ? 'bg-accent' : 'bg-rule',
+                    )}
+                  />
+                ))}
+              </div>
+              <span className="text-[0.75rem] text-muted">{state.label}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Chip tone="outline">outline</Chip>
+          <Chip tone="outline">voices</Chip>
+          <Chip tone="outline">refs</Chip>
+          <span className="text-[0.6875rem] text-faint">
+            everything the coach knows about this piece lives in layer 2 — which is why editing it
+            by hand changes the advice
+          </span>
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/review/NotesToChatScreen.tsx
+++ b/ui/src/screens/review/NotesToChatScreen.tsx
@@ -1,0 +1,81 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Button } from '../../components/Button'
+import { ChatComposer, ChatMessage, ChatSuggestions } from '../../components/Chat'
+import { Chip } from '../../components/Chip'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { Pane, PaneHeader } from '../../components/Pane'
+import { ARTICLE_TITLE, outlineRevised } from '../../mock/content'
+import { PlanOutline } from '../article/PlanBlocks'
+
+/**
+ * 4(c) — Notes sent to chat, and the plan gets revised. This is what closes
+ * the loop: draft → review → accept → chat → the plan changes → draft again.
+ * Counts are restated against the new plan, so "3 of 5 quotes used" becomes
+ * "3 of 4" rather than staying a failure against a plan you have abandoned.
+ */
+export function NotesToChatScreen() {
+  return (
+    <Frame width={800}>
+      <ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="after review 2" />
+      <FrameBody row className="min-h-[21rem]">
+        <Pane divider="right" className="gap-3">
+          <ChatMessage from="me">
+            <MetaLabel className="mb-1.5">4 accepted notes, pasted in</MetaLabel>
+            <ol className="flex list-decimal flex-col gap-1 pl-4">
+              <li>The crane index carries §1 and §4 both — kill the second one.</li>
+              <li>The human cost lands 600 words late.</li>
+              <li>§3 drifts into Newsletter aside.</li>
+              <li>Two planned quotes unused, both §3.</li>
+            </ol>
+          </ChatMessage>
+
+          <ChatMessage from="agent">
+            Notes 1 and 2 are the same problem: §3 is doing §4's job. If §3 loses the throughput
+            quote and §4 absorbs the argument, the unused quotes stop being unused — one gets cut
+            for good. Want me to redo the outline that way?
+          </ChatMessage>
+
+          <ChatSuggestions>
+            <Chip tone="accent" interactive>
+              yes, update the plan
+            </Chip>
+            <Chip tone="outline" interactive>
+              leave it, I'll do it
+            </Chip>
+          </ChatSuggestions>
+
+          <ChatComposer />
+        </Pane>
+
+        <Pane tone="sunk" padded={false}>
+          <div className="flex flex-1 flex-col gap-3.5 p-3.5">
+            <PaneHeader title="Plan" meta="revised just now" />
+            <PlanOutline sections={outlineRevised} dense changedFrom={3} />
+
+            <div className="flex flex-col gap-2">
+              <MetaLabel>Quotes</MetaLabel>
+              <div className="flex items-center gap-2.5">
+                <Chip tone="accent">3 / 4</Chip>
+                <span className="text-[0.75rem] text-faint">was 3 / 5</span>
+              </div>
+              <div className="flex items-start gap-2.5 opacity-55">
+                <span className="text-[0.6875rem] text-faint">dropped</span>
+                <blockquote className="min-w-0 flex-1 border-l-2 border-rule pl-2.5 text-[0.75rem] leading-relaxed text-muted">
+                  “The meter runs on an empty lot exactly as fast as it runs on a finished one.”
+                  <span className="mt-0.5 block text-[0.6875rem] text-faint">
+                    no longer needed in §3
+                  </span>
+                </blockquote>
+              </div>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
+            <Button>back to the draft →</Button>
+            <span className="text-[0.75rem] text-faint">round 3 whenever</span>
+          </div>
+        </Pane>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/review/PaneCombosScreen.tsx
+++ b/ui/src/screens/review/PaneCombosScreen.tsx
@@ -1,0 +1,84 @@
+import { Frame, FrameBody } from '../../components/Frame'
+import { PaneRail, type PaneId } from '../../components/PaneRail'
+import { cx } from '../../lib/cx'
+
+interface Combo {
+  open: PaneId[]
+  widths: Array<{ pane: PaneId; flex: number }>
+}
+
+const combos: Combo[] = [
+  {
+    open: ['chat', 'plan'],
+    widths: [
+      { pane: 'chat', flex: 1 },
+      { pane: 'plan', flex: 1 },
+    ],
+  },
+  {
+    open: ['plan', 'draft'],
+    widths: [
+      { pane: 'plan', flex: 0.38 },
+      { pane: 'draft', flex: 1 },
+    ],
+  },
+  {
+    open: ['draft', 'notes'],
+    widths: [
+      { pane: 'draft', flex: 1 },
+      { pane: 'notes', flex: 0.26 },
+    ],
+  },
+  {
+    open: ['chat', 'notes'],
+    widths: [
+      { pane: 'chat', flex: 0.5 },
+      { pane: 'notes', flex: 0.5 },
+    ],
+  },
+  {
+    open: ['plan', 'draft', 'notes'],
+    widths: [
+      { pane: 'plan', flex: 0.24 },
+      { pane: 'draft', flex: 1 },
+      { pane: 'notes', flex: 0.24 },
+    ],
+  },
+]
+
+/**
+ * 4(e) — Recap: which panes can be open at once. Order never changes, panes
+ * never stack, and the two support panes are always the narrow ones.
+ */
+export function PaneCombosScreen() {
+  return (
+    <Frame width={360}>
+      <FrameBody className="gap-4 p-4">
+        {combos.map((combo, i) => (
+          <div key={i} className="flex flex-col gap-2">
+            <PaneRail open={combo.open} />
+            <div className="flex h-10 overflow-hidden rounded-md border border-edge">
+              {combo.widths.map(({ pane, flex }, j) => (
+                <div
+                  key={pane}
+                  style={{ flex }}
+                  className={cx(
+                    'grid place-items-center text-[0.625rem] text-faint',
+                    j > 0 && 'border-l border-edge',
+                    pane === 'draft' ? 'bg-surface' : 'bg-sunk',
+                  )}
+                >
+                  {pane}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+        <p className="text-[0.6875rem] leading-relaxed text-faint">
+          Notes is always the narrow one. Plan collapses to a rail when the draft is up. Draft alone
+          is the sixth state, and the most common.
+        </p>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/review/PhoneNotesScreen.tsx
+++ b/ui/src/screens/review/PhoneNotesScreen.tsx
@@ -1,0 +1,67 @@
+import { Chip } from '../../components/Chip'
+import { CoachNote } from '../../components/CoachNote'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { draftShort } from '../../mock/content'
+
+/**
+ * 4(d) — The phone. A form factor, not a phase: read the draft, triage the
+ * notes, and nothing else. No writing happens here.
+ */
+export function PhoneNotesScreen() {
+  return (
+    <Frame width={280}>
+      <div className="flex items-baseline justify-between px-3.5 py-2.5">
+        <span className="text-[0.8125rem] text-faint">The Long Tail of Batteries</span>
+        <span className="text-[0.6875rem] text-faint">draft 1</span>
+      </div>
+      <FrameBody className="gap-3.5 px-3.5 pb-4">
+        <div className="flex gap-1.5">
+          <Chip tone="solid" interactive>
+            notes 3
+          </Chip>
+          <Chip tone="outline" interactive>
+            read
+          </Chip>
+          <Chip tone="outline" interactive>
+            plan
+          </Chip>
+        </div>
+
+        <CoachNote
+          anchor="§3"
+          confidence="confident"
+          live
+          title="You're restating §2"
+          body="§3 is meant to move to the cost of the delay."
+          actions={
+            <>
+              <Chip tone="outline" interactive>
+                accept
+              </Chip>
+              <Chip tone="muted" interactive>
+                later
+              </Chip>
+            </>
+          }
+        />
+        <CoachNote
+          anchor="whole piece"
+          confidence="tentative"
+          title="220 words over target"
+        />
+
+        <div className="flex flex-col gap-1.5">
+          <MetaLabel>Read</MetaLabel>
+          <div className="prose-draft">
+            {draftShort.map((paragraph, i) => (
+              <p key={i} className={i > 0 ? 'mt-3 text-[0.8125rem]' : 'text-[0.8125rem]'}>
+                {paragraph}
+              </p>
+            ))}
+          </div>
+        </div>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/review/ReviewRailScreen.tsx
+++ b/ui/src/screens/review/ReviewRailScreen.tsx
@@ -1,0 +1,85 @@
+import { ArticleBar } from '../../components/ArticleBar'
+import { Button } from '../../components/Button'
+import { Check } from '../../components/Check'
+import { Chip } from '../../components/Chip'
+import { DraftSurface } from '../../components/DraftSurface'
+import { Frame, FrameBody } from '../../components/Frame'
+import { MetaLabel } from '../../components/MetaLabel'
+import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
+
+/**
+ * 4(b) — Back in the draft with the review's findings in the rail. The
+ * findings became a checklist; the prose has gone quiet behind it because you
+ * are reading, not writing, for a moment.
+ */
+export function ReviewRailScreen() {
+  return (
+    <Frame width={660}>
+      <ArticleBar title={ARTICLE_TITLE} open={['draft', 'notes']} status="round 2" />
+      <FrameBody row className="min-h-[18rem]">
+        <DraftSurface paragraphs={draftParagraphs.slice(0, 3)} measure="narrow" dimmed />
+
+        <aside className="flex w-[14rem] shrink-0 flex-col gap-3.5 border-l border-edge bg-sunk p-3.5">
+          <h3 className="text-[0.875rem] font-semibold text-ink">Full review</h3>
+
+          <section className="flex flex-col gap-2">
+            <MetaLabel count={2}>Structure</MetaLabel>
+            <div className="flex items-start gap-2">
+              <Check />
+              <p className="text-[0.75rem] leading-snug text-ink">
+                The crane index carries §1 and §4 both
+              </p>
+            </div>
+            <div className="flex items-start gap-2 opacity-55">
+              <Check checked />
+              <p className="text-[0.75rem] leading-snug text-ink line-through">
+                Human cost arrives too late
+              </p>
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <MetaLabel count={1}>Voice</MetaLabel>
+            <div className="flex items-start gap-2">
+              <Check />
+              <p className="text-[0.75rem] leading-snug text-ink">
+                §3 drifts into Newsletter aside
+              </p>
+            </div>
+          </section>
+
+          <section className="flex flex-col gap-2">
+            <MetaLabel count={3}>Citations</MetaLabel>
+            <div className="flex items-start gap-2">
+              <Check />
+              <p className="text-[0.75rem] leading-snug text-ink">£4,100 figure needs attribution</p>
+            </div>
+            <div className="flex items-start gap-2">
+              <Check />
+              <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+                <p className="text-[0.75rem] leading-snug text-ink">
+                  2 of 5 planned quotes unused
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  <Chip tone="outline" interactive>
+                    ledger
+                  </Chip>
+                  <Chip tone="muted" interactive>
+                    fine as is
+                  </Chip>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <div className="mt-auto flex flex-wrap gap-2">
+            <Button size="sm">send notes to chat</Button>
+            <Button size="sm" tone="quiet">
+              finish →
+            </Button>
+          </div>
+        </aside>
+      </FrameBody>
+    </Frame>
+  )
+}

--- a/ui/src/screens/review/Reviews.stories.tsx
+++ b/ui/src/screens/review/Reviews.stories.tsx
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Annotation } from '../../components/Annotation'
+import { FullReviewScreen } from './FullReviewScreen'
+import { LayersRecapScreen } from './LayersRecapScreen'
+import { NotesToChatScreen } from './NotesToChatScreen'
+import { PaneCombosScreen } from './PaneCombosScreen'
+import { PhoneNotesScreen } from './PhoneNotesScreen'
+import { ReviewRailScreen } from './ReviewRailScreen'
+
+const meta = {
+  title: 'Screens/4 Reviews',
+  parameters: { layout: 'centered' },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const A_FullReview: Story = {
+  name: '4(a) In-depth review',
+  render: () => (
+    <div className="flex flex-col">
+      <FullReviewScreen />
+      <Annotation>
+        Only this pass is full screen — you asked for it, so it gets the window once. Accepted
+        findings then live in the notes rail while you write.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const B_ReviewRail: Story = {
+  name: '4(b) Findings in the rail',
+  render: () => <ReviewRailScreen />,
+}
+
+export const C_NotesToChat: Story = {
+  name: '4(c) Notes sent to chat',
+  render: () => (
+    <div className="flex flex-col">
+      <NotesToChatScreen />
+      <Annotation>
+        The loop: draft → review → accept notes → notes go to chat → the plan changes → draft again.
+        Counts are restated against the new plan, so "3 of 5 quotes used" becomes "3 of 4" instead
+        of standing as a permanent failure against a plan you have already moved on from.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const D_Phone: Story = {
+  name: '4(d) On the phone',
+  render: () => (
+    <div className="flex flex-col">
+      <PhoneNotesScreen />
+      <Annotation>
+        A form factor, not a phase. Read and triage; no writing happens here.
+      </Annotation>
+    </div>
+  ),
+}
+
+export const E_PaneCombos: Story = {
+  name: '4(e) Recap · pane combinations',
+  render: () => <PaneCombosScreen />,
+}
+
+export const F_LayersRecap: Story = {
+  name: '4(f) Recap · the four layers',
+  render: () => <LayersRecapScreen />,
+}

--- a/ui/src/styles/theme.css
+++ b/ui/src/styles/theme.css
@@ -1,0 +1,94 @@
+@import 'tailwindcss';
+
+/*
+ * Joarness design tokens.
+ *
+ * The page is deliberately quiet: paper, ink, and three greys. `accent` is the
+ * one colour that asks for attention, and it is rationed — see the "Accent"
+ * docs page in Storybook. If a screen has two yellow things on it, one of them
+ * is probably wrong.
+ */
+@theme {
+  /* Surfaces */
+  --color-paper: #f4f2ee; /* the desk the app sits on */
+  --color-surface: #ffffff; /* cards, panes, the writing surface */
+  --color-sunk: #faf8f5; /* secondary panes: plan, notes, sidebars */
+  --color-hush: #f0ede7; /* your own chat messages, inert fills */
+
+  /* Ink */
+  --color-ink: #1b1a17; /* body + headings */
+  --color-muted: #6b665e; /* secondary copy */
+  --color-faint: #9b958a; /* meta, counts, timestamps */
+
+  /* Lines */
+  --color-rule: #e3dfd7; /* hairlines between rows */
+  --color-edge: #cdc7bc; /* card borders, inputs */
+  --color-strong: #1b1a17; /* the one heavy divider per frame */
+
+  /* The accent — light yellow highlight. Rationed. */
+  --color-accent: #ffe6a3;
+  --color-accent-soft: #fff6df; /* wash behind an accented block */
+  --color-accent-edge: #e3c471;
+  --color-accent-ink: #6a5312; /* text sitting on accent */
+
+  /* Type */
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --font-serif: 'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif;
+  --font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Meta label: the small uppercase mono labels used all over the design */
+  --text-meta: 0.6875rem;
+  --text-meta--line-height: 1.4;
+  --text-meta--letter-spacing: 0.06em;
+
+  --radius-frame: 0.625rem;
+
+  /* One elevation, used only on the outermost frame */
+  --shadow-frame: 0 1px 2px rgb(27 26 23 / 0.05), 0 8px 24px -16px rgb(27 26 23 / 0.25);
+}
+
+@layer base {
+  html {
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  body {
+    background: var(--color-paper);
+    color: var(--color-ink);
+    font-family: var(--font-sans);
+  }
+
+  /* Keyboard focus is visible everywhere; it borrows the accent edge rather
+     than the accent fill so it never competes with a real accent element. */
+  :focus-visible {
+    outline: 2px solid var(--color-accent-edge);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+}
+
+@layer components {
+  /* The small uppercase mono label. Used often enough to earn a class. */
+  .label-meta {
+    font-family: var(--font-mono);
+    font-size: var(--text-meta);
+    line-height: var(--text-meta--line-height);
+    letter-spacing: var(--text-meta--letter-spacing);
+    text-transform: uppercase;
+    color: var(--color-faint);
+  }
+
+  /* Prose in the writing surface and the draft previews. */
+  .prose-draft {
+    font-family: var(--font-serif);
+    font-size: 1rem;
+    line-height: 1.75;
+    color: var(--color-ink);
+  }
+
+  .prose-draft p + p {
+    margin-top: 1.1em;
+  }
+}

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["vite/client"]
+  },
+  "include": ["src", ".storybook", "vite.config.ts"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { fileURLToPath, URL } from 'node:url'
+
+// The app is consumed through Storybook; `vite build` produces the library entry
+// so the screens can be dropped into the real app once the back end exists.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  build: {
+    lib: {
+      entry: fileURLToPath(new URL('./src/index.ts', import.meta.url)),
+      name: 'JoarnessUI',
+      formats: ['es'],
+      fileName: 'joarness-ui',
+    },
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
+    },
+  },
+})


### PR DESCRIPTION
Builds the "Joarness WF" wireframes as a real React component library, with Storybook as the only entry point. 21 screens across six sections: desk, board and table; writer settings (voices, adjectives, favourite sources); the chat/plan/draft/notes rail and the source ledger; the drafting surface and its notes; reviews and the loop back into the plan; finish, archive and the public showcase.

Stack is Vite 8, React 19, Tailwind v4 and Storybook 10, all under ui/. The lo-fi styling is gone — real type, real copy, real spacing — but the structure and behaviour follow the wireframes closely, including the annotations that explain why each screen is shaped the way it is.

One design rule carries the whole thing: paper, ink and three greys, plus exactly one colour (#ffe6a3) reserved for the single element on a screen that wants a decision. Selected tabs, open panes and progress bars take ink instead, so the yellow keeps its meaning. src/foundations/Accent.mdx writes this down.

Nothing is wired to data — screens are static compositions over src/mock, and only PaneRail takes a handler.

Claude-Session: https://claude.ai/code/session_01HUFyF3Bvvoxh2UoAVbjcaA