### PR TITLE
Implement Offer management in Article Agent

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,11 +4,7 @@
   "categories": {
     "correctness": "error"
   },
-  "rules": {
-    // The Agents SDK spells a statement as a tagged template: `this.sql`
-    // runs the query and a caller that only writes discards the rows.
-    "no-unused-expressions": ["error", { "allowTaggedTemplates": true }]
-  },
+  "rules": {},
   "env": {
     "builtin": true,
     "browser": true,
@@ -19,6 +15,12 @@
     {
       "files": ["src/server/**", "test/**", "*.config.ts", ".storybook/**"],
       "env": { "browser": false, "node": true }
+    },
+    {
+      // `this.sql` is a statement written as a tagged template, so a write
+      // discards the rows it returns. Only the Agents SDK spells it that way.
+      "files": ["src/server/**"],
+      "rules": { "no-unused-expressions": ["error", { "allowTaggedTemplates": true }] }
     }
   ]
 }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,7 +4,11 @@
   "categories": {
     "correctness": "error"
   },
-  "rules": {},
+  "rules": {
+    // The Agents SDK spells a statement as a tagged template: `this.sql`
+    // runs the query and a caller that only writes discards the rows.
+    "no-unused-expressions": ["error", { "allowTaggedTemplates": true }]
+  },
   "env": {
     "builtin": true,
     "browser": true,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,17 +365,15 @@ Settings and known defects. None is a decision to make; all are things to get ri
   everything, and not survivable the moment that stops being true.
 - **An expired Access session answers with a redirect rather than a 1008 close**, so
   party-db's client reconnect-loops instead of firing `onAuthError`.
-- **`@callable` cannot be written as a decorator, and no build setting fixes it.** Vite 8
-  bundles through oxc, which does not transform a standard decorator at any `target` — it
-  emits the `@` syntax verbatim and workerd's V8 refuses to parse it. Its
-  `decorator.legacy` option does transform, to the pre-standard calling convention, which
-  hands `callable()` the prototype instead of the method: registration lands on the wrong
-  object and every RPC call is refused at runtime with "is not callable". Both measured
-  against the oxc inside rolldown 1.2.3, which Vite 8.2 bundles with — Vite 7 used
-  esbuild, which lowers these. `src/server/article-agent.ts` therefore calls `callable()` on each
-  method instead of decorating it, which is the same registration by the same function,
-  and a test names the set so a method left out fails loudly. Recovering the syntax means
-  lowering decorators ahead of oxc, in both `vite.config.ts` and `vitest.config.ts`.
+- **`@callable` needs the `agents/vite` plugin, in both Vite configs.** Vite 8 transpiles
+  with oxc, which does not implement TC39 decorators (oxc#9170) and emits the `@` syntax
+  verbatim, so the Worker fails to parse with "SyntaxError: Invalid or unexpected token".
+  The plugin lowers them through Babel. `vitest.config.ts` needs it as well as
+  `vite.config.ts` — a worker test builds the Article Agent, and the two files do not
+  share plugins. **Do not reach for `experimentalDecorators`**: the SDK uses standard
+  decorators, and the legacy convention hands `callable()` the prototype instead of the
+  method, so nothing registers and every RPC call is refused at runtime with "is not
+  callable" — a silent failure where the missing plugin is a loud one.
 - **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
   completeness server-side with **no orphan timeout**, so a Proposal the writer neither
   Accepts nor Declines stalls the conversation silently. Surface it in the UI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -371,7 +371,8 @@ Settings and known defects. None is a decision to make; all are things to get ri
   `decorator.legacy` option does transform, to the pre-standard calling convention, which
   hands `callable()` the prototype instead of the method: registration lands on the wrong
   object and every RPC call is refused at runtime with "is not callable". Both measured
-  against oxc 0.127. `src/server/article-agent.ts` therefore calls `callable()` on each
+  against the oxc inside rolldown 1.2.3, which Vite 8.2 bundles with — Vite 7 used
+  esbuild, which lowers these. `src/server/article-agent.ts` therefore calls `callable()` on each
   method instead of decorating it, which is the same registration by the same function,
   and a test names the set so a method left out fails loudly. Recovering the syntax means
   lowering decorators ahead of oxc, in both `vite.config.ts` and `vitest.config.ts`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,6 +365,11 @@ Settings and known defects. None is a decision to make; all are things to get ri
   everything, and not survivable the moment that stops being true.
 - **An expired Access session answers with a redirect rather than a 1008 close**, so
   party-db's client reconnect-loops instead of firing `onAuthError`.
+- **`@callable` cannot be written as a decorator.** Vite 8 bundles through oxc, which
+  leaves a standard decorator in the output, and workerd's V8 does not implement one — so
+  the Worker fails to parse rather than failing a test. `src/server/article-agent.ts`
+  registers its callable methods by calling `callable()` on each one instead, which is the
+  same registration the decorator performs.
 - **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
   completeness server-side with **no orphan timeout**, so a Proposal the writer neither
   Accepts nor Declines stalls the conversation silently. Surface it in the UI.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,11 +365,16 @@ Settings and known defects. None is a decision to make; all are things to get ri
   everything, and not survivable the moment that stops being true.
 - **An expired Access session answers with a redirect rather than a 1008 close**, so
   party-db's client reconnect-loops instead of firing `onAuthError`.
-- **`@callable` cannot be written as a decorator.** Vite 8 bundles through oxc, which
-  leaves a standard decorator in the output, and workerd's V8 does not implement one — so
-  the Worker fails to parse rather than failing a test. `src/server/article-agent.ts`
-  registers its callable methods by calling `callable()` on each one instead, which is the
-  same registration the decorator performs.
+- **`@callable` cannot be written as a decorator, and no build setting fixes it.** Vite 8
+  bundles through oxc, which does not transform a standard decorator at any `target` — it
+  emits the `@` syntax verbatim and workerd's V8 refuses to parse it. Its
+  `decorator.legacy` option does transform, to the pre-standard calling convention, which
+  hands `callable()` the prototype instead of the method: registration lands on the wrong
+  object and every RPC call is refused at runtime with "is not callable". Both measured
+  against oxc 0.127. `src/server/article-agent.ts` therefore calls `callable()` on each
+  method instead of decorating it, which is the same registration by the same function,
+  and a test names the set so a method left out fails loudly. Recovering the syntax means
+  lowering decorators ahead of oxc, in both `vite.config.ts` and `vitest.config.ts`.
 - **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
   completeness server-side with **no orphan timeout**, so a Proposal the writer neither
   Accepts nor Declines stalls the conversation silently. Surface it in the UI.

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -10,7 +10,13 @@ import {
 	type Ruling,
 	rulings,
 } from '../shared/offer'
-import { emptyPlan, type Plan, planSchema, type Source } from '../shared/plan'
+import {
+	emptyPlan,
+	type Plan,
+	type PlanRefused,
+	planSchema,
+	type Source,
+} from '../shared/plan'
 
 /** One Offer row as SQLite returns it. The column names are snake_case and the
  * source is a JSON string, so nothing here is handed to a client unmapped. */
@@ -73,15 +79,21 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	 * The only guard on the blob. Every write is parsed, whatever its source:
 	 * the client is the Plan's one writer, so a server write is already a bug.
 	 *
-	 * The Agents SDK answers a rejected client write with a fixed
-	 * `cf_agent_state_error` string and logs the reason, so the message thrown
-	 * here reaches the log rather than the writer.
+	 * The throw is what refuses the write. The SDK turns it into a fixed
+	 * `cf_agent_state_error` string and logs the rest, so the `plan_refused`
+	 * frame is what carries the reason back to the writer's own connection.
 	 */
-	validateStateChange(nextState: Plan, _source: Connection | 'server'): void {
+	validateStateChange(nextState: Plan, source: Connection | 'server'): void {
 		const result = planSchema.safeParse(nextState)
 		if (result.success) return
 
-		throw new Error(`The Plan does not parse. ${z.prettifyError(result.error)}`)
+		const reason = z.prettifyError(result.error)
+		if (source !== 'server') {
+			const refusal: PlanRefused = { type: 'plan_refused', error: reason }
+			source.send(JSON.stringify(refusal))
+		}
+
+		throw new Error(`The Plan does not parse. ${reason}`)
 	}
 
 	/** Every Offer on this Article, oldest first. The Ledger filters by
@@ -161,12 +173,18 @@ export class ArticleAgent extends Agent<Env, Plan> {
 /**
  * The four Offer methods a client may call over the socket it already holds.
  *
- * `@callable()` on the method is the SDK's own spelling and this build cannot
- * use it. Vite 8 bundles through oxc, which leaves a standard decorator in the
- * output, and workerd's V8 does not implement one — so the Worker fails to
- * parse rather than failing a test. The decorator's whole job is to register
- * the method function in the SDK's callable table, which is what calling it
- * here does. Replace this block with the decorators the day oxc lowers them.
+ * `@callable()` on the method is the SDK's own spelling, and this build cannot
+ * use it. Vite 8 bundles through oxc, which does not transform a standard
+ * decorator at any `target` — it emits the `@` syntax verbatim, and workerd's
+ * V8 refuses to parse it. Its `decorator.legacy` option does transform, to the
+ * pre-standard calling convention, which hands `callable()` the prototype
+ * instead of the method: registration then lands on the wrong object and every
+ * RPC call is refused at runtime with "is not callable". Both were measured
+ * against oxc 0.127, and neither is a setting away from working.
+ *
+ * So this calls the decorator rather than writing it, which is the same
+ * registration by the same function. Adding a callable method means adding it
+ * here, and `test/worker/article-agent.test.ts` fails if it is left out.
  */
 for (const method of [
 	ArticleAgent.prototype.listOffers,

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -8,7 +8,7 @@ import {
 	type OfferKind,
 	offerContentSchema,
 	type Ruling,
-	rulings,
+	rulingSchema,
 } from '../shared/offer'
 import {
 	emptyPlan,
@@ -18,12 +18,13 @@ import {
 	type Source,
 } from '../shared/plan'
 
-/** One Offer row as SQLite returns it. The column names are snake_case and the
- * source is a JSON string, so nothing here is handed to a client unmapped. */
+/** One Offer row as SQLite returns it. `this.sql` asserts the row type rather
+ * than checking it, and this class is the table's only writer, so the columns
+ * are stated as what `createOffer` parsed before writing them. */
 type OfferRow = {
 	id: string
-	kind: string
-	disposition: string
+	kind: OfferKind
+	disposition: Disposition
 	text: string | null
 	source: string | null
 	note: string | null
@@ -31,19 +32,21 @@ type OfferRow = {
 	decided_at: number | null
 }
 
-/** A row back into an Offer. The casts restate what `createOffer` parsed before
- * writing the row — this class is the only writer of the table. */
 function toOffer(row: OfferRow): Offer {
 	return {
 		id: row.id,
-		kind: row.kind as OfferKind,
-		disposition: row.disposition as Disposition,
+		kind: row.kind,
+		disposition: row.disposition,
 		text: row.text ?? undefined,
 		source: row.source === null ? undefined : (JSON.parse(row.source) as Source),
 		note: row.note ?? undefined,
 		createdAt: row.created_at,
 		decidedAt: row.decided_at,
 	}
+}
+
+function missingOffer(id: string): Error {
+	return new Error(`No Offer carries the id ${id}.`)
 }
 
 /**
@@ -53,9 +56,9 @@ function toOffer(row: OfferRow): Offer {
 export class ArticleAgent extends Agent<Env, Plan> {
 	initialState = emptyPlan()
 
-	/** Runs on every wake, including the wake after a hibernation. A later
-	 * column arrives as another statement here rather than as an edit to this
-	 * one, so an Article Agent that has been asleep for a month still migrates. */
+	/** Runs on every wake, so every statement here has to be idempotent. A new
+	 * table can join this one. A new column cannot — SQLite has no ADD COLUMN
+	 * IF NOT EXISTS, so the second wake throws on a duplicate column. */
 	onStart(): void {
 		this.sql`
 			CREATE TABLE IF NOT EXISTS offer (
@@ -129,19 +132,22 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	/** Mark an Offer as having been Accepted or Declined by the client. */
 	@callable()
 	setOfferDisposition(id: string, disposition: Ruling): Offer {
-		const ruling = z.enum(rulings).parse(disposition)
-		this.readOffer(id)
+		const ruling = rulingSchema.parse(disposition)
 
-		this.sql`
-			UPDATE offer SET disposition = ${ruling}, decided_at = ${Date.now()} WHERE id = ${id}
+		const rows = this.sql<OfferRow>`
+			UPDATE offer SET disposition = ${ruling}, decided_at = ${Date.now()}
+			WHERE id = ${id} RETURNING *
 		`
+		if (rows.length === 0) throw missingOffer(id)
 
-		return this.readOffer(id)
+		return toOffer(rows[0])
 	}
 
 	/** Restore a Declined Offer back to Undecided. */
 	@callable()
 	restoreOffer(id: string): Offer {
+		// Read first: an Offer that is Accepted and one that does not exist have
+		// to be told apart, and one conditional UPDATE cannot do that.
 		const offer = this.readOffer(id)
 		if (offer.disposition !== 'declined') {
 			throw new Error(
@@ -149,16 +155,17 @@ export class ArticleAgent extends Agent<Env, Plan> {
 			)
 		}
 
-		this.sql`
-			UPDATE offer SET disposition = 'undecided', decided_at = NULL WHERE id = ${id}
+		const rows = this.sql<OfferRow>`
+			UPDATE offer SET disposition = 'undecided', decided_at = NULL
+			WHERE id = ${id} RETURNING *
 		`
 
-		return this.readOffer(id)
+		return toOffer(rows[0])
 	}
 
 	private readOffer(id: string): Offer {
 		const rows = this.sql<OfferRow>`SELECT * FROM offer WHERE id = ${id}`
-		if (rows.length === 0) throw new Error(`No Offer carries the id ${id}.`)
+		if (rows.length === 0) throw missingOffer(id)
 
 		return toOffer(rows[0])
 	}

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -101,8 +101,10 @@ export class ArticleAgent extends Agent<Env, Plan> {
 		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY created_at, id`.map(toOffer)
 	}
 
-	/** Record something the Chat turned up. It starts Undecided. */
-	@callable()
+	/** Record something the Chat turned up. It starts Undecided.
+	 *
+	 * Not `@callable`: the writer never authors an Offer, so the Chat's research
+	 * tool is the only caller and it runs inside this Agent (§3, rule 4). */
 	createOffer(content: OfferContent): Offer {
 		const offer: Offer = {
 			...offerContentSchema.parse(content),

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -1,14 +1,178 @@
-import { Agent } from 'agents'
+import { Agent, callable, type Connection } from 'agents'
+import { z } from 'zod'
+
+import {
+	type Disposition,
+	type Offer,
+	type OfferContent,
+	type OfferKind,
+	offerContentSchema,
+	type Ruling,
+	rulings,
+} from '../shared/offer'
+import { emptyPlan, type Plan, planSchema, type Source } from '../shared/plan'
+
+/** One Offer row as SQLite returns it. The column names are snake_case and the
+ * source is a JSON string, so nothing here is handed to a client unmapped. */
+type OfferRow = {
+	id: string
+	kind: string
+	disposition: string
+	text: string | null
+	source: string | null
+	note: string | null
+	created_at: number
+	decided_at: number | null
+}
+
+/** A row back into an Offer. The casts restate what `createOffer` parsed before
+ * writing the row — this class is the only writer of the table. */
+function toOffer(row: OfferRow): Offer {
+	return {
+		id: row.id,
+		kind: row.kind as OfferKind,
+		disposition: row.disposition as Disposition,
+		text: row.text ?? undefined,
+		source: row.source === null ? undefined : (JSON.parse(row.source) as Source),
+		note: row.note ?? undefined,
+		createdAt: row.created_at,
+		decidedAt: row.decided_at,
+	}
+}
 
 /**
  * One Article Agent per Article — docs/architecture.md §2, and §3 for what goes
  * in the state blob against what goes in its SQLite.
- *
- * Empty so far: `validateStateChange`, which runs `planSchema` from
- * `src/shared/plan`, and the Offer rows.
  */
-export class ArticleAgent extends Agent<Env> {
+export class ArticleAgent extends Agent<Env, Plan> {
+	initialState = emptyPlan()
+
+	/** Runs on every wake, including the wake after a hibernation. A later
+	 * column arrives as another statement here rather than as an edit to this
+	 * one, so an Article Agent that has been asleep for a month still migrates. */
+	onStart(): void {
+		this.sql`
+			CREATE TABLE IF NOT EXISTS offer (
+				id TEXT PRIMARY KEY,
+				kind TEXT NOT NULL,
+				disposition TEXT NOT NULL,
+				text TEXT,
+				source TEXT,
+				note TEXT,
+				created_at INTEGER NOT NULL,
+				decided_at INTEGER
+			)
+		`
+	}
+
 	async onRequest(_request: Request): Promise<Response> {
 		return Response.json({ agent: 'ArticleAgent', name: this.name })
 	}
+
+	/**
+	 * The only guard on the blob. Every write is parsed, whatever its source:
+	 * the client is the Plan's one writer, so a server write is already a bug.
+	 *
+	 * The Agents SDK answers a rejected client write with a fixed
+	 * `cf_agent_state_error` string and logs the reason, so the message thrown
+	 * here reaches the log rather than the writer.
+	 */
+	validateStateChange(nextState: Plan, _source: Connection | 'server'): void {
+		const result = planSchema.safeParse(nextState)
+		if (result.success) return
+
+		throw new Error(`The Plan does not parse. ${z.prettifyError(result.error)}`)
+	}
+
+	/** Every Offer on this Article, oldest first. The Ledger filters by
+	 * disposition and counts, and it does that over this list — it is a View
+	 * over Offers rather than a store, and one Article's Offers are few. */
+	listOffers(): Offer[] {
+		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY created_at, id`.map(toOffer)
+	}
+
+	/** Record something the Chat turned up. It starts Undecided. */
+	createOffer(content: OfferContent): Offer {
+		const offer: Offer = {
+			...offerContentSchema.parse(content),
+			id: crypto.randomUUID(),
+			disposition: 'undecided',
+			createdAt: Date.now(),
+			decidedAt: null,
+		}
+
+		this.sql`
+			INSERT INTO offer (id, kind, disposition, text, source, note, created_at, decided_at)
+			VALUES (
+				${offer.id},
+				${offer.kind},
+				${offer.disposition},
+				${offer.text ?? null},
+				${offer.source === undefined ? null : JSON.stringify(offer.source)},
+				${offer.note ?? null},
+				${offer.createdAt},
+				${offer.decidedAt}
+			)
+		`
+
+		return offer
+	}
+
+	/** Rule on an Offer: Accept it into the Plan, or Decline it. Accepting does
+	 * not touch the Plan — the client copies the Offer in and keeps its
+	 * Provenance (§3, rule 5). */
+	setOfferDisposition(id: string, disposition: Ruling): Offer {
+		const ruling = z.enum(rulings).parse(disposition)
+		this.readOffer(id)
+
+		this.sql`
+			UPDATE offer SET disposition = ${ruling}, decided_at = ${Date.now()} WHERE id = ${id}
+		`
+
+		return this.readOffer(id)
+	}
+
+	/** Put a Declined Offer back to Undecided. Declining is restorable and
+	 * nothing is deleted, so this is the undo of a Decline rather than a third
+	 * ruling. */
+	restoreOffer(id: string): Offer {
+		const offer = this.readOffer(id)
+		if (offer.disposition !== 'declined') {
+			throw new Error(
+				`Offer ${id} is ${offer.disposition}, and restoring undoes a Decline.`,
+			)
+		}
+
+		this.sql`
+			UPDATE offer SET disposition = 'undecided', decided_at = NULL WHERE id = ${id}
+		`
+
+		return this.readOffer(id)
+	}
+
+	private readOffer(id: string): Offer {
+		const rows = this.sql<OfferRow>`SELECT * FROM offer WHERE id = ${id}`
+		if (rows.length === 0) throw new Error(`No Offer carries the id ${id}.`)
+
+		return toOffer(rows[0])
+	}
+}
+
+/**
+ * The four Offer methods a client may call over the socket it already holds.
+ *
+ * `@callable()` on the method is the SDK's own spelling and this build cannot
+ * use it. Vite 8 bundles through oxc, which leaves a standard decorator in the
+ * output, and workerd's V8 does not implement one — so the Worker fails to
+ * parse rather than failing a test. The decorator's whole job is to register
+ * the method function in the SDK's callable table, which is what calling it
+ * here does. Replace this block with the decorators the day oxc lowers them.
+ */
+for (const method of [
+	ArticleAgent.prototype.listOffers,
+	ArticleAgent.prototype.createOffer,
+	ArticleAgent.prototype.setOfferDisposition,
+	ArticleAgent.prototype.restoreOffer,
+] as ((...args: never[]) => unknown)[]) {
+	callable()(method, {} as ClassMethodDecoratorContext)
 }

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -180,7 +180,8 @@ export class ArticleAgent extends Agent<Env, Plan> {
  * pre-standard calling convention, which hands `callable()` the prototype
  * instead of the method: registration then lands on the wrong object and every
  * RPC call is refused at runtime with "is not callable". Both were measured
- * against oxc 0.127, and neither is a setting away from working.
+ * against the oxc inside rolldown 1.2.3, and neither is a setting away from
+ * working.
  *
  * So this calls the decorator rather than writing it, which is the same
  * registration by the same function. Adding a callable method means adding it

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -78,10 +78,6 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	/**
 	 * The only guard on the blob. Every write is parsed, whatever its source:
 	 * the client is the Plan's one writer, so a server write is already a bug.
-	 *
-	 * The throw is what refuses the write. The SDK turns it into a fixed
-	 * `cf_agent_state_error` string and logs the rest, so the `plan_refused`
-	 * frame is what carries the reason back to the writer's own connection.
 	 */
 	validateStateChange(nextState: Plan, source: Connection | 'server'): void {
 		const result = planSchema.safeParse(nextState)
@@ -96,9 +92,7 @@ export class ArticleAgent extends Agent<Env, Plan> {
 		throw new Error(`The Plan does not parse. ${reason}`)
 	}
 
-	/** Every Offer on this Article, oldest first. The Ledger filters by
-	 * disposition and counts, and it does that over this list — it is a View
-	 * over Offers rather than a store, and one Article's Offers are few. */
+	/** Every Offer on this Article, oldest first. */
 	@callable()
 	listOffers(): Offer[] {
 		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY created_at, id`.map(toOffer)
@@ -132,9 +126,7 @@ export class ArticleAgent extends Agent<Env, Plan> {
 		return offer
 	}
 
-	/** Rule on an Offer: Accept it into the Plan, or Decline it. Accepting does
-	 * not touch the Plan — the client copies the Offer in and keeps its
-	 * Provenance (§3, rule 5). */
+	/** Mark an Offer as having been Accepted or Declined by the client. */
 	@callable()
 	setOfferDisposition(id: string, disposition: Ruling): Offer {
 		const ruling = z.enum(rulings).parse(disposition)
@@ -147,9 +139,7 @@ export class ArticleAgent extends Agent<Env, Plan> {
 		return this.readOffer(id)
 	}
 
-	/** Put a Declined Offer back to Undecided. Declining is restorable and
-	 * nothing is deleted, so this is the undo of a Decline rather than a third
-	 * ruling. */
+	/** Restore a Declined Offer back to Undecided. */
 	@callable()
 	restoreOffer(id: string): Offer {
 		const offer = this.readOffer(id)

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -99,11 +99,13 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	/** Every Offer on this Article, oldest first. The Ledger filters by
 	 * disposition and counts, and it does that over this list — it is a View
 	 * over Offers rather than a store, and one Article's Offers are few. */
+	@callable()
 	listOffers(): Offer[] {
 		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY created_at, id`.map(toOffer)
 	}
 
 	/** Record something the Chat turned up. It starts Undecided. */
+	@callable()
 	createOffer(content: OfferContent): Offer {
 		const offer: Offer = {
 			...offerContentSchema.parse(content),
@@ -133,6 +135,7 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	/** Rule on an Offer: Accept it into the Plan, or Decline it. Accepting does
 	 * not touch the Plan — the client copies the Offer in and keeps its
 	 * Provenance (§3, rule 5). */
+	@callable()
 	setOfferDisposition(id: string, disposition: Ruling): Offer {
 		const ruling = z.enum(rulings).parse(disposition)
 		this.readOffer(id)
@@ -147,6 +150,7 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	/** Put a Declined Offer back to Undecided. Declining is restorable and
 	 * nothing is deleted, so this is the undo of a Decline rather than a third
 	 * ruling. */
+	@callable()
 	restoreOffer(id: string): Offer {
 		const offer = this.readOffer(id)
 		if (offer.disposition !== 'declined') {
@@ -168,30 +172,4 @@ export class ArticleAgent extends Agent<Env, Plan> {
 
 		return toOffer(rows[0])
 	}
-}
-
-/**
- * The four Offer methods a client may call over the socket it already holds.
- *
- * `@callable()` on the method is the SDK's own spelling, and this build cannot
- * use it. Vite 8 bundles through oxc, which does not transform a standard
- * decorator at any `target` — it emits the `@` syntax verbatim, and workerd's
- * V8 refuses to parse it. Its `decorator.legacy` option does transform, to the
- * pre-standard calling convention, which hands `callable()` the prototype
- * instead of the method: registration then lands on the wrong object and every
- * RPC call is refused at runtime with "is not callable". Both were measured
- * against the oxc inside rolldown 1.2.3, and neither is a setting away from
- * working.
- *
- * So this calls the decorator rather than writing it, which is the same
- * registration by the same function. Adding a callable method means adding it
- * here, and `test/worker/article-agent.test.ts` fails if it is left out.
- */
-for (const method of [
-	ArticleAgent.prototype.listOffers,
-	ArticleAgent.prototype.createOffer,
-	ArticleAgent.prototype.setOfferDisposition,
-	ArticleAgent.prototype.restoreOffer,
-] as ((...args: never[]) => unknown)[]) {
-	callable()(method, {} as ClassMethodDecoratorContext)
 }

--- a/src/shared/offer.ts
+++ b/src/shared/offer.ts
@@ -3,19 +3,11 @@ import { z } from 'zod'
 import { sourceSchema } from './plan'
 
 /**
- * An Offer: something the Chat turned up and handed to the writer to rule on.
- *
- * An Offer is a row in the Article Agent's SQLite, never a field of the Plan.
- * A row write touches named columns, so the Chat can add an Offer while the
- * writer edits the Plan and neither write erases the other
- * (docs/architecture.md §3, rule 2).
- *
- * Offers are flat: two Quotes from one publication are two Offers.
+ * An Offer, as coined in context.md. Stored in the Article Agent's SQLite,
+ * Offers are kept as a flat list of References and Quotes turned up from
+ * research.
  */
 
-/** What sort of thing an Offer holds. A Quote is a Reference that carries a
- * text, so today the Kind follows from the content — it is stored because the
- * Kinds that come later will not follow from anything. */
 export const offerKinds = ['reference', 'quote'] as const
 export type OfferKind = (typeof offerKinds)[number]
 
@@ -23,9 +15,6 @@ export type OfferKind = (typeof offerKinds)[number]
 export const dispositions = ['undecided', 'accepted', 'declined'] as const
 export type Disposition = (typeof dispositions)[number]
 
-/** What the writer may rule. Undecided is absent because it is not a ruling:
- * an Offer starts there, and a Declined one returns there through
- * `restoreOffer`, which is the undo of a Decline. */
 export const rulings = ['accepted', 'declined'] as const
 export type Ruling = (typeof rulings)[number]
 

--- a/src/shared/offer.ts
+++ b/src/shared/offer.ts
@@ -1,0 +1,58 @@
+import { z } from 'zod'
+
+import { sourceSchema } from './plan'
+
+/**
+ * An Offer: something the Chat turned up and handed to the writer to rule on.
+ *
+ * An Offer is a row in the Article Agent's SQLite, never a field of the Plan.
+ * A row write touches named columns, so the Chat can add an Offer while the
+ * writer edits the Plan and neither write erases the other
+ * (docs/architecture.md §3, rule 2).
+ *
+ * Offers are flat: two Quotes from one publication are two Offers.
+ */
+
+/** What sort of thing an Offer holds. A Quote is a Reference that carries a
+ * text, so today the Kind follows from the content — it is stored because the
+ * Kinds that come later will not follow from anything. */
+export const offerKinds = ['reference', 'quote'] as const
+export type OfferKind = (typeof offerKinds)[number]
+
+/** How far the writer has got with one Offer. Every Offer starts Undecided. */
+export const dispositions = ['undecided', 'accepted', 'declined'] as const
+export type Disposition = (typeof dispositions)[number]
+
+/** What the writer may rule. Undecided is absent because it is not a ruling:
+ * an Offer starts there, and a Declined one returns there through
+ * `restoreOffer`, which is the undo of a Decline. */
+export const rulings = ['accepted', 'declined'] as const
+export type Ruling = (typeof rulings)[number]
+
+/** What the Chat turned up. The id, the disposition, and the timestamps are
+ * the Article Agent's to set, so they are not here. */
+export const offerContentSchema = z
+	.strictObject({
+		kind: z.enum(offerKinds),
+		text: z.string().min(1).optional(),
+		source: sourceSchema.optional(),
+		note: z.string().min(1).optional(),
+	})
+	.refine((offer) => offer.text !== undefined || offer.source !== undefined, {
+		error: 'An Offer carries a text, a source, or both. One with neither is nothing.',
+	})
+	.refine((offer) => offer.kind !== 'quote' || offer.text !== undefined, {
+		error:
+			'A Quote is a Reference that carries a text, so an Offer of kind quote has one.',
+	})
+
+export type OfferContent = z.infer<typeof offerContentSchema>
+
+/** One Offer row. `decidedAt` is null while the Offer is Undecided, and
+ * returns to null when a Declined one is restored. */
+export type Offer = OfferContent & {
+	id: string
+	disposition: Disposition
+	createdAt: number
+	decidedAt: number | null
+}

--- a/src/shared/offer.ts
+++ b/src/shared/offer.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { sourceSchema } from './plan'
+import { sourceSchema } from './plan/schema'
 
 /**
  * An Offer, as coined in context.md. Stored in the Article Agent's SQLite,
@@ -15,8 +15,8 @@ export type OfferKind = (typeof offerKinds)[number]
 export const dispositions = ['undecided', 'accepted', 'declined'] as const
 export type Disposition = (typeof dispositions)[number]
 
-export const rulings = ['accepted', 'declined'] as const
-export type Ruling = (typeof rulings)[number]
+export const rulingSchema = z.enum(['accepted', 'declined'])
+export type Ruling = z.infer<typeof rulingSchema>
 
 /** What the Chat turned up. The id, the disposition, and the timestamps are
  * the Article Agent's to set, so they are not here. */

--- a/src/shared/plan/index.ts
+++ b/src/shared/plan/index.ts
@@ -1,9 +1,11 @@
-// The Plan: its schema, its Scope resolution, its word-count arithmetic, and
-// the Proposal ops the client applies to it. No Worker and no React here, so
-// both sides of the socket import the same rules.
+// The Plan: its schema, its Scope resolution, its word-count arithmetic, the
+// Proposal ops the client applies to it, and what the Article Agent sends back
+// when a write does not parse. No Worker and no React here, so both sides of
+// the socket import the same rules.
 
 export * from './apply'
 export * from './ops'
+export * from './refusal'
 export * from './schema'
 export * from './scope'
 export * from './word-count'

--- a/src/shared/plan/refusal.ts
+++ b/src/shared/plan/refusal.ts
@@ -1,0 +1,27 @@
+/**
+ * What the Article Agent sends back when a Plan write does not parse.
+ *
+ * The Agents SDK answers a refused write with a fixed `cf_agent_state_error`
+ * string and logs the real reason, so the writer would otherwise be told
+ * "State update rejected" and nothing about which rule failed. This frame
+ * carries the reason.
+ *
+ * It has its own type rather than reusing `cf_agent_state_error`, because the
+ * SDK sends that one too: a client would run its state-error handler twice and
+ * keep the useless message. `useAgent` hands a frame it does not recognise to
+ * `onMessage`, which is where this one arrives.
+ */
+export type PlanRefused = {
+	type: 'plan_refused'
+	/** Every rule the Plan broke, one per line, from `z.prettifyError`. */
+	error: string
+}
+
+/** Pick the refusal out of everything else on the multiplexed socket. */
+export function isPlanRefused(frame: unknown): frame is PlanRefused {
+	return (
+		typeof frame === 'object' &&
+		frame !== null &&
+		(frame as { type?: unknown }).type === 'plan_refused'
+	)
+}

--- a/test/worker/agent-socket.ts
+++ b/test/worker/agent-socket.ts
@@ -22,23 +22,22 @@ export async function openAgentSocket(name: string) {
 		throw new Error(`The Agent route answered ${response.status}, not a socket.`)
 	socket.accept()
 
+	/** Frames that have arrived and not yet been taken. `take` splices what it
+	 * returns, so what is left is exactly what a later call may still match. */
 	const frames: Frame[] = []
-	const taken = new Set<number>()
 	socket.addEventListener('message', (event) => {
 		frames.push(JSON.parse(event.data as string) as Frame)
 	})
 
-	/** The first frame this test has not yet taken that the predicate accepts.
-	 * Polls, because a broadcast arrives whenever the Agent sends it. */
+	/** The first untaken frame the predicate accepts. Polls, because a broadcast
+	 * arrives whenever the Agent sends it. */
 	async function take(match: (frame: Frame) => boolean, wanted: string): Promise<Frame> {
-		for (let attempt = 0; attempt < 200; attempt++) {
-			for (let index = 0; index < frames.length; index++) {
-				if (taken.has(index) || !match(frames[index])) continue
-				taken.add(index)
-				return frames[index]
-			}
+		const deadline = Date.now() + 2000
+		do {
+			const index = frames.findIndex(match)
+			if (index !== -1) return frames.splice(index, 1)[0]
 			await wait(10)
-		}
+		} while (Date.now() < deadline)
 
 		throw new Error(`No ${wanted} frame arrived on the ${name} socket.`)
 	}
@@ -75,11 +74,7 @@ export async function openAgentSocket(name: string) {
 		async quiet(type: string): Promise<Frame[]> {
 			await wait(50)
 
-			return frames.filter((frame, index) => !taken.has(index) && frame.type === type)
-		},
-
-		close() {
-			socket.close()
+			return frames.filter((frame) => frame.type === type)
 		},
 	}
 }

--- a/test/worker/agent-socket.ts
+++ b/test/worker/agent-socket.ts
@@ -1,0 +1,85 @@
+import { SELF } from 'cloudflare:test'
+
+/** One JSON frame off the Article Agent's WebSocket. The socket is
+ * multiplexed — state, RPC, identity, and MCP frames all ride it — so a test
+ * asks for the frame it wants rather than reading the next one. */
+type Frame = { type: string } & Record<string, unknown>
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+/**
+ * A test client speaking the Agents SDK's wire protocol directly. The real
+ * client is `useAgent`, which needs React and a browser, so a workerd test
+ * sends the frames itself.
+ */
+export async function openAgentSocket(name: string) {
+	const response = await SELF.fetch(`https://harness.test/agents/article-agent/${name}`, {
+		headers: { Upgrade: 'websocket' },
+	})
+
+	const socket = response.webSocket
+	if (!socket)
+		throw new Error(`The Agent route answered ${response.status}, not a socket.`)
+	socket.accept()
+
+	const frames: Frame[] = []
+	const taken = new Set<number>()
+	socket.addEventListener('message', (event) => {
+		frames.push(JSON.parse(event.data as string) as Frame)
+	})
+
+	/** The first frame this test has not yet taken that the predicate accepts.
+	 * Polls, because a broadcast arrives whenever the Agent sends it. */
+	async function take(match: (frame: Frame) => boolean, wanted: string): Promise<Frame> {
+		for (let attempt = 0; attempt < 200; attempt++) {
+			for (let index = 0; index < frames.length; index++) {
+				if (taken.has(index) || !match(frames[index])) continue
+				taken.add(index)
+				return frames[index]
+			}
+			await wait(10)
+		}
+
+		throw new Error(`No ${wanted} frame arrived on the ${name} socket.`)
+	}
+
+	return {
+		/** Push a Plan up the socket, the way the client applies every Plan
+		 * write. Nothing is awaited: the Agent answers with a broadcast or an
+		 * error frame. */
+		setState(state: unknown) {
+			socket.send(JSON.stringify({ type: 'cf_agent_state', state }))
+		},
+
+		/** Call a `@callable` method and wait for its answer. */
+		async call<T>(method: string, ...args: unknown[]): Promise<T> {
+			const id = crypto.randomUUID()
+			socket.send(JSON.stringify({ type: 'rpc', id, method, args }))
+
+			const frame = await take(
+				(candidate) => candidate.type === 'rpc' && candidate.id === id,
+				`rpc answer to ${method}`,
+			)
+			if (frame.success !== true) throw new Error(String(frame.error))
+
+			return frame.result as T
+		},
+
+		/** The next frame of this type the test has not already taken. */
+		next(type: string): Promise<Frame> {
+			return take((frame) => frame.type === type, type)
+		},
+
+		/** Every frame of this type still untaken once the wire goes quiet. Use
+		 * it to assert that nothing arrived. */
+		async quiet(type: string): Promise<Frame[]> {
+			await wait(50)
+
+			return frames.filter((frame, index) => !taken.has(index) && frame.type === type)
+		},
+
+		close() {
+			socket.close()
+		},
+	}
+}

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -1,10 +1,20 @@
 import { env, evictDurableObject, runInDurableObject } from 'cloudflare:test'
 import { describe, expect, it } from 'vitest'
 
-import type { Offer } from '../../src/shared/offer'
+import type { Offer, OfferContent } from '../../src/shared/offer'
 import { emptyPlan, isPlanRefused } from '../../src/shared/plan'
 import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
 import { openAgentSocket } from './agent-socket'
+
+/** Record an Offer the way the Chat will: inside the Agent, not over RPC.
+ * `createOffer` is deliberately not `@callable`, so a test reaches it the same
+ * way the research tool does. The Article Agent must already be awake, which
+ * every caller here arranges by opening a socket first. */
+function createOffer(name: string, content: OfferContent): Promise<Offer> {
+	const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName(name))
+
+	return runInDurableObject(stub, (agent) => agent.createOffer(content))
+}
 
 /** A Plan that parses: one Outline node, and one Reference placed at it. */
 const plan = makePlan({
@@ -92,28 +102,23 @@ describe('the Plan in Article Agent state', () => {
 
 describe('Offers in the Article Agent', () => {
 	// `@callable` is the whole allowlist of what a browser may invoke on this
-	// Durable Object, so the set is worth naming. It also proves the decorator
-	// survived the build: oxc does not lower one, and the Babel transform in
-	// `agents/vite` is what does.
-	it('marks every Offer method callable', async () => {
+	// Durable Object, so the set is worth naming — `createOffer` is absent
+	// because only the Chat records an Offer. It also proves the decorator
+	// survived the build: oxc does not lower one, and `agents/vite` does.
+	it('marks the three writer-facing Offer methods callable', async () => {
 		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('callable-set'))
 
 		const methods = await runInDurableObject(stub, (agent) => [
 			...agent.getCallableMethods().keys(),
 		])
 
-		expect(methods.sort()).toEqual([
-			'createOffer',
-			'listOffers',
-			'restoreOffer',
-			'setOfferDisposition',
-		])
+		expect(methods.sort()).toEqual(['listOffers', 'restoreOffer', 'setOfferDisposition'])
 	})
 
 	it('records an Offer as Undecided and lists it', async () => {
 		const writer = await openAgentSocket('offer-create')
 
-		const offer = await writer.call<Offer>('createOffer', quote)
+		const offer = await createOffer('offer-create', quote)
 
 		expect(offer).toMatchObject({
 			kind: 'quote',
@@ -123,17 +128,17 @@ describe('Offers in the Article Agent', () => {
 		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual([offer])
 	})
 
+	// No socket first: the content is parsed before any row is written, so this
+	// one refuses without the Article Agent ever reaching its table.
 	it('refuses an Offer carrying neither a text nor a source', async () => {
-		const writer = await openAgentSocket('offer-empty')
-
-		await expect(writer.call('createOffer', { kind: 'reference' })).rejects.toThrow(
-			/text, a source, or both/,
-		)
+		await expect(
+			createOffer('offer-empty', { kind: 'reference' } as OfferContent),
+		).rejects.toThrow(/text, a source, or both/)
 	})
 
 	it('rules on an Offer, and restores a Declined one', async () => {
 		const writer = await openAgentSocket('offer-rulings')
-		const offer = await writer.call<Offer>('createOffer', reference)
+		const offer = await createOffer('offer-rulings', reference)
 
 		const declined = await writer.call<Offer>('setOfferDisposition', offer.id, 'declined')
 		expect(declined.disposition).toBe('declined')
@@ -145,7 +150,7 @@ describe('Offers in the Article Agent', () => {
 
 	it('restores only a Declined Offer', async () => {
 		const writer = await openAgentSocket('offer-restore-guard')
-		const offer = await writer.call<Offer>('createOffer', reference)
+		const offer = await createOffer('offer-restore-guard', reference)
 		await writer.call('setOfferDisposition', offer.id, 'accepted')
 
 		await expect(writer.call('restoreOffer', offer.id)).rejects.toThrow(
@@ -166,8 +171,8 @@ describe('Offers in the Article Agent', () => {
 
 	it('keeps its Offers through a hibernation cycle', async () => {
 		const writer = await openAgentSocket('offer-hibernation')
-		const kept = await writer.call<Offer>('createOffer', quote)
-		const declined = await writer.call<Offer>('createOffer', reference)
+		const kept = await createOffer('offer-hibernation', quote)
+		const declined = await createOffer('offer-hibernation', reference)
 		await writer.call('setOfferDisposition', declined.id, 'declined')
 
 		// The socket hibernates rather than closing, so the next call wakes the
@@ -188,7 +193,7 @@ describe('Offers in the Article Agent', () => {
 		const writer = await openAgentSocket('offer-and-plan')
 		await writer.next('cf_agent_state')
 		writer.setState(plan)
-		const offer = await writer.call<Offer>('createOffer', quote)
+		const offer = await createOffer('offer-and-plan', quote)
 
 		await writer.call('setOfferDisposition', offer.id, 'accepted')
 

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -1,0 +1,158 @@
+import { env, evictDurableObject } from 'cloudflare:test'
+import { describe, expect, it } from 'vitest'
+
+import type { Offer } from '../../src/shared/offer'
+import { emptyPlan } from '../../src/shared/plan'
+import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
+import { openAgentSocket } from './agent-socket'
+
+/** A Plan that parses: one Outline node, and one Reference placed at it. */
+const plan = makePlan({
+	title: 'The permit queue',
+	totalTarget: 1200,
+	outline: [makeNode({ id: 'n1', title: 'The opening' })],
+	references: [makeReference({ id: 'r1', text: 'Forty separate times.', nodeId: 'n1' })],
+})
+
+/** The same Plan with its Reference placed at a node no Outline carries. The
+ * object shape is valid, so only `planSchema`'s referential check refuses it. */
+const orphaned = {
+	...plan,
+	references: [
+		makeReference({ id: 'r1', text: 'Forty separate times.', nodeId: 'gone' }),
+	],
+}
+
+const quote = {
+	kind: 'quote' as const,
+	text: 'We did not decide to stop building.',
+	source: { title: 'Permit throughput in six mid-sized cities', year: 2023 },
+}
+
+const reference = {
+	kind: 'reference' as const,
+	source: { title: 'Zoning and the missing middle', author: 'A. Weill' },
+	note: 'Primary data for the opening figure.',
+}
+
+describe('the Plan in Article Agent state', () => {
+	it('opens a new Article on the empty Plan', async () => {
+		const writer = await openAgentSocket('opens-empty')
+
+		await expect(writer.next('cf_agent_state')).resolves.toMatchObject({
+			state: emptyPlan(),
+		})
+	})
+
+	it('persists a Plan that parses, and broadcasts it to the other connection', async () => {
+		const writer = await openAgentSocket('valid-write')
+		const reader = await openAgentSocket('valid-write')
+		await writer.next('cf_agent_state')
+		await reader.next('cf_agent_state')
+
+		writer.setState(plan)
+
+		await expect(reader.next('cf_agent_state')).resolves.toMatchObject({ state: plan })
+
+		const returning = await openAgentSocket('valid-write')
+		await expect(returning.next('cf_agent_state')).resolves.toMatchObject({ state: plan })
+	})
+
+	it('refuses a Plan that does not parse, and keeps the one it had', async () => {
+		const writer = await openAgentSocket('invalid-write')
+		const reader = await openAgentSocket('invalid-write')
+		await writer.next('cf_agent_state')
+		await reader.next('cf_agent_state')
+		writer.setState(plan)
+		await reader.next('cf_agent_state')
+
+		writer.setState(orphaned)
+
+		await expect(writer.next('cf_agent_state_error')).resolves.toMatchObject({
+			type: 'cf_agent_state_error',
+		})
+		await expect(reader.quiet('cf_agent_state')).resolves.toEqual([])
+
+		const returning = await openAgentSocket('invalid-write')
+		await expect(returning.next('cf_agent_state')).resolves.toMatchObject({ state: plan })
+	})
+})
+
+describe('Offers in the Article Agent', () => {
+	it('records an Offer as Undecided and lists it', async () => {
+		const writer = await openAgentSocket('offer-create')
+
+		const offer = await writer.call<Offer>('createOffer', quote)
+
+		expect(offer).toMatchObject({
+			kind: 'quote',
+			disposition: 'undecided',
+			decidedAt: null,
+		})
+		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual([offer])
+	})
+
+	it('refuses an Offer carrying neither a text nor a source', async () => {
+		const writer = await openAgentSocket('offer-empty')
+
+		await expect(writer.call('createOffer', { kind: 'reference' })).rejects.toThrow(
+			/text, a source, or both/,
+		)
+	})
+
+	it('rules on an Offer, and restores a Declined one', async () => {
+		const writer = await openAgentSocket('offer-rulings')
+		const offer = await writer.call<Offer>('createOffer', reference)
+
+		const declined = await writer.call<Offer>('setOfferDisposition', offer.id, 'declined')
+		expect(declined.disposition).toBe('declined')
+		expect(declined.decidedAt).not.toBeNull()
+
+		const restored = await writer.call<Offer>('restoreOffer', offer.id)
+		expect(restored).toEqual({ ...offer, disposition: 'undecided', decidedAt: null })
+	})
+
+	it('restores only a Declined Offer', async () => {
+		const writer = await openAgentSocket('offer-restore-guard')
+		const offer = await writer.call<Offer>('createOffer', reference)
+		await writer.call('setOfferDisposition', offer.id, 'accepted')
+
+		await expect(writer.call('restoreOffer', offer.id)).rejects.toThrow(
+			/is accepted, and restoring undoes a Decline/,
+		)
+	})
+
+	it('keeps its Offers through a hibernation cycle', async () => {
+		const writer = await openAgentSocket('offer-hibernation')
+		const kept = await writer.call<Offer>('createOffer', quote)
+		const declined = await writer.call<Offer>('createOffer', reference)
+		await writer.call('setOfferDisposition', declined.id, 'declined')
+
+		// The socket hibernates rather than closing, so the next call wakes the
+		// Article Agent with its in-memory state gone and onStart run again.
+		await evictDurableObject(
+			env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-hibernation')),
+		)
+
+		const offers = await writer.call<Offer[]>('listOffers')
+
+		expect(offers.map((offer) => [offer.id, offer.disposition])).toEqual([
+			[kept.id, 'undecided'],
+			[declined.id, 'declined'],
+		])
+	})
+
+	it('leaves the Plan alone when a disposition changes', async () => {
+		const writer = await openAgentSocket('offer-and-plan')
+		await writer.next('cf_agent_state')
+		writer.setState(plan)
+		const offer = await writer.call<Offer>('createOffer', quote)
+
+		await writer.call('setOfferDisposition', offer.id, 'accepted')
+
+		await expect(writer.quiet('cf_agent_state')).resolves.toEqual([])
+
+		const returning = await openAgentSocket('offer-and-plan')
+		await expect(returning.next('cf_agent_state')).resolves.toMatchObject({ state: plan })
+	})
+})

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -91,10 +91,10 @@ describe('the Plan in Article Agent state', () => {
 })
 
 describe('Offers in the Article Agent', () => {
-	// The build cannot lower a decorator, so `article-agent.ts` registers its
-	// callable methods by calling `callable()` on each one. A method left out of
-	// that list is refused at runtime with no other symptom, so this names the
-	// set the client may call.
+	// `@callable` is the whole allowlist of what a browser may invoke on this
+	// Durable Object, so the set is worth naming. It also proves the decorator
+	// survived the build: oxc does not lower one, and the Babel transform in
+	// `agents/vite` is what does.
 	it('marks every Offer method callable', async () => {
 		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('callable-set'))
 

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -1,8 +1,8 @@
-import { env, evictDurableObject } from 'cloudflare:test'
+import { env, evictDurableObject, runInDurableObject } from 'cloudflare:test'
 import { describe, expect, it } from 'vitest'
 
 import type { Offer } from '../../src/shared/offer'
-import { emptyPlan } from '../../src/shared/plan'
+import { emptyPlan, isPlanRefused } from '../../src/shared/plan'
 import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
 import { openAgentSocket } from './agent-socket'
 
@@ -76,9 +76,40 @@ describe('the Plan in Article Agent state', () => {
 		const returning = await openAgentSocket('invalid-write')
 		await expect(returning.next('cf_agent_state')).resolves.toMatchObject({ state: plan })
 	})
+
+	it('tells the writer which rule the refused Plan broke', async () => {
+		const writer = await openAgentSocket('refusal-reason')
+		await writer.next('cf_agent_state')
+
+		writer.setState(orphaned)
+
+		const frame = await writer.next('plan_refused')
+
+		expect(isPlanRefused(frame)).toBe(true)
+		expect(frame.error).toContain('which no Outline node carries')
+	})
 })
 
 describe('Offers in the Article Agent', () => {
+	// The build cannot lower a decorator, so `article-agent.ts` registers its
+	// callable methods by calling `callable()` on each one. A method left out of
+	// that list is refused at runtime with no other symptom, so this names the
+	// set the client may call.
+	it('marks every Offer method callable', async () => {
+		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('callable-set'))
+
+		const methods = await runInDurableObject(stub, (agent) => [
+			...agent.getCallableMethods().keys(),
+		])
+
+		expect(methods.sort()).toEqual([
+			'createOffer',
+			'listOffers',
+			'restoreOffer',
+			'setOfferDisposition',
+		])
+	})
+
 	it('records an Offer as Undecided and lists it', async () => {
 		const writer = await openAgentSocket('offer-create')
 

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -153,6 +153,17 @@ describe('Offers in the Article Agent', () => {
 		)
 	})
 
+	it('refuses to rule on or restore an Offer that does not exist', async () => {
+		const writer = await openAgentSocket('offer-unknown-id')
+
+		await expect(writer.call('setOfferDisposition', 'nope', 'declined')).rejects.toThrow(
+			/No Offer carries the id nope/,
+		)
+		await expect(writer.call('restoreOffer', 'nope')).rejects.toThrow(
+			/No Offer carries the id nope/,
+		)
+	})
+
 	it('keeps its Offers through a hibernation cycle', async () => {
 		const writer = await openAgentSocket('offer-hibernation')
 		const kept = await writer.call<Offer>('createOffer', quote)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { cloudflare } from '@cloudflare/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { tanstackRouter } from '@tanstack/router-plugin/vite'
 import react from '@vitejs/plugin-react'
+import agents from 'agents/vite'
 import { defineConfig } from 'vite'
 
 // Storybook loads this same config, and it renders components without the app
@@ -25,6 +26,12 @@ export default defineConfig({
 				}),
 		react(),
 		tailwindcss(),
+		// Lowers the `@callable` decorators in the Article Agent through Babel.
+		// Vite 8 transpiles with oxc, which does not implement TC39 decorators
+		// (oxc#9170) and emits the `@` syntax verbatim — so without this the
+		// Worker fails to parse. Required in vitest.config.ts as well, which
+		// builds the Worker for the tests and does not read this file.
+		forStorybook ? [] : agents(),
 		// Runs the Worker in workerd beside the client, so `pnpm dev` serves both.
 		forStorybook
 			? []

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,11 +26,7 @@ export default defineConfig({
 				}),
 		react(),
 		tailwindcss(),
-		// Lowers the `@callable` decorators in the Article Agent through Babel.
-		// Vite 8 transpiles with oxc, which does not implement TC39 decorators
-		// (oxc#9170) and emits the `@` syntax verbatim — so without this the
-		// Worker fails to parse. Required in vitest.config.ts as well, which
-		// builds the Worker for the tests and does not read this file.
+		// Cloudflare's workaround for `@callable` support in Vite 8.
 		forStorybook ? [] : agents(),
 		// Runs the Worker in workerd beside the client, so `pnpm dev` serves both.
 		forStorybook

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import { cloudflareTest } from '@cloudflare/vitest-pool-workers'
+import agents from 'agents/vite'
 import { defineConfig } from 'vitest/config'
 
 // Two projects, split by what the code under test needs. A test in test/shared
@@ -17,6 +18,10 @@ export default defineConfig({
 			},
 			{
 				plugins: [
+					// The same decorator transform vite.config.ts carries. This file does
+					// not read that one, and a worker test builds the Article Agent, so
+					// leaving it out here fails every worker test on a parse error.
+					agents(),
 					// `cloudflareTest` is the current API. Most docs still show
 					// `defineWorkersConfig` with `poolOptions.workers`, which no longer
 					// resolves — the package stopped exporting "./config".

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,9 +18,7 @@ export default defineConfig({
 			},
 			{
 				plugins: [
-					// The same decorator transform vite.config.ts carries. This file does
-					// not read that one, and a worker test builds the Article Agent, so
-					// leaving it out here fails every worker test on a parse error.
+					// Cloudflare's workaround for `@callable` support in Vite 8.
 					agents(),
 					// `cloudflareTest` is the current API. Most docs still show
 					// `defineWorkersConfig` with `poolOptions.workers`, which no longer


### PR DESCRIPTION
Closes #23.

The Article Agent now owns both of its 1a stores. The Plan sits in Article Agent state, parsed whole on every write. Offers sit in an `offer` table, read and ruled on over the WebSocket the client already holds.

The two homes are not interchangeable, and the split is `docs/architecture.md` §3: state is a whole-blob replace, so it holds only the Plan and only the client writes it, while a row write touches named columns and cannot erase a concurrent one.

## Who does what to an Offer

Three different actors, which is the whole reason Offers are rows:

- **The Chat generates them.** Research turns something up and records it (§5). `createOffer` is a plain method, not `@callable` — the writer never authors an Offer (§3, rule 4), so the research tool in #28 is its only caller and it runs inside this Agent.
- **The Article Agent stores them**, as rows in its own SQLite, surviving hibernation.
- **The writer rules on them** from the client, over `@callable` RPC: `listOffers`, `setOfferDisposition`, `restoreOffer`. That set is the entire allowlist of what a browser may invoke on this Durable Object, and a test names it.

## Changes

- **`src/shared/offer.ts`** — the Offer's Kinds, dispositions, and content schema. Shared, so the Ledger in #28 imports the same rules the Agent enforces. An Offer carries a text, a source, or both.
- **`src/server/article-agent.ts`** — `initialState` calls `emptyPlan()` rather than restating an empty Plan. `validateStateChange` parses the whole Plan on every write, whatever its source. `onStart` creates the `offer` table. The three writer-facing methods above, plus `createOffer`.
- **`src/shared/plan/refusal.ts`** — the `plan_refused` frame. See below.
- **`test/worker/`** — 10 integration tests in workerd, plus `agent-socket.ts`, a test client speaking the Agents SDK wire protocol directly.
- **Build config** — `agents/vite` in both `vite.config.ts` and `vitest.config.ts`.

## Three decisions worth a reviewer's eye

**A refused Plan write now says why.** The Agents SDK answers a refused client write with a fixed "State update rejected" and logs the real reason, so the Plan Panel would have had nothing to show. `validateStateChange` sends a `plan_refused` frame to the connection that made the write, carrying every rule the Plan broke. It has its own frame type rather than reusing `cf_agent_state_error`, because the SDK sends that one too and a client would run its handler twice and keep the useless message. `useAgent` hands an unrecognised frame to `onMessage`, which is where this one lands.

**`@callable` needs the `agents/vite` plugin, in both Vite configs.** Vite 8 transpiles with oxc, which does not implement TC39 decorators ([oxc#9170](https://github.com/oxc-project/oxc/issues/9170)) and emits the `@` syntax verbatim, so the Worker fails to parse. Cloudflare's plugin lowers them through Babel. `vitest.config.ts` needs it too — a worker test builds the Article Agent, and the two files do not share plugins. Recorded as a carry in §11, along with the trap: `experimentalDecorators` looks like the fix and is not, because the legacy convention hands `callable()` the prototype instead of the method, so nothing registers and every RPC call is refused at runtime.

**Two definitions of a Reference exist, deliberately unreconciled.** `referenceSchema` and `offerContentSchema` declare the same three fields and the same invariant, and nothing couples them. Factoring them needs a name `context.md` has not coined, and it edits merged code, so this PR left it. It starts to matter when Accepting copies an Offer into the Plan field by field — written up on #28.

## Verification

`pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and `pnpm test` all pass; 62 tests.

Integration tests cover the ticket's four "done when" cases — a valid Plan write persists and broadcasts, an invalid one is refused and the old Plan survives, Offers survive a hibernation cycle, and a disposition change leaves the Plan alone — plus the refusal reason, the rulings, and the unknown-id path. Two claims the code rests on were measured in workerd rather than assumed: `UPDATE … RETURNING *` is supported and returns `[]` on no match, and `ALTER TABLE … ADD COLUMN` throws on a second wake, which is why `onStart` only promises to take new tables.