### PR TITLE
Add the Proposal op vocabulary and the client-side applier

### DIFF
--- a/context.md
+++ b/context.md
@@ -1,8 +1,8 @@
 # Journo Harness
 
-A writing harness where the writer writes the prose and an AI acts as a guide. The
-requirements source is [docs/ux-outline.md](./docs/ux-outline.md); this file fixes the
-words, and nothing else.
+A writing harness where the writer writes the prose and an AI acts as a guide. What is
+true now is [docs/architecture.md](./docs/architecture.md), and what is deferred is
+[docs/later.md](./docs/later.md); this file fixes the words, and nothing else.
 
 ## The app
 

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -157,6 +157,12 @@ lift from #1's typed document-operation API, now applied client-side per #11.
 writer has since fixed a typo in will be refused rather than merged, so the UI must say why
 rather than greying the Proposal out.
 
+**Amended:** #24 built the vocabulary in `src/shared/plan/ops.ts` and the applier in
+`apply.ts`, and settled the question this section left open. The op payloads reuse the piece
+schemas as they stand, `strictObject` and all, so a model that adds one field fails the tool
+call and retries with the validation error rather than having the field stripped. What that
+costs, and what to do if a model thrashes the retry, is in `docs/architecture.md` §6.
+
 ## Consequences
 
 - **The soft size ceiling is around 100 KB; the hard wall is 2 MB.** A SQLite-backed

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -73,6 +73,11 @@ state the Ledger groups by, not an absence, and a blob written whole should not 
 spellings of it. The schema also rejects a `nodeId` naming a node the Outline does not
 carry, so deleting a node unplaces its References in the same Proposal.
 
+**Amended:** the second half of that reason is general and was stated here only because
+`nodeId` is where it first came up. #24 applied it to the rest of the Plan — a node's
+Adjectives took both an absent key and an empty list — and `docs/architecture.md` §4 now
+carries it as a rule of the data model.
+
 ## Provenance names what kind of thing a Reference came from
 
 `{ kind: 'offer', offerId }` for a Reference copied from an Offer, and `{ kind: 'writer' }`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,9 +200,9 @@ proposal: [
 `deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
 `placeReference`. A content op reads `nodeId: null` as the Article Scope, so setting the
 Article's Voice and setting one node's Voice are one op rather than two. Two ops carry a
-consequence worth stating: **`deleteNode` unplaces every Reference that sat in the subtree it
-removes**, because the Plan is written whole and a Reference naming a node that is gone does
-not parse; and **`mergeNodes` keeps the target's own fields**, moving the source's children
+consequence worth stating: **`deleteNode` unplaces every Reference placed at the node it
+removes or at any node below it**, because the Plan is written whole and a Reference naming a
+node that is gone does not parse; and **`mergeNodes` keeps the target's own fields**, moving the source's children
 and placed References onto it, so a Proposal that wants the source's intent note carried over
 says so with a `setIntent` op in the same batch.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -55,7 +55,7 @@ rather than synced. D1 also carries the backup story, because a Durable Object's
 no export path and D1 has `wrangler d1 export`.
 
 **Three source roots**: `src/client`, `src/server`, and `src/shared` for the modules both
-sides import — the Plan schema and, next, the Proposal applier. Nothing in `src/shared`
+sides import — the Plan schema, the Proposal ops, and the applier. Nothing in `src/shared`
 touches a Worker binding or React, and each tsconfig lists the root once rather than
 naming each domain.
 
@@ -181,7 +181,7 @@ A list of ops, applied all-or-nothing.
 
 ```
 proposal: [
-  { op: 'createNode', parentId, beforeId, node: { id, title, intent } },
+  { op: 'createNode', parentId, beforeId, node: { id, title, intent, children: [] } },
   { op: 'setTarget',  nodeId, expected: null, value: 400 },
 ]
 ```
@@ -195,6 +195,32 @@ proposal: [
 - **If any op's `expected` fails, the whole Proposal is Stale.** The UI must say why rather
   than greying it out — whole-field comparison is conservative and will refuse a Proposal
   against a field the writer has since touched.
+
+**Ten ops**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
+`deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
+`placeReference`. A content op reads `nodeId: null` as the Article Scope, so setting the
+Article's Voice and setting one node's Voice are one op rather than two. Two ops carry a
+consequence worth stating: **`deleteNode` unplaces every Reference that sat in the subtree it
+removes**, because the Plan is written whole and a Reference naming a node that is gone does
+not parse; and **`mergeNodes` keeps the target's own fields**, moving the source's children
+and placed References onto it, so a Proposal that wants the source's intent note carried over
+says so with a `setIntent` op in the same batch.
+
+**The applier refuses with a reason**, in `src/shared/plan/apply.ts`. `applyProposal` returns
+either a new Plan or a refusal naming which op failed, its position in the Proposal, and what
+it expected against what it found. Four kinds: `malformed` (outside the vocabulary), `missing`
+(an anchor that is gone), `stale` (an `expected` that no longer matches), and `invalid` (the
+ops resolve, but the result would not be a Plan). It parses the Plan it produces, so a
+Proposal the Article Agent would reject is refused here, where there is a reason to show,
+rather than there, where there is none.
+
+**The op payloads are strict, and a rejected tool call retries with the validation error.**
+The piece schemas the payloads reuse are `strictObject`, so a model that adds one field fails
+the whole tool call rather than having the field stripped. Stripping would produce a Proposal
+the model did not make and the writer would rule on it without seeing what was dropped. The
+cost is real: a model that adds the same field every time thrashes the retry instead of
+converging, and the answer to that is naming the field in the schema, not loosening every
+payload to strip.
 
 **Staleness is not a multi-client problem.** It comes from the gap between generating a
 Proposal and applying it, and inference is slower than typing, so it exists with one writer

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,9 +121,10 @@ plan: {
 - **One spelling per state.** A field that may be absent says "nothing here" by being absent,
   and never also by an empty string or an empty list — the blob is written whole, compared
   whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a second
-  spelling is a second Plan for the same content. Two fields carry their key always and say
-  "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, and
-  the Article's `adjectives`, which is the empty list.
+  spelling is a second Plan for the same content. Three fields carry their key always and say
+  "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, the
+  Article's `adjectives`, and an Outline node's `children`, both of them the empty list. A
+  node's own `adjectives` is the other way round, and says it by being absent.
 
 **The schema guards client writes.** `validateStateChange` parses the whole Plan on every
 write, and nothing the model emits ever goes through it — the Chat proposes and the client

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -118,6 +118,12 @@ plan: {
   under a somber middle is somber unless it says otherwise.
 - **The word-count total is stored and nothing is derived.** The parts may disagree with the
   whole; the gap is information. Auto-distributing the remainder is rejected.
+- **One spelling per state.** A field that may be absent says "nothing here" by being absent,
+  and never also by an empty string or an empty list — the blob is written whole, compared
+  whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a second
+  spelling is a second Plan for the same content. Two fields carry their key always and say
+  "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, and
+  the Article's `adjectives`, which is the empty list.
 
 **The schema guards client writes.** `validateStateChange` parses the whole Plan on every
 write, and nothing the model emits ever goes through it — the Chat proposes and the client

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,9 +208,8 @@ says so with a `setIntent` op in the same batch.
 
 **The applier refuses with a reason**, in `src/shared/plan/apply.ts`. `applyProposal` returns
 either a new Plan or a refusal naming which op failed, its position in the Proposal, and what
-it expected against what it found. Four kinds: `malformed` (outside the vocabulary), `missing`
-(an anchor that is gone), `stale` (an `expected` that no longer matches), and `invalid` (the
-ops resolve, but the result would not be a Plan). It parses the Plan it produces, so a
+it expected against what it found. It sorts refusals into four kinds, listed on `RefusalKind`
+where they cannot drift away from the union. It also parses the Plan it produces, so a
 Proposal the Article Agent would reject is refused here, where there is a reason to show,
 rather than there, where there is none.
 

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -1,8 +1,8 @@
 import { Agent } from 'agents'
 
 /**
- * One Article Agent per Article. It holds the Plan in Agent state, and the
- * Offers, Notes, and Rounds as rows in its own SQLite.
+ * One Article Agent per Article — docs/architecture.md §2, and §3 for what goes
+ * in the state blob against what goes in its SQLite.
  *
  * Empty so far: `validateStateChange`, which runs `planSchema` from
  * `src/shared/plan`, and the Offer rows.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,6 +1,5 @@
-// Nothing here parses a token. Cloudflare Access gates this Worker at the edge,
-// and localhost has no Access gate — so requiring the Cf-Access-Jwt-Assertion
-// header would make the app unrunnable in development.
+// Nothing here parses a token, and nothing may require the
+// Cf-Access-Jwt-Assertion header — docs/architecture.md §9.
 
 import { routeAgentRequest } from 'agents'
 import { Hono } from 'hono'

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -70,18 +70,21 @@ export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
 }
 
 function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
-	const refuse = (
-		kind: RefusalKind,
-		message: string,
-		values?: { expected: unknown; found: unknown },
-	): Refusal => ({ kind, index, op: op.op, message, ...values })
+	const refuse = (kind: RefusalKind, message: string): Refusal => ({
+		kind,
+		index,
+		op: op.op,
+		message,
+	})
 
-	const stale = (where: string, expected: unknown, found: unknown) =>
-		refuse(
+	const stale = (where: string, expected: unknown, found: unknown): Refusal => ({
+		...refuse(
 			'stale',
-			`${op.op} on ${where} expected ${show(expected)} and the Plan carries ${show(found)}.`,
-			{ expected, found },
-		)
+			`${op.op} on ${where} expected ${JSON.stringify(expected)} and the Plan carries ${JSON.stringify(found)}.`,
+		),
+		expected,
+		found,
+	})
 
 	const absent = (what: string) =>
 		refuse('missing', `${op.op} names ${what}, which the Plan does not carry.`)
@@ -92,25 +95,20 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			if (siblings === null) return absent(`parent ${op.parentId}`)
 
 			const at = insertionIndex(siblings, op)
-			if (at === null) {
-				return refuse(
-					'missing',
-					`${op.op} ${anchorPhrase(op)}, which ${under(op.parentId)}.`,
-				)
-			}
+			if (at === null) return refuse('missing', anchorMissing(op))
 
-			const added = subtreeIds(op.node)
-			const taken = plan.outline.flatMap(subtreeIds)
-			const clash = added.find((id) => taken.includes(id))
-			if (clash !== undefined) {
-				return refuse(
-					'invalid',
-					`${op.op} carries the id ${clash}, which an Outline node already carries.`,
-				)
-			}
-			const twice = added.find((id, position) => added.indexOf(id) !== position)
-			if (twice !== undefined) {
-				return refuse('invalid', `${op.op} carries the id ${twice} twice.`)
+			// The final parse catches a repeated id through checkIds, but that
+			// refusal cannot say which op carried it. Claiming the ids here is what
+			// lets this one name the op, so the duplication is the point.
+			const taken = new Set(plan.outline.flatMap(subtreeIds))
+			for (const id of subtreeIds(op.node)) {
+				if (taken.has(id)) {
+					return refuse(
+						'invalid',
+						`${op.op} would leave two Outline nodes carrying the id ${id}.`,
+					)
+				}
+				taken.add(id)
 			}
 
 			siblings.splice(at, 0, op.node)
@@ -135,12 +133,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			if (siblings === null) return absent(`parent ${op.parentId}`)
 
 			const at = insertionIndex(siblings, op)
-			if (at === null) {
-				return refuse(
-					'missing',
-					`${op.op} ${anchorPhrase(op)}, which ${under(op.parentId)}.`,
-				)
-			}
+			if (at === null) return refuse('missing', anchorMissing(op))
 
 			siblings.splice(at, 0, node)
 			return null
@@ -177,10 +170,10 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			const site = locate(plan.outline, op.nodeId)
 			if (site === null) return absent(`node ${op.nodeId}`)
 
-			const gone = subtreeIds(site.siblings[site.index])
+			const gone = new Set(subtreeIds(site.siblings[site.index]))
 			site.siblings.splice(site.index, 1)
 			for (const reference of plan.references) {
-				if (reference.nodeId !== null && gone.includes(reference.nodeId))
+				if (reference.nodeId !== null && gone.has(reference.nodeId))
 					reference.nodeId = null
 			}
 			return null
@@ -211,6 +204,10 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		}
 
 		case 'setTarget': {
+			// setTitle and setVoice reach both Scopes through scopeOf, and this op
+			// and setAdjectives cannot: the Article spells its target `totalTarget`,
+			// and its Adjectives are a required field where a node's are optional.
+			// The op vocabulary unifies the two Scopes further than the Plan does.
 			if (op.nodeId === null) {
 				if (!matches(op.expected, plan.totalTarget)) {
 					return stale(scopeName(null), op.expected, plan.totalTarget)
@@ -354,49 +351,42 @@ function scopeName(nodeId: string | null): string {
 	return nodeId === null ? 'the Article' : `node ${nodeId}`
 }
 
-function anchorPhrase(anchor: Anchor): string {
-	return anchor.afterId !== undefined
-		? `anchors after ${anchor.afterId}`
-		: `anchors before ${anchor.beforeId}`
-}
+/** Why a structural op refused: the anchor it stated, and where it looked. */
+function anchorMissing(op: Anchor & { op: OpName; parentId: string | null }): string {
+	const anchor =
+		op.afterId !== undefined ? `after ${op.afterId}` : `before ${op.beforeId}`
+	const holder = op.parentId === null ? 'the Outline' : `node ${op.parentId}`
 
-function under(parentId: string | null): string {
-	return parentId === null
-		? 'the Outline does not carry'
-		: `node ${parentId} does not carry`
-}
-
-function show(value: unknown): string {
-	return JSON.stringify(value)
+	return `${op.op} anchors ${anchor}, which ${holder} does not carry.`
 }
 
 function malformed(error: z.ZodError): Refusal {
 	const issue = error.issues[0]
+	// A Proposal is a bare array of ops, so the first path segment is the op's
+	// position. Wrapping the array in ops.ts would silently make this null.
 	const index = typeof issue.path[0] === 'number' ? issue.path[0] : null
-	const field = issue.path.slice(1).join('.')
 
 	return {
 		kind: 'malformed',
 		index,
 		op: null,
-		message:
-			field === ''
-				? `An op does not match the vocabulary: ${issue.message}`
-				: `An op does not match the vocabulary at ${field}: ${issue.message}`,
+		message: `An op does not match the vocabulary${at(issue.path.slice(1))}: ${issue.message}`,
 	}
 }
 
 function invalidPlan(error: z.ZodError): Refusal {
 	const issue = error.issues[0]
-	const at = issue.path.join('.')
 
 	return {
 		kind: 'invalid',
 		index: null,
 		op: null,
-		message:
-			at === ''
-				? `The Proposal would leave a Plan the schema refuses: ${issue.message}`
-				: `The Proposal would leave a Plan the schema refuses at ${at}: ${issue.message}`,
+		message: `The Proposal would leave a Plan the schema refuses${at(issue.path)}: ${issue.message}`,
 	}
+}
+
+/** Which field a zod issue names, as a phrase, and nothing when it names the
+ * whole value. */
+function at(path: PropertyKey[]): string {
+	return path.length === 0 ? '' : ` at ${path.join('.')}`
 }

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -1,0 +1,402 @@
+import type { z } from 'zod'
+
+import type { Anchor, OpName, ProposalOp } from './ops'
+import { proposalSchema } from './ops'
+import type { OutlineNode, Plan } from './schema'
+import { planSchema } from './schema'
+
+/**
+ * The client-side applier. A Proposal is a list of ops applied
+ * **all-or-nothing**: the applier works on a copy, and the first op that refuses
+ * throws the copy away, so the Plan the writer sees never holds half a Proposal.
+ *
+ * A refusal names which op failed and why, because the UI has to say why rather
+ * than greying the Proposal out. Whole-field comparison is conservative on
+ * purpose — a Proposal that rewords an intent note the writer has since edited
+ * is refused rather than merged.
+ */
+
+/**
+ * - `malformed` — the ops do not match the vocabulary in ops.ts.
+ * - `missing` — an op names a node, a Reference, or an anchor the Plan does not
+ *   carry.
+ * - `stale` — an `expected` names a value the Plan no longer carries.
+ * - `invalid` — the ops resolve, but applying them would leave something that is
+ *   not a Plan.
+ */
+export type RefusalKind = 'malformed' | 'missing' | 'stale' | 'invalid'
+
+export type Refusal = {
+	kind: RefusalKind
+	/** Which op refused, counting from 0, and null when the refusal is about the
+	 * Proposal as a whole. */
+	index: number | null
+	/** Which op refused, and null when the malformed payload is what hid it. */
+	op: OpName | null
+	/** One sentence, written for the writer to read. */
+	message: string
+	/** The value the op named against the value the Plan carries. Both are
+	 * present on a stale field and absent otherwise. */
+	expected?: unknown
+	found?: unknown
+}
+
+export type ApplyResult = { ok: true; plan: Plan } | { ok: false; refusal: Refusal }
+
+/**
+ * Apply a Proposal to a Plan. The Plan passed in is never touched: a success
+ * carries a new Plan, and a refusal carries the reason.
+ *
+ * The Proposal arrives from a tool call, so this parses it rather than trusting
+ * its type, and it parses the Plan it produces rather than trusting the ops —
+ * `validateStateChange` in the Article Agent would reject a Plan that does not
+ * parse, and a refusal here says why while a rejected write says nothing.
+ */
+export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
+	const parsed = proposalSchema.safeParse(proposal)
+	if (!parsed.success) return { ok: false, refusal: malformed(parsed.error) }
+
+	const next = structuredClone(plan)
+
+	for (const [index, op] of parsed.data.entries()) {
+		const refusal = applyOp(next, op, index)
+		if (refusal !== null) return { ok: false, refusal }
+	}
+
+	const checked = planSchema.safeParse(next)
+	if (!checked.success) return { ok: false, refusal: invalidPlan(checked.error) }
+
+	return { ok: true, plan: checked.data }
+}
+
+function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
+	const refuse = (
+		kind: RefusalKind,
+		message: string,
+		values?: { expected: unknown; found: unknown },
+	): Refusal => ({ kind, index, op: op.op, message, ...values })
+
+	const stale = (where: string, expected: unknown, found: unknown) =>
+		refuse(
+			'stale',
+			`${op.op} on ${where} expected ${show(expected)} and the Plan carries ${show(found)}.`,
+			{ expected, found },
+		)
+
+	const absent = (what: string) =>
+		refuse('missing', `${op.op} names ${what}, which the Plan does not carry.`)
+
+	switch (op.op) {
+		case 'createNode': {
+			const siblings = childrenOf(plan, op.parentId)
+			if (siblings === null) return absent(`parent ${op.parentId}`)
+
+			const at = insertionIndex(siblings, op)
+			if (at === null) {
+				return refuse(
+					'missing',
+					`${op.op} ${anchorPhrase(op)}, which ${under(op.parentId)}.`,
+				)
+			}
+
+			const added = subtreeIds(op.node)
+			const taken = plan.outline.flatMap(subtreeIds)
+			const clash = added.find((id) => taken.includes(id))
+			if (clash !== undefined) {
+				return refuse(
+					'invalid',
+					`${op.op} carries the id ${clash}, which an Outline node already carries.`,
+				)
+			}
+			const twice = added.find((id, position) => added.indexOf(id) !== position)
+			if (twice !== undefined) {
+				return refuse('invalid', `${op.op} carries the id ${twice} twice.`)
+			}
+
+			siblings.splice(at, 0, op.node)
+			return null
+		}
+
+		case 'moveNode': {
+			const site = locate(plan.outline, op.nodeId)
+			if (site === null) return absent(`node ${op.nodeId}`)
+
+			const node = site.siblings[site.index]
+			if (op.parentId !== null && subtreeIds(node).includes(op.parentId)) {
+				return refuse(
+					'invalid',
+					`${op.op} would move ${op.nodeId} inside its own subtree.`,
+				)
+			}
+
+			site.siblings.splice(site.index, 1)
+
+			const siblings = childrenOf(plan, op.parentId)
+			if (siblings === null) return absent(`parent ${op.parentId}`)
+
+			const at = insertionIndex(siblings, op)
+			if (at === null) {
+				return refuse(
+					'missing',
+					`${op.op} ${anchorPhrase(op)}, which ${under(op.parentId)}.`,
+				)
+			}
+
+			siblings.splice(at, 0, node)
+			return null
+		}
+
+		case 'mergeNodes': {
+			if (op.nodeId === op.intoId) {
+				return refuse('invalid', `${op.op} names ${op.nodeId} on both sides.`)
+			}
+
+			const site = locate(plan.outline, op.nodeId)
+			if (site === null) return absent(`node ${op.nodeId}`)
+			const intoSite = locate(plan.outline, op.intoId)
+			if (intoSite === null) return absent(`node ${op.intoId}`)
+
+			const node = site.siblings[site.index]
+			const into = intoSite.siblings[intoSite.index]
+			if (subtreeIds(node).includes(op.intoId)) {
+				return refuse(
+					'invalid',
+					`${op.op} would merge ${op.nodeId} into ${op.intoId}, which it contains.`,
+				)
+			}
+
+			site.siblings.splice(site.index, 1)
+			into.children.push(...node.children)
+			for (const reference of plan.references) {
+				if (reference.nodeId === op.nodeId) reference.nodeId = op.intoId
+			}
+			return null
+		}
+
+		case 'deleteNode': {
+			const site = locate(plan.outline, op.nodeId)
+			if (site === null) return absent(`node ${op.nodeId}`)
+
+			const gone = subtreeIds(site.siblings[site.index])
+			site.siblings.splice(site.index, 1)
+			for (const reference of plan.references) {
+				if (reference.nodeId !== null && gone.includes(reference.nodeId))
+					reference.nodeId = null
+			}
+			return null
+		}
+
+		case 'setTitle': {
+			const scope = scopeOf(plan, op.nodeId)
+			if (scope === null) return absent(`node ${op.nodeId}`)
+
+			if (!matches(op.expected, scope.title))
+				return stale(scopeName(op.nodeId), op.expected, scope.title)
+
+			scope.title = op.value
+			return null
+		}
+
+		case 'setIntent': {
+			const node = findNode(plan, op.nodeId)
+			if (node === null) return absent(`node ${op.nodeId}`)
+
+			const found = node.intent ?? null
+			if (!matches(op.expected, found))
+				return stale(scopeName(op.nodeId), op.expected, found)
+
+			if (op.value === null) delete node.intent
+			else node.intent = op.value
+			return null
+		}
+
+		case 'setTarget': {
+			if (op.nodeId === null) {
+				if (!matches(op.expected, plan.totalTarget)) {
+					return stale(scopeName(null), op.expected, plan.totalTarget)
+				}
+				plan.totalTarget = op.value
+				return null
+			}
+
+			const node = findNode(plan, op.nodeId)
+			if (node === null) return absent(`node ${op.nodeId}`)
+
+			const found = node.target ?? null
+			if (!matches(op.expected, found))
+				return stale(scopeName(op.nodeId), op.expected, found)
+
+			if (op.value === null) delete node.target
+			else node.target = op.value
+			return null
+		}
+
+		case 'setVoice': {
+			const scope = scopeOf(plan, op.nodeId)
+			if (scope === null) return absent(`node ${op.nodeId}`)
+
+			const found = scope.voice ?? null
+			if (!matches(op.expected, found))
+				return stale(scopeName(op.nodeId), op.expected, found)
+
+			if (op.value === null) delete scope.voice
+			else scope.voice = op.value
+			return null
+		}
+
+		case 'setAdjectives': {
+			if (op.nodeId === null) {
+				if (!matches(op.expected, plan.adjectives)) {
+					return stale(scopeName(null), op.expected, plan.adjectives)
+				}
+				plan.adjectives = op.value
+				return null
+			}
+
+			const node = findNode(plan, op.nodeId)
+			if (node === null) return absent(`node ${op.nodeId}`)
+
+			// A node stating no Adjectives and one stating an empty list are the
+			// same node, so both read as the empty list here.
+			const found = node.adjectives ?? []
+			if (!matches(op.expected, found))
+				return stale(scopeName(op.nodeId), op.expected, found)
+
+			if (op.value.length === 0) delete node.adjectives
+			else node.adjectives = op.value
+			return null
+		}
+
+		case 'placeReference': {
+			const reference = plan.references.find((held) => held.id === op.referenceId)
+			if (reference === undefined) return absent(`Reference ${op.referenceId}`)
+
+			if (!matches(op.expected, reference.nodeId)) {
+				return stale(`Reference ${op.referenceId}`, op.expected, reference.nodeId)
+			}
+			if (op.value !== null && findNode(plan, op.value) === null)
+				return absent(`node ${op.value}`)
+
+			reference.nodeId = op.value
+			return null
+		}
+	}
+}
+
+/** Where a node sits: the array holding it, and its position in that array. The
+ * applier splices, so it needs the array rather than the node alone. */
+type Site = { siblings: OutlineNode[]; index: number }
+
+function locate(nodes: OutlineNode[], id: string): Site | null {
+	const index = nodes.findIndex((node) => node.id === id)
+	if (index !== -1) return { siblings: nodes, index }
+
+	for (const node of nodes) {
+		const deeper = locate(node.children, id)
+		if (deeper !== null) return deeper
+	}
+
+	return null
+}
+
+function findNode(plan: Plan, id: string): OutlineNode | null {
+	const site = locate(plan.outline, id)
+	return site === null ? null : site.siblings[site.index]
+}
+
+/** What a content op with `nodeId: null` acts on. The Article and an Outline
+ * node carry the same Scope fields, which is why one op serves both. */
+function scopeOf(plan: Plan, nodeId: string | null): Plan | OutlineNode | null {
+	return nodeId === null ? plan : findNode(plan, nodeId)
+}
+
+function childrenOf(plan: Plan, parentId: string | null): OutlineNode[] | null {
+	if (parentId === null) return plan.outline
+
+	const parent = findNode(plan, parentId)
+	return parent === null ? null : parent.children
+}
+
+/** Where the anchor puts the node among `siblings`, or null when the sibling it
+ * names is gone. A null anchor names no sibling, so it never goes missing. */
+function insertionIndex(siblings: OutlineNode[], anchor: Anchor): number | null {
+	if (anchor.afterId !== undefined) {
+		if (anchor.afterId === null) return 0
+
+		const at = siblings.findIndex((node) => node.id === anchor.afterId)
+		return at === -1 ? null : at + 1
+	}
+
+	if (anchor.beforeId === null) return siblings.length
+
+	const at = siblings.findIndex((node) => node.id === anchor.beforeId)
+	return at === -1 ? null : at
+}
+
+/** Every id in a subtree, the node's own first. */
+function subtreeIds(node: Pick<OutlineNode, 'id' | 'children'>): string[] {
+	return [node.id, ...node.children.flatMap(subtreeIds)]
+}
+
+/** Whole-field comparison. Adjectives are the one list a content op sets, and
+ * two lists match when they carry the same terms in the same order. */
+function matches(expected: unknown, found: unknown): boolean {
+	if (Array.isArray(expected) && Array.isArray(found)) {
+		return (
+			expected.length === found.length && expected.every((term, at) => term === found[at])
+		)
+	}
+
+	return expected === found
+}
+
+function scopeName(nodeId: string | null): string {
+	return nodeId === null ? 'the Article' : `node ${nodeId}`
+}
+
+function anchorPhrase(anchor: Anchor): string {
+	return anchor.afterId !== undefined
+		? `anchors after ${anchor.afterId}`
+		: `anchors before ${anchor.beforeId}`
+}
+
+function under(parentId: string | null): string {
+	return parentId === null
+		? 'the Outline does not carry'
+		: `node ${parentId} does not carry`
+}
+
+function show(value: unknown): string {
+	return JSON.stringify(value)
+}
+
+function malformed(error: z.ZodError): Refusal {
+	const issue = error.issues[0]
+	const index = typeof issue.path[0] === 'number' ? issue.path[0] : null
+	const field = issue.path.slice(1).join('.')
+
+	return {
+		kind: 'malformed',
+		index,
+		op: null,
+		message:
+			field === ''
+				? `An op does not match the vocabulary: ${issue.message}`
+				: `An op does not match the vocabulary at ${field}: ${issue.message}`,
+	}
+}
+
+function invalidPlan(error: z.ZodError): Refusal {
+	const issue = error.issues[0]
+	const at = issue.path.join('.')
+
+	return {
+		kind: 'invalid',
+		index: null,
+		op: null,
+		message:
+			at === ''
+				? `The Proposal would leave a Plan the schema refuses: ${issue.message}`
+				: `The Proposal would leave a Plan the schema refuses at ${at}: ${issue.message}`,
+	}
+}

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -6,14 +6,9 @@ import type { OutlineNode, Plan } from './schema'
 import { planSchema } from './schema'
 
 /**
- * The client-side applier. A Proposal is a list of ops applied
- * **all-or-nothing**: the applier works on a copy, and the first op that refuses
- * throws the copy away, so the Plan the writer sees never holds half a Proposal.
- *
- * A refusal names which op failed and why, because the UI has to say why rather
- * than greying the Proposal out. Whole-field comparison is conservative on
- * purpose — a Proposal that rewords an intent note the writer has since edited
- * is refused rather than merged.
+ * The client-side applier, working on a copy so that the first op to refuse
+ * throws the whole Proposal away. What the ops mean is `docs/architecture.md`
+ * §6, and the vocabulary is ops.ts.
  */
 
 /**
@@ -44,13 +39,12 @@ export type Refusal = {
 export type ApplyResult = { ok: true; plan: Plan } | { ok: false; refusal: Refusal }
 
 /**
- * Apply a Proposal to a Plan. The Plan passed in is never touched: a success
- * carries a new Plan, and a refusal carries the reason.
+ * Apply a Proposal to a Plan, leaving the Plan passed in untouched.
  *
  * The Proposal arrives from a tool call, so this parses it rather than trusting
- * its type, and it parses the Plan it produces rather than trusting the ops —
- * `validateStateChange` in the Article Agent would reject a Plan that does not
- * parse, and a refusal here says why while a rejected write says nothing.
+ * its type, and it parses the Plan it produces rather than trusting the ops:
+ * `validateStateChange` would reject an unparseable Plan with nothing to show
+ * the writer, where a refusal here says which op did it.
  */
 export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
 	const parsed = proposalSchema.safeParse(proposal)
@@ -97,9 +91,8 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			const at = insertionIndex(siblings, op)
 			if (at === null) return refuse('missing', anchorMissing(op))
 
-			// The final parse catches a repeated id through checkIds, but that
-			// refusal cannot say which op carried it. Claiming the ids here is what
-			// lets this one name the op, so the duplication is the point.
+			// checkIds catches a repeated id at the final parse, but that refusal
+			// cannot say which op carried it. Claiming them here is what does.
 			const taken = new Set(plan.outline.flatMap(subtreeIds))
 			for (const id of subtreeIds(op.node)) {
 				if (taken.has(id)) {
@@ -123,7 +116,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			if (op.parentId !== null && subtreeIds(node).includes(op.parentId)) {
 				return refuse(
 					'invalid',
-					`${op.op} would move ${op.nodeId} inside its own subtree.`,
+					`${op.op} would move ${op.nodeId} under a node it contains.`,
 				)
 			}
 
@@ -170,6 +163,8 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			const site = locate(plan.outline, op.nodeId)
 			if (site === null) return absent(`node ${op.nodeId}`)
 
+			// A Reference naming a node that is gone does not parse, and the Plan is
+			// written whole, so the unplacing lands in this op or nowhere.
 			const gone = new Set(subtreeIds(site.siblings[site.index]))
 			site.siblings.splice(site.index, 1)
 			for (const reference of plan.references) {
@@ -204,10 +199,9 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		}
 
 		case 'setTarget': {
-			// setTitle and setVoice reach both Scopes through scopeOf, and this op
-			// and setAdjectives cannot: the Article spells its target `totalTarget`,
-			// and its Adjectives are a required field where a node's are optional.
-			// The op vocabulary unifies the two Scopes further than the Plan does.
+			// This op and setAdjectives cannot reach both Scopes through scopeOf the
+			// way setTitle and setVoice do: the Article spells its target
+			// `totalTarget`, and its Adjectives are required where a node's are not.
 			if (op.nodeId === null) {
 				if (!matches(op.expected, plan.totalTarget)) {
 					return stale(scopeName(null), op.expected, plan.totalTarget)
@@ -253,8 +247,6 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			const node = findNode(plan, op.nodeId)
 			if (node === null) return absent(`node ${op.nodeId}`)
 
-			// A node stating no Adjectives and one stating an empty list are the
-			// same node, so both read as the empty list here.
 			const found = node.adjectives ?? []
 			if (!matches(op.expected, found))
 				return stale(scopeName(op.nodeId), op.expected, found)
@@ -280,8 +272,8 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 	}
 }
 
-/** Where a node sits: the array holding it, and its position in that array. The
- * applier splices, so it needs the array rather than the node alone. */
+/** Splicing needs the array holding a node, which `findNodePath` in scope.ts
+ * does not return. */
 type Site = { siblings: OutlineNode[]; index: number }
 
 function locate(nodes: OutlineNode[], id: string): Site | null {
@@ -301,8 +293,7 @@ function findNode(plan: Plan, id: string): OutlineNode | null {
 	return site === null ? null : site.siblings[site.index]
 }
 
-/** What a content op with `nodeId: null` acts on. The Article and an Outline
- * node carry the same Scope fields, which is why one op serves both. */
+/** What a content op with `nodeId: null` acts on. */
 function scopeOf(plan: Plan, nodeId: string | null): Plan | OutlineNode | null {
 	return nodeId === null ? plan : findNode(plan, nodeId)
 }
@@ -315,7 +306,7 @@ function childrenOf(plan: Plan, parentId: string | null): OutlineNode[] | null {
 }
 
 /** Where the anchor puts the node among `siblings`, or null when the sibling it
- * names is gone. A null anchor names no sibling, so it never goes missing. */
+ * names is gone. A null anchor names none, so it never goes missing. */
 function insertionIndex(siblings: OutlineNode[], anchor: Anchor): number | null {
 	if (anchor.afterId !== undefined) {
 		if (anchor.afterId === null) return 0
@@ -330,13 +321,12 @@ function insertionIndex(siblings: OutlineNode[], anchor: Anchor): number | null 
 	return at === -1 ? null : at
 }
 
-/** Every id in a subtree, the node's own first. */
 function subtreeIds(node: Pick<OutlineNode, 'id' | 'children'>): string[] {
 	return [node.id, ...node.children.flatMap(subtreeIds)]
 }
 
 /** Whole-field comparison. Adjectives are the one list a content op sets, and
- * two lists match when they carry the same terms in the same order. */
+ * order counts there. */
 function matches(expected: unknown, found: unknown): boolean {
 	if (Array.isArray(expected) && Array.isArray(found)) {
 		return (
@@ -351,7 +341,6 @@ function scopeName(nodeId: string | null): string {
 	return nodeId === null ? 'the Article' : `node ${nodeId}`
 }
 
-/** Why a structural op refused: the anchor it stated, and where it looked. */
 function anchorMissing(op: Anchor & { op: OpName; parentId: string | null }): string {
 	const anchor =
 		op.afterId !== undefined ? `after ${op.afterId}` : `before ${op.beforeId}`
@@ -385,8 +374,6 @@ function invalidPlan(error: z.ZodError): Refusal {
 	}
 }
 
-/** Which field a zod issue names, as a phrase, and nothing when it names the
- * whole value. */
 function at(path: PropertyKey[]): string {
 	return path.length === 0 ? '' : ` at ${path.join('.')}`
 }

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -100,6 +100,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 				taken.add(id)
 			}
 
+			dropEmptyAdjectives(op.node)
 			siblings.splice(at, 0, op.node)
 			return null
 		}
@@ -115,7 +116,16 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 					`${op.op} would move ${op.nodeId} under a node it contains.`,
 				)
 			}
+			// Caught here rather than as a missing anchor, which is what it becomes
+			// once the node is out of the Outline, and which would say the Plan does
+			// not carry a node it does.
+			if (op.afterId === op.nodeId || op.beforeId === op.nodeId) {
+				return refuse('invalid', `${op.op} cannot anchor ${op.nodeId} to itself.`)
+			}
 
+			// The node comes out before the destination is known good. That is safe
+			// only because a refusal discards this whole copy: a dry run, or applying
+			// an op in place, would need every check above the splice.
 			site.siblings.splice(site.index, 1)
 
 			const siblings = childrenOf(plan, op.parentId)
@@ -319,6 +329,13 @@ function insertionIndex(siblings: OutlineNode[], anchor: Anchor): number | null 
 
 function subtreeIds(node: Pick<OutlineNode, 'id' | 'children'>): string[] {
 	return [node.id, ...node.children.flatMap(subtreeIds)]
+}
+
+/** The payload of a createNode op may state an empty Adjectives list where the
+ * Plan says absent — §4. */
+function dropEmptyAdjectives(node: OutlineNode) {
+	if (node.adjectives?.length === 0) delete node.adjectives
+	node.children.forEach(dropEmptyAdjectives)
 }
 
 /** Whole-field comparison. Adjectives are the one list a content op sets, and

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -39,12 +39,8 @@ export type Refusal = {
 export type ApplyResult = { ok: true; plan: Plan } | { ok: false; refusal: Refusal }
 
 /**
- * Apply a Proposal to a Plan, leaving the Plan passed in untouched.
- *
- * The Proposal arrives from a tool call, so this parses it rather than trusting
- * its type, and it parses the Plan it produces rather than trusting the ops:
- * `validateStateChange` would reject an unparseable Plan with nothing to show
- * the writer, where a refusal here says which op did it.
+ * Apply a Proposal to a Plan, leaving the Plan passed in untouched. The Proposal
+ * arrives from a tool call, so this parses it rather than trusting its type.
  */
 export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
 	const parsed = proposalSchema.safeParse(proposal)
@@ -163,8 +159,8 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			const site = locate(plan.outline, op.nodeId)
 			if (site === null) return absent(`node ${op.nodeId}`)
 
-			// A Reference naming a node that is gone does not parse, and the Plan is
-			// written whole, so the unplacing lands in this op or nowhere.
+			// The unplacing lands in this op or nowhere: the Plan is written whole,
+			// and a Reference naming a node that is gone does not parse — §4.
 			const gone = new Set(subtreeIds(site.siblings[site.index]))
 			site.siblings.splice(site.index, 1)
 			for (const reference of plan.references) {

--- a/src/shared/plan/index.ts
+++ b/src/shared/plan/index.ts
@@ -1,7 +1,9 @@
-// The Plan: its schema, its Scope resolution, and its word-count arithmetic.
-// No Worker and no React here, so both sides of the socket import the same
-// rules.
+// The Plan: its schema, its Scope resolution, its word-count arithmetic, and
+// the Proposal ops the client applies to it. No Worker and no React here, so
+// both sides of the socket import the same rules.
 
+export * from './apply'
+export * from './ops'
 export * from './schema'
 export * from './scope'
 export * from './word-count'

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -29,17 +29,17 @@ import {
  * **The payloads are strict, and a rejected tool call retries with the
  * validation error.** These schemas and the piece schemas they reuse are
  * `strictObject`, so a model that adds one field fails the whole tool call
- * rather than having the field stripped. That is the choice, paired with the
- * single retry in `docs/architecture.md` §7: stripping produces a Proposal the
- * model did not make, and the writer would rule on it without ever seeing what
- * was dropped. The cost is real — a model that adds the same field every time
- * thrashes the retry instead of converging — and the answer to that is naming
- * the field in the schema here, not loosening every payload to strip.
+ * rather than having the field stripped. If a model adds the same field every
+ * turn it will thrash that retry, and the answer is naming the field here
+ * rather than loosening every payload to strip. Reasoning in
+ * `docs/architecture.md` §6.
  */
 
-// A structural op states exactly one anchor. Both keys are optional and
-// nullable, because `afterId: null` and an absent `afterId` mean different
-// things: first child, against "this op anchors on beforeId instead".
+/** The anchor a structural op states, and what the applier reads. Both keys are
+ * optional and nullable, because `afterId: null` and an absent `afterId` mean
+ * different things: first child, against "this op anchors on beforeId". */
+export type Anchor = { afterId?: string | null; beforeId?: string | null }
+
 const anchorFields = {
 	afterId: idSchema.nullable().optional(),
 	beforeId: idSchema.nullable().optional(),
@@ -49,19 +49,23 @@ const anchorRule = {
 	error: 'A structural op states exactly one of afterId and beforeId.',
 }
 
-function statesOneAnchor(op: { afterId?: string | null; beforeId?: string | null }) {
+function statesOneAnchor(op: Anchor) {
 	return (op.afterId !== undefined) !== (op.beforeId !== undefined)
 }
 
 // Which Scope a content op acts on: an Outline node, or the Article itself.
 const scopeIdSchema = idSchema.nullable()
 
+// Where a structural op puts a node: under an Outline node, or at the root of
+// the Outline. Null means the Outline here, not the Article.
+const parentIdSchema = idSchema.nullable()
+
 /** Insert a new Outline node. The payload is `outlineNodeSchema` whole, so a
  * leaf states `children: []` and a Proposal may create a subtree in one op. */
 export const createNodeOpSchema = z
 	.strictObject({
 		op: z.literal('createNode'),
-		parentId: scopeIdSchema,
+		parentId: parentIdSchema,
 		node: outlineNodeSchema,
 		...anchorFields,
 	})
@@ -72,7 +76,7 @@ export const moveNodeOpSchema = z
 	.strictObject({
 		op: z.literal('moveNode'),
 		nodeId: idSchema,
-		parentId: scopeIdSchema,
+		parentId: parentIdSchema,
 		...anchorFields,
 	})
 	.refine(statesOneAnchor, anchorRule)
@@ -167,6 +171,3 @@ export const proposalSchema = z.array(proposalOpSchema).min(1)
 export type ProposalOp = z.infer<typeof proposalOpSchema>
 export type Proposal = z.infer<typeof proposalSchema>
 export type OpName = ProposalOp['op']
-
-/** The anchor a structural op states, read by the applier. */
-export type Anchor = Pick<z.infer<typeof createNodeOpSchema>, 'afterId' | 'beforeId'>

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import type { OutlineNode } from './schema'
 import {
 	adjectiveSchema,
 	idSchema,
@@ -38,13 +39,32 @@ function statesOneAnchor(op: Anchor) {
 const scopeIdSchema = idSchema.nullable()
 const parentIdSchema = idSchema.nullable()
 
-/** The payload is `outlineNodeSchema` whole, so a node with nothing under it
- * states `children: []`, and one op may create a node with its children. */
+/**
+ * The node a `createNode` op carries: `outlineNodeSchema` loosened at its two
+ * list fields, so a model is never made to state one empty list while being
+ * refused the other. `children` may be left out and `adjectives` may arrive
+ * empty; the applier writes the Plan's spelling of both.
+ *
+ * The leniency lives here rather than on `outlineNodeSchema` because
+ * `validateStateChange` guards a write without rewriting it — a default there
+ * would let a node reach the blob carrying no `children` key at all, which
+ * every reader of a Plan assumes it has.
+ */
+export const createdNodeSchema: z.ZodType<OutlineNode, CreatedNode> =
+	outlineNodeSchema.extend({
+		adjectives: z.array(adjectiveSchema).optional(),
+		get children() {
+			return z.array(createdNodeSchema).default([])
+		},
+	})
+
+type CreatedNode = Omit<OutlineNode, 'children'> & { children?: CreatedNode[] }
+
 export const createNodeOpSchema = z
 	.strictObject({
 		op: z.literal('createNode'),
 		parentId: parentIdSchema,
-		node: outlineNodeSchema,
+		node: createdNodeSchema,
 		...anchorFields,
 	})
 	.refine(statesOneAnchor, anchorRule)
@@ -135,3 +155,7 @@ export const proposalSchema = z.array(proposalOpSchema).min(1)
 export type ProposalOp = z.infer<typeof proposalOpSchema>
 export type Proposal = z.infer<typeof proposalSchema>
 export type OpName = ProposalOp['op']
+
+/** What a caller may write, against `Proposal`, which is what the parse returns.
+ * They differ where `createdNodeSchema` is lenient. */
+export type ProposalInput = z.input<typeof proposalSchema>

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -10,34 +10,18 @@ import {
 } from './schema'
 
 /**
- * The vocabulary a Proposal is written in. Ten ops, named after the typed
- * document-operation API in #1 and applied on the client: the Chat proposes and
- * the client applies, so these payloads are the only thing a model emits that
- * reaches the Plan.
+ * The op vocabulary a Proposal is written in. What the ops mean, and why they
+ * are shaped this way, is `docs/architecture.md` §6; the applier is apply.ts.
  *
- * Two shapes, and the split is deliberate.
- *
- * - A **structural** op anchors on IDs and carries no `expected`. It states
- *   exactly one of `afterId` or `beforeId`, so a Proposal anchors to whichever
- *   neighbour its insertion relates to and survives the other one being deleted.
- *   `afterId: null` means first child and `beforeId: null` means last child;
- *   neither names a sibling, so neither can go stale.
- * - A **content** op carries `expected` and `value`, compared whole-field.
- *   `nodeId: null` is the Article Scope, so setting the Article's Voice and
- *   setting one node's Voice are one op rather than two.
- *
- * **The payloads are strict, and a rejected tool call retries with the
- * validation error.** These schemas and the piece schemas they reuse are
- * `strictObject`, so a model that adds one field fails the whole tool call
- * rather than having the field stripped. If a model adds the same field every
- * turn it will thrash that retry, and the answer is naming the field here
- * rather than loosening every payload to strip. Reasoning in
- * `docs/architecture.md` §6.
+ * The payloads reuse the Plan's piece schemas, which are `strictObject`, so a
+ * model that adds one field fails the whole tool call and retries with the
+ * validation error rather than having the field stripped. If a model adds the
+ * same field every turn it thrashes that retry: name the field here rather than
+ * loosening the payloads to strip.
  */
 
-/** The anchor a structural op states, and what the applier reads. Both keys are
- * optional and nullable, because `afterId: null` and an absent `afterId` mean
- * different things: first child, against "this op anchors on beforeId". */
+/** Nullable and optional say different things: `afterId: null` is first child,
+ * and an absent `afterId` is an op anchored on `beforeId`. */
 export type Anchor = { afterId?: string | null; beforeId?: string | null }
 
 const anchorFields = {
@@ -53,15 +37,14 @@ function statesOneAnchor(op: Anchor) {
 	return (op.afterId !== undefined) !== (op.beforeId !== undefined)
 }
 
-// Which Scope a content op acts on: an Outline node, or the Article itself.
+// The two nullable ids below are the same schema and not the same field: null
+// is the Article for a content op, and the root of the Outline for a
+// structural one.
 const scopeIdSchema = idSchema.nullable()
-
-// Where a structural op puts a node: under an Outline node, or at the root of
-// the Outline. Null means the Outline here, not the Article.
 const parentIdSchema = idSchema.nullable()
 
-/** Insert a new Outline node. The payload is `outlineNodeSchema` whole, so a
- * leaf states `children: []` and a Proposal may create a subtree in one op. */
+/** The payload is `outlineNodeSchema` whole, so a leaf states `children: []`
+ * and one op may create a node with its children. */
 export const createNodeOpSchema = z
 	.strictObject({
 		op: z.literal('createNode'),
@@ -71,7 +54,6 @@ export const createNodeOpSchema = z
 	})
 	.refine(statesOneAnchor, anchorRule)
 
-/** Move a node, with its subtree, under a new parent. */
 export const moveNodeOpSchema = z
 	.strictObject({
 		op: z.literal('moveNode'),
@@ -81,26 +63,18 @@ export const moveNodeOpSchema = z
 	})
 	.refine(statesOneAnchor, anchorRule)
 
-/** Fold one node into another. `intoId` keeps its own fields and gains the
- * children and the placed References of `nodeId`, which disappears. A Proposal
- * that wants the merged intent note carried over says so with a `setIntent` op
- * in the same batch. */
 export const mergeNodesOpSchema = z.strictObject({
 	op: z.literal('mergeNodes'),
 	nodeId: idSchema,
 	intoId: idSchema,
 })
 
-/** Delete a node and its subtree. Every Reference placed at a deleted node is
- * unplaced in the same op, because the Plan is written whole and a Reference
- * naming a node that is gone does not parse. */
 export const deleteNodeOpSchema = z.strictObject({
 	op: z.literal('deleteNode'),
 	nodeId: idSchema,
 })
 
-/** Retitle the Article or one node. A title may be empty, so neither side is
- * nullable. */
+/** A title may be empty, so neither side is nullable. */
 export const setTitleOpSchema = z.strictObject({
 	op: z.literal('setTitle'),
 	nodeId: scopeIdSchema,
@@ -108,8 +82,8 @@ export const setTitleOpSchema = z.strictObject({
 	value: z.string(),
 })
 
-/** Set a node's intent note, or null to clear it. The Article carries no intent
- * note, so this op takes a node. */
+/** The Article carries no intent note, so this op takes a node rather than a
+ * Scope. */
 export const setIntentOpSchema = z.strictObject({
 	op: z.literal('setIntent'),
 	nodeId: idSchema,
@@ -117,7 +91,6 @@ export const setIntentOpSchema = z.strictObject({
 	value: intentSchema.nullable(),
 })
 
-/** Set the Article's total or one node's target, or null to clear it. */
 export const setTargetOpSchema = z.strictObject({
 	op: z.literal('setTarget'),
 	nodeId: scopeIdSchema,
@@ -125,7 +98,6 @@ export const setTargetOpSchema = z.strictObject({
 	value: targetSchema.nullable(),
 })
 
-/** Set the Voice at one Scope, or null to state none there. */
 export const setVoiceOpSchema = z.strictObject({
 	op: z.literal('setVoice'),
 	nodeId: scopeIdSchema,
@@ -133,8 +105,8 @@ export const setVoiceOpSchema = z.strictObject({
 	value: voiceSchema.nullable(),
 })
 
-/** Replace the Adjectives at one Scope. A Scope stating none reads as the empty
- * list on both sides, so there is no null spelling here. */
+/** A Scope stating no Adjectives reads as the empty list on both sides, so
+ * there is no null spelling here. */
 export const setAdjectivesOpSchema = z.strictObject({
 	op: z.literal('setAdjectives'),
 	nodeId: scopeIdSchema,
@@ -142,8 +114,6 @@ export const setAdjectivesOpSchema = z.strictObject({
 	value: z.array(adjectiveSchema),
 })
 
-/** Place a Reference at a node, or null to unplace it. `expected` names the
- * node the Reference sits at now. */
 export const placeReferenceOpSchema = z.strictObject({
 	op: z.literal('placeReference'),
 	referenceId: idSchema,
@@ -164,8 +134,7 @@ export const proposalOpSchema = z.discriminatedUnion('op', [
 	placeReferenceOpSchema,
 ])
 
-/** A Proposal: a list of ops the applier applies all-or-nothing. An empty list
- * changes nothing, so it is not a Proposal. */
+/** The whole Proposal, applied as one ordered batch. An empty list is not one. */
 export const proposalSchema = z.array(proposalOpSchema).min(1)
 
 export type ProposalOp = z.infer<typeof proposalOpSchema>

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -1,0 +1,172 @@
+import { z } from 'zod'
+
+import {
+	adjectiveSchema,
+	idSchema,
+	intentSchema,
+	outlineNodeSchema,
+	targetSchema,
+	voiceSchema,
+} from './schema'
+
+/**
+ * The vocabulary a Proposal is written in. Ten ops, named after the typed
+ * document-operation API in #1 and applied on the client: the Chat proposes and
+ * the client applies, so these payloads are the only thing a model emits that
+ * reaches the Plan.
+ *
+ * Two shapes, and the split is deliberate.
+ *
+ * - A **structural** op anchors on IDs and carries no `expected`. It states
+ *   exactly one of `afterId` or `beforeId`, so a Proposal anchors to whichever
+ *   neighbour its insertion relates to and survives the other one being deleted.
+ *   `afterId: null` means first child and `beforeId: null` means last child;
+ *   neither names a sibling, so neither can go stale.
+ * - A **content** op carries `expected` and `value`, compared whole-field.
+ *   `nodeId: null` is the Article Scope, so setting the Article's Voice and
+ *   setting one node's Voice are one op rather than two.
+ *
+ * **The payloads are strict, and a rejected tool call retries with the
+ * validation error.** These schemas and the piece schemas they reuse are
+ * `strictObject`, so a model that adds one field fails the whole tool call
+ * rather than having the field stripped. That is the choice, paired with the
+ * single retry in `docs/architecture.md` §7: stripping produces a Proposal the
+ * model did not make, and the writer would rule on it without ever seeing what
+ * was dropped. The cost is real — a model that adds the same field every time
+ * thrashes the retry instead of converging — and the answer to that is naming
+ * the field in the schema here, not loosening every payload to strip.
+ */
+
+// A structural op states exactly one anchor. Both keys are optional and
+// nullable, because `afterId: null` and an absent `afterId` mean different
+// things: first child, against "this op anchors on beforeId instead".
+const anchorFields = {
+	afterId: idSchema.nullable().optional(),
+	beforeId: idSchema.nullable().optional(),
+}
+
+const anchorRule = {
+	error: 'A structural op states exactly one of afterId and beforeId.',
+}
+
+function statesOneAnchor(op: { afterId?: string | null; beforeId?: string | null }) {
+	return (op.afterId !== undefined) !== (op.beforeId !== undefined)
+}
+
+// Which Scope a content op acts on: an Outline node, or the Article itself.
+const scopeIdSchema = idSchema.nullable()
+
+/** Insert a new Outline node. The payload is `outlineNodeSchema` whole, so a
+ * leaf states `children: []` and a Proposal may create a subtree in one op. */
+export const createNodeOpSchema = z
+	.strictObject({
+		op: z.literal('createNode'),
+		parentId: scopeIdSchema,
+		node: outlineNodeSchema,
+		...anchorFields,
+	})
+	.refine(statesOneAnchor, anchorRule)
+
+/** Move a node, with its subtree, under a new parent. */
+export const moveNodeOpSchema = z
+	.strictObject({
+		op: z.literal('moveNode'),
+		nodeId: idSchema,
+		parentId: scopeIdSchema,
+		...anchorFields,
+	})
+	.refine(statesOneAnchor, anchorRule)
+
+/** Fold one node into another. `intoId` keeps its own fields and gains the
+ * children and the placed References of `nodeId`, which disappears. A Proposal
+ * that wants the merged intent note carried over says so with a `setIntent` op
+ * in the same batch. */
+export const mergeNodesOpSchema = z.strictObject({
+	op: z.literal('mergeNodes'),
+	nodeId: idSchema,
+	intoId: idSchema,
+})
+
+/** Delete a node and its subtree. Every Reference placed at a deleted node is
+ * unplaced in the same op, because the Plan is written whole and a Reference
+ * naming a node that is gone does not parse. */
+export const deleteNodeOpSchema = z.strictObject({
+	op: z.literal('deleteNode'),
+	nodeId: idSchema,
+})
+
+/** Retitle the Article or one node. A title may be empty, so neither side is
+ * nullable. */
+export const setTitleOpSchema = z.strictObject({
+	op: z.literal('setTitle'),
+	nodeId: scopeIdSchema,
+	expected: z.string(),
+	value: z.string(),
+})
+
+/** Set a node's intent note, or null to clear it. The Article carries no intent
+ * note, so this op takes a node. */
+export const setIntentOpSchema = z.strictObject({
+	op: z.literal('setIntent'),
+	nodeId: idSchema,
+	expected: intentSchema.nullable(),
+	value: intentSchema.nullable(),
+})
+
+/** Set the Article's total or one node's target, or null to clear it. */
+export const setTargetOpSchema = z.strictObject({
+	op: z.literal('setTarget'),
+	nodeId: scopeIdSchema,
+	expected: targetSchema.nullable(),
+	value: targetSchema.nullable(),
+})
+
+/** Set the Voice at one Scope, or null to state none there. */
+export const setVoiceOpSchema = z.strictObject({
+	op: z.literal('setVoice'),
+	nodeId: scopeIdSchema,
+	expected: voiceSchema.nullable(),
+	value: voiceSchema.nullable(),
+})
+
+/** Replace the Adjectives at one Scope. A Scope stating none reads as the empty
+ * list on both sides, so there is no null spelling here. */
+export const setAdjectivesOpSchema = z.strictObject({
+	op: z.literal('setAdjectives'),
+	nodeId: scopeIdSchema,
+	expected: z.array(adjectiveSchema),
+	value: z.array(adjectiveSchema),
+})
+
+/** Place a Reference at a node, or null to unplace it. `expected` names the
+ * node the Reference sits at now. */
+export const placeReferenceOpSchema = z.strictObject({
+	op: z.literal('placeReference'),
+	referenceId: idSchema,
+	expected: idSchema.nullable(),
+	value: idSchema.nullable(),
+})
+
+export const proposalOpSchema = z.discriminatedUnion('op', [
+	createNodeOpSchema,
+	moveNodeOpSchema,
+	mergeNodesOpSchema,
+	deleteNodeOpSchema,
+	setTitleOpSchema,
+	setIntentOpSchema,
+	setTargetOpSchema,
+	setVoiceOpSchema,
+	setAdjectivesOpSchema,
+	placeReferenceOpSchema,
+])
+
+/** A Proposal: a list of ops the applier applies all-or-nothing. An empty list
+ * changes nothing, so it is not a Proposal. */
+export const proposalSchema = z.array(proposalOpSchema).min(1)
+
+export type ProposalOp = z.infer<typeof proposalOpSchema>
+export type Proposal = z.infer<typeof proposalSchema>
+export type OpName = ProposalOp['op']
+
+/** The anchor a structural op states, read by the applier. */
+export type Anchor = Pick<z.infer<typeof createNodeOpSchema>, 'afterId' | 'beforeId'>

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -10,14 +10,9 @@ import {
 } from './schema'
 
 /**
- * The op vocabulary a Proposal is written in. What the ops mean, and why they
- * are shaped this way, is `docs/architecture.md` §6; the applier is apply.ts.
- *
- * The payloads reuse the Plan's piece schemas, which are `strictObject`, so a
- * model that adds one field fails the whole tool call and retries with the
- * validation error rather than having the field stripped. If a model adds the
- * same field every turn it thrashes that retry: name the field here rather than
- * loosening the payloads to strip.
+ * The op vocabulary a Proposal is written in. What the ops mean, how strict the
+ * payloads are, and what to do when a model fights that strictness are all
+ * `docs/architecture.md` §6. The applier is apply.ts.
  */
 
 /** Nullable and optional say different things: `afterId: null` is first child,
@@ -43,8 +38,8 @@ function statesOneAnchor(op: Anchor) {
 const scopeIdSchema = idSchema.nullable()
 const parentIdSchema = idSchema.nullable()
 
-/** The payload is `outlineNodeSchema` whole, so a leaf states `children: []`
- * and one op may create a node with its children. */
+/** The payload is `outlineNodeSchema` whole, so a node with nothing under it
+ * states `children: []`, and one op may create a node with its children. */
 export const createNodeOpSchema = z
 	.strictObject({
 		op: z.literal('createNode'),

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -1,29 +1,23 @@
 import { z } from 'zod'
 
 /**
- * The Plan: one JSON blob in Article Agent state, parsed whole by
- * `validateStateChange` on every write. Nothing the model emits goes through
- * `planSchema` — the Chat proposes and the client applies. The piece schemas
- * below are the ones a Proposal's op payloads reuse.
- *
- * Rationale in docs/adr/0002-the-plan-data-model.md.
+ * The Plan's schema, parsed whole on every write. The data model it enforces is
+ * `docs/architecture.md` §4, who may write it is §3, and the reasoning behind
+ * both is docs/adr/0002-the-plan-data-model.md.
  */
 
-// `.min(1)` throughout: absence is how a Scope says "nothing here", and neither
-// the empty string nor the empty list is a second way to say it. Which of these
-// fields may be absent is decided below, and again in a Proposal's op payloads.
+// `.min(1)` throughout, so that a field carries one spelling of "nothing here"
+// rather than two — §4.
 export const idSchema = z.string().min(1)
 export const voiceSchema = z.string().min(1)
 export const adjectiveSchema = z.string().min(1)
 export const intentSchema = z.string().min(1)
 export const targetSchema = z.number().int().positive()
 
-// strictObject throughout: only the client writes the Plan, so an unknown key
-// is a bug rather than a forward-compatible extension.
+// strictObject throughout: the Plan has one writer, so an unknown key is a bug
+// rather than a forward-compatible extension — §3, rule 1.
 
-/** The attribution inside a Reference. Every field is optional on its own,
- * because a book has no url and a leaked memo has no author, and at least one
- * of them is present. */
+/** The attribution inside a Reference. */
 export const sourceSchema = z
 	.strictObject({
 		title: z.string().min(1).optional(),
@@ -36,8 +30,7 @@ export const sourceSchema = z
 		error: 'A source carries at least one of title, author, publication, year, or url.',
 	})
 
-/** Where a record came from. An Accepted Offer is copied into the Plan as a new
- * editable record that keeps a pointer to the Offer row it came from. */
+/** Where a record came from. */
 export const provenanceSchema = z
 	.strictObject({
 		kind: z.enum(['writer', 'offer']),
@@ -50,10 +43,7 @@ export const provenanceSchema = z
 		},
 	)
 
-/** Something the writer is drawing on. A Quote is a Reference that carries a
- * `text` — one structure, not two, and the Plan Panel's separate counts are a
- * display filter. `nodeId` is null until the Reference is placed at an Outline
- * node. */
+/** Something the writer is drawing on. */
 export const referenceSchema = z
 	.strictObject({
 		id: idSchema,
@@ -67,11 +57,7 @@ export const referenceSchema = z
 		error: 'A Reference carries a text, a source, or both. One with neither is nothing.',
 	})
 
-/** The unit of structure in the Plan. Children are contained rather than
- * referenced, so orphans and cycles are impossible rather than merely invalid,
- * and sibling order is array position.
- *
- * `title` may be empty: the writer creates a node and then types into it. */
+/** The unit of structure in the Plan. */
 export const outlineNodeSchema = z.strictObject({
 	id: idSchema,
 	title: z.string(),
@@ -89,12 +75,8 @@ export const outlineNodeSchema = z.strictObject({
 // inferring the type from the refined schema would be circular.
 const planObjectSchema = z.strictObject({
 	title: z.string(),
-	// Null until the writer states a total, and never derived from the node
-	// targets, which are free to disagree with it.
 	totalTarget: targetSchema.nullable(),
 	voice: voiceSchema.optional(),
-	// The Article always carries the key, so the empty list is how it says
-	// "nothing here". A node says the same by carrying no key at all.
 	adjectives: z.array(adjectiveSchema),
 	outline: z.array(outlineNodeSchema),
 	references: z.array(referenceSchema),
@@ -108,8 +90,7 @@ export type Plan = z.infer<typeof planObjectSchema>
 
 export const planSchema = planObjectSchema.superRefine(checkIds)
 
-/** What a new Article opens into. `validateStateChange` accepts it, so the
- * Article Agent can use it as `initialState`. */
+/** What a new Article opens into, shaped so `validateStateChange` accepts it. */
 export function emptyPlan(title = ''): Plan {
 	return {
 		title,
@@ -122,10 +103,7 @@ export function emptyPlan(title = ''): Plan {
 
 type Path = (string | number)[]
 
-/**
- * Uniqueness and referential integrity, which the object shape cannot state. A
- * Proposal that deletes a node must also unplace its References.
- */
+/** Uniqueness and referential integrity, which the object shape cannot state. */
 function checkIds(plan: Plan, ctx: z.RefinementCtx) {
 	const claim = (seen: Set<string>, id: string, path: Path, noun: string) => {
 		if (seen.has(id)) {

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -7,7 +7,8 @@ import { z } from 'zod'
  */
 
 // `.min(1)` throughout, so that a field carries one spelling of "nothing here"
-// rather than two — §4.
+// rather than two — §4. A title is the exception below and carries no floor: it
+// is empty from the moment a node is made until the writer types into it.
 export const idSchema = z.string().min(1)
 export const voiceSchema = z.string().min(1)
 export const adjectiveSchema = z.string().min(1)

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -9,9 +9,9 @@ import { z } from 'zod'
  * Rationale in docs/adr/0002-the-plan-data-model.md.
  */
 
-// `.min(1)` throughout: absence is how a Scope says "nothing here", and the
-// empty string is not a second way to say it. Which of these fields may be
-// absent is decided below, and again in a Proposal's op payloads.
+// `.min(1)` throughout: absence is how a Scope says "nothing here", and neither
+// the empty string nor the empty list is a second way to say it. Which of these
+// fields may be absent is decided below, and again in a Proposal's op payloads.
 export const idSchema = z.string().min(1)
 export const voiceSchema = z.string().min(1)
 export const adjectiveSchema = z.string().min(1)
@@ -78,7 +78,7 @@ export const outlineNodeSchema = z.strictObject({
 	intent: intentSchema.optional(),
 	target: targetSchema.optional(),
 	voice: voiceSchema.optional(),
-	adjectives: z.array(adjectiveSchema).optional(),
+	adjectives: z.array(adjectiveSchema).min(1).optional(),
 	// zod 4 recursive schema
 	get children() {
 		return z.array(outlineNodeSchema)
@@ -93,6 +93,8 @@ const planObjectSchema = z.strictObject({
 	// targets, which are free to disagree with it.
 	totalTarget: targetSchema.nullable(),
 	voice: voiceSchema.optional(),
+	// The Article always carries the key, so the empty list is how it says
+	// "nothing here". A node says the same by carrying no key at all.
 	adjectives: z.array(adjectiveSchema),
 	outline: z.array(outlineNodeSchema),
 	references: z.array(referenceSchema),

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -9,12 +9,16 @@ import { z } from 'zod'
  * Rationale in docs/adr/0002-the-plan-data-model.md.
  */
 
-const id = z.string().min(1)
+// The field rules, stated once. A Proposal's op payloads set the same fields
+// through ops.ts, so restating `.min(1)` there is drift waiting to happen.
+export const idSchema = z.string().min(1)
 
 // An absent Voice is how a Scope says "nothing here". The empty string is not a
-// second way to say it.
-const voice = z.string().min(1)
-const adjective = z.string().min(1)
+// second way to say it. An absent intent note says the same.
+export const voiceSchema = z.string().min(1)
+export const adjectiveSchema = z.string().min(1)
+export const intentSchema = z.string().min(1)
+export const targetSchema = z.number().int().positive()
 
 // strictObject throughout: only the client writes the Plan, so an unknown key
 // is a bug rather than a forward-compatible extension.
@@ -39,7 +43,7 @@ export const sourceSchema = z
 export const provenanceSchema = z
 	.strictObject({
 		kind: z.enum(['writer', 'offer']),
-		offerId: id.optional(),
+		offerId: idSchema.optional(),
 	})
 	.refine(
 		(provenance) => (provenance.kind === 'offer') === (provenance.offerId !== undefined),
@@ -54,11 +58,11 @@ export const provenanceSchema = z
  * node. */
 export const referenceSchema = z
 	.strictObject({
-		id,
+		id: idSchema,
 		provenance: provenanceSchema,
 		text: z.string().min(1).optional(),
 		source: sourceSchema.optional(),
-		nodeId: id.nullable(),
+		nodeId: idSchema.nullable(),
 		note: z.string().min(1).optional(),
 	})
 	.refine((reference) => reference.text !== undefined || reference.source !== undefined, {
@@ -71,12 +75,12 @@ export const referenceSchema = z
  *
  * `title` may be empty: the writer creates a node and then types into it. */
 export const outlineNodeSchema = z.strictObject({
-	id,
+	id: idSchema,
 	title: z.string(),
-	intent: z.string().min(1).optional(),
-	target: z.number().int().positive().optional(),
-	voice: voice.optional(),
-	adjectives: z.array(adjective).optional(),
+	intent: intentSchema.optional(),
+	target: targetSchema.optional(),
+	voice: voiceSchema.optional(),
+	adjectives: z.array(adjectiveSchema).optional(),
 	// zod 4 recursive schema
 	get children() {
 		return z.array(outlineNodeSchema)
@@ -89,9 +93,9 @@ const planObjectSchema = z.strictObject({
 	title: z.string(),
 	// Null until the writer states a total. The total is stored and nothing
 	// derives it — see word-count.ts for why the parts may disagree with it.
-	totalTarget: z.number().int().positive().nullable(),
-	voice: voice.optional(),
-	adjectives: z.array(adjective),
+	totalTarget: targetSchema.nullable(),
+	voice: voiceSchema.optional(),
+	adjectives: z.array(adjectiveSchema),
 	outline: z.array(outlineNodeSchema),
 	references: z.array(referenceSchema),
 })

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -9,12 +9,10 @@ import { z } from 'zod'
  * Rationale in docs/adr/0002-the-plan-data-model.md.
  */
 
-// The field rules, stated once. A Proposal's op payloads set the same fields
-// through ops.ts, so restating `.min(1)` there is drift waiting to happen.
+// `.min(1)` throughout: absence is how a Scope says "nothing here", and the
+// empty string is not a second way to say it. Which of these fields may be
+// absent is decided below, and again in a Proposal's op payloads.
 export const idSchema = z.string().min(1)
-
-// An absent Voice is how a Scope says "nothing here". The empty string is not a
-// second way to say it. An absent intent note says the same.
 export const voiceSchema = z.string().min(1)
 export const adjectiveSchema = z.string().min(1)
 export const intentSchema = z.string().min(1)
@@ -91,8 +89,8 @@ export const outlineNodeSchema = z.strictObject({
 // inferring the type from the refined schema would be circular.
 const planObjectSchema = z.strictObject({
 	title: z.string(),
-	// Null until the writer states a total. The total is stored and nothing
-	// derives it — see word-count.ts for why the parts may disagree with it.
+	// Null until the writer states a total, and never derived from the node
+	// targets, which are free to disagree with it.
 	totalTarget: targetSchema.nullable(),
 	voice: voiceSchema.optional(),
 	adjectives: z.array(adjectiveSchema),

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Plan, Proposal } from '../../src/shared/plan'
+import { applyProposal } from '../../src/shared/plan'
+import { makeNode, makePlan, makeReference } from './plan-fixtures'
+
+const plan = makePlan({
+	title: 'The raid',
+	totalTarget: 2000,
+	voice: 'reported feature',
+	adjectives: ['funny'],
+	outline: [
+		makeNode({ id: 'n1', title: 'Opening', intent: 'Open on the raid', target: 400 }),
+		makeNode({
+			id: 'n2',
+			title: 'Middle',
+			voice: 'academic',
+			adjectives: ['somber'],
+			children: [makeNode({ id: 'n2a' }), makeNode({ id: 'n2b' })],
+		}),
+		makeNode({ id: 'n3', title: 'Close' }),
+	],
+	references: [
+		makeReference({ id: 'r1', text: 'A pulled passage', nodeId: 'n2a' }),
+		makeReference({ id: 'r2', text: 'An unplaced passage', nodeId: null }),
+		makeReference({ id: 'r3', text: 'A passage about the middle', nodeId: 'n2' }),
+	],
+})
+
+/** The Plan a Proposal produced, or a failed assertion naming the refusal. */
+function applied(proposal: Proposal, to: Plan = plan): Plan {
+	const result = applyProposal(to, proposal)
+	if (!result.ok) throw new Error(`Refused: ${result.refusal.message}`)
+
+	return result.plan
+}
+
+/** The refusal a Proposal produced, or a failed assertion. */
+function refused(proposal: Proposal, to: Plan = plan) {
+	const result = applyProposal(to, proposal)
+	if (result.ok) throw new Error('The Proposal applied, and the test expected a refusal.')
+
+	return result.refusal
+}
+
+const titles = (nodes: { title: string }[]) => nodes.map((node) => node.title)
+const ids = (nodes: { id: string }[]) => nodes.map((node) => node.id)
+
+describe('applying a Proposal', () => {
+	it('applies every op in one Proposal', () => {
+		const next = applied([
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: 'n3',
+				node: { id: 'n4', title: 'A turn', intent: 'Turn on the memo', children: [] },
+			},
+			{ op: 'setTarget', nodeId: 'n4', expected: null, value: 400 },
+			{
+				op: 'setTitle',
+				nodeId: null,
+				expected: 'The raid',
+				value: 'The raid, revisited',
+			},
+		])
+
+		expect(ids(next.outline)).toEqual(['n1', 'n2', 'n4', 'n3'])
+		expect(next.outline[2].target).toBe(400)
+		expect(next.title).toBe('The raid, revisited')
+	})
+
+	it('refuses the whole Proposal when one expected fails, and applies nothing', () => {
+		const refusal = refused([
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: null,
+				node: { id: 'n4', title: 'A turn', children: [] },
+			},
+			{
+				op: 'setIntent',
+				nodeId: 'n1',
+				expected: 'Open on the dawn raid',
+				value: 'Open colder',
+			},
+		])
+
+		expect(refusal.kind).toBe('stale')
+		expect(refusal.index).toBe(1)
+		expect(refusal.op).toBe('setIntent')
+		expect(refusal.expected).toBe('Open on the dawn raid')
+		expect(refusal.found).toBe('Open on the raid')
+		expect(refusal.message).toContain('node n1')
+	})
+
+	it('never touches the Plan it is given', () => {
+		const before = structuredClone(plan)
+		applied([{ op: 'deleteNode', nodeId: 'n2' }])
+		refused([{ op: 'deleteNode', nodeId: 'gone' }])
+
+		expect(plan).toEqual(before)
+	})
+
+	it('applies an insert whose anchor survived an unrelated sibling being deleted', () => {
+		const withoutN2 = applied([{ op: 'deleteNode', nodeId: 'n2' }])
+		const insert: Proposal = [
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: 'n3',
+				node: { id: 'n4', title: 'A turn', children: [] },
+			},
+		]
+
+		expect(ids(applied(insert, withoutN2).outline)).toEqual(['n1', 'n4', 'n3'])
+	})
+
+	it('refuses an insert whose own anchor is gone, and names it', () => {
+		const withoutN2 = applied([{ op: 'deleteNode', nodeId: 'n2' }])
+		const refusal = refused(
+			[
+				{
+					op: 'createNode',
+					parentId: null,
+					afterId: 'n2',
+					node: { id: 'n4', title: 'A turn', children: [] },
+				},
+			],
+			withoutN2,
+		)
+
+		expect(refusal.kind).toBe('missing')
+		expect(refusal.op).toBe('createNode')
+		expect(refusal.message).toContain('after n2')
+	})
+
+	it('refuses a Proposal that does not match the vocabulary', () => {
+		const refusal = refused([{ op: 'setTone', nodeId: 'n1' }] as unknown as Proposal)
+
+		expect(refusal.kind).toBe('malformed')
+		expect(refusal.index).toBe(0)
+	})
+
+	it('refuses rather than hand the Article Agent a Plan it would reject', () => {
+		const broken = makePlan({
+			references: [makeReference({ id: 'r1', text: 'A passage', nodeId: 'gone' })],
+		})
+		const refusal = refused(
+			[{ op: 'setTitle', nodeId: null, expected: 'The article', value: 'A title' }],
+			broken,
+		)
+
+		expect(refusal.kind).toBe('invalid')
+		expect(refusal.message).toContain('references.0.nodeId')
+	})
+})
+
+describe('the structural ops', () => {
+	it('inserts first when afterId is null, and last when beforeId is null', () => {
+		const first = applied([
+			{
+				op: 'createNode',
+				parentId: 'n2',
+				afterId: null,
+				node: { id: 'n2z', title: 'First', children: [] },
+			},
+			{
+				op: 'createNode',
+				parentId: 'n2',
+				beforeId: null,
+				node: { id: 'n2y', title: 'Last', children: [] },
+			},
+		])
+
+		expect(ids(first.outline[1].children)).toEqual(['n2z', 'n2a', 'n2b', 'n2y'])
+	})
+
+	it('creates a subtree in one op', () => {
+		const next = applied([
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: null,
+				node: {
+					id: 'n4',
+					title: 'A turn',
+					children: [makeNode({ id: 'n4a', title: 'Its first part' })],
+				},
+			},
+		])
+
+		expect(ids(next.outline[3].children)).toEqual(['n4a'])
+	})
+
+	it('refuses a created node carrying an id the Outline already carries', () => {
+		const refusal = refused([
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: null,
+				node: { id: 'n2a', title: 'A second n2a', children: [] },
+			},
+		])
+
+		expect(refusal.kind).toBe('invalid')
+		expect(refusal.message).toContain('n2a')
+	})
+
+	it('refuses an anchor that names a node under a different parent', () => {
+		const refusal = refused([
+			{
+				op: 'createNode',
+				parentId: 'n2',
+				afterId: 'n3',
+				node: { id: 'n4', title: 'A turn', children: [] },
+			},
+		])
+
+		expect(refusal.kind).toBe('missing')
+		expect(refusal.message).toContain('node n2 does not carry')
+	})
+
+	it('moves a node with its subtree, and reorders among siblings', () => {
+		const next = applied([
+			{ op: 'moveNode', nodeId: 'n2', parentId: null, afterId: 'n3' },
+		])
+
+		expect(ids(next.outline)).toEqual(['n1', 'n3', 'n2'])
+		expect(ids(next.outline[2].children)).toEqual(['n2a', 'n2b'])
+	})
+
+	it('moves a node under a new parent', () => {
+		const next = applied([
+			{ op: 'moveNode', nodeId: 'n3', parentId: 'n2', beforeId: 'n2b' },
+		])
+
+		expect(ids(next.outline)).toEqual(['n1', 'n2'])
+		expect(ids(next.outline[1].children)).toEqual(['n2a', 'n3', 'n2b'])
+	})
+
+	it('refuses to move a node inside its own subtree', () => {
+		const refusal = refused([
+			{ op: 'moveNode', nodeId: 'n2', parentId: 'n2a', beforeId: null },
+		])
+
+		expect(refusal.kind).toBe('invalid')
+		expect(refusal.message).toContain('its own subtree')
+	})
+
+	it('deletes a node with its subtree, and unplaces the References that sat there', () => {
+		const next = applied([{ op: 'deleteNode', nodeId: 'n2' }])
+
+		expect(ids(next.outline)).toEqual(['n1', 'n3'])
+		expect(next.references.map((reference) => reference.nodeId)).toEqual([
+			null,
+			null,
+			null,
+		])
+	})
+
+	it('merges a node into another, moving its children and its References', () => {
+		const next = applied([{ op: 'mergeNodes', nodeId: 'n2', intoId: 'n3' }])
+
+		expect(ids(next.outline)).toEqual(['n1', 'n3'])
+		expect(titles(next.outline)).toEqual(['Opening', 'Close'])
+		expect(ids(next.outline[1].children)).toEqual(['n2a', 'n2b'])
+		expect(next.references.map((reference) => reference.nodeId)).toEqual([
+			'n2a',
+			null,
+			'n3',
+		])
+	})
+
+	it('refuses to merge a node into one it contains', () => {
+		const refusal = refused([{ op: 'mergeNodes', nodeId: 'n2', intoId: 'n2b' }])
+
+		expect(refusal.kind).toBe('invalid')
+		expect(refusal.message).toContain('which it contains')
+	})
+})
+
+describe('the content ops', () => {
+	it('sets the Article total and one node target from the same op', () => {
+		const next = applied([
+			{ op: 'setTarget', nodeId: null, expected: 2000, value: 2400 },
+			{ op: 'setTarget', nodeId: 'n1', expected: 400, value: 600 },
+		])
+
+		expect(next.totalTarget).toBe(2400)
+		expect(next.outline[0].target).toBe(600)
+	})
+
+	it('clears a field the Plan states, and states one it does not', () => {
+		const next = applied([
+			{ op: 'setVoice', nodeId: 'n2', expected: 'academic', value: null },
+			{ op: 'setVoice', nodeId: 'n1', expected: null, value: 'plain' },
+			{ op: 'setIntent', nodeId: 'n1', expected: 'Open on the raid', value: null },
+		])
+
+		expect(next.outline[1].voice).toBeUndefined()
+		expect(next.outline[0].voice).toBe('plain')
+		expect(next.outline[0].intent).toBeUndefined()
+	})
+
+	it('reads a node that states no Adjectives as the empty list', () => {
+		const next = applied([
+			{ op: 'setAdjectives', nodeId: 'n1', expected: [], value: ['high energy'] },
+			{ op: 'setAdjectives', nodeId: 'n2', expected: ['somber'], value: [] },
+			{
+				op: 'setAdjectives',
+				nodeId: null,
+				expected: ['funny'],
+				value: ['funny', 'warm'],
+			},
+		])
+
+		expect(next.outline[0].adjectives).toEqual(['high energy'])
+		expect(next.outline[1].adjectives).toBeUndefined()
+		expect(next.adjectives).toEqual(['funny', 'warm'])
+	})
+
+	it('compares a list whole, so one term out of order is stale', () => {
+		const refusal = refused([
+			{ op: 'setAdjectives', nodeId: null, expected: ['warm', 'funny'], value: [] },
+		])
+
+		expect(refusal.kind).toBe('stale')
+		expect(refusal.found).toEqual(['funny'])
+	})
+
+	it('places a Reference, and unplaces one', () => {
+		const next = applied([
+			{ op: 'placeReference', referenceId: 'r2', expected: null, value: 'n1' },
+			{ op: 'placeReference', referenceId: 'r1', expected: 'n2a', value: null },
+		])
+
+		expect(next.references.map((reference) => reference.nodeId)).toEqual([
+			null,
+			'n1',
+			'n2',
+		])
+	})
+
+	it('refuses to place a Reference at a node the Plan does not carry', () => {
+		const refusal = refused([
+			{ op: 'placeReference', referenceId: 'r2', expected: null, value: 'gone' },
+		])
+
+		expect(refusal.kind).toBe('missing')
+		expect(refusal.message).toContain('node gone')
+	})
+
+	it('refuses a Reference whose placement has moved since the Proposal', () => {
+		const refusal = refused([
+			{ op: 'placeReference', referenceId: 'r1', expected: null, value: 'n1' },
+		])
+
+		expect(refusal.kind).toBe('stale')
+		expect(refusal.found).toBe('n2a')
+	})
+
+	it('refuses a content op naming a node the Plan does not carry', () => {
+		const refusal = refused([
+			{ op: 'setTitle', nodeId: 'gone', expected: '', value: 'A title' },
+		])
+
+		expect(refusal.kind).toBe('missing')
+		expect(refusal.op).toBe('setTitle')
+		expect(refusal.message).toContain('node gone')
+	})
+})

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -43,7 +43,6 @@ function refused(proposal: Proposal, to: Plan = plan) {
 	return result.refusal
 }
 
-const titles = (nodes: { title: string }[]) => nodes.map((node) => node.title)
 const ids = (nodes: { id: string }[]) => nodes.map((node) => node.id)
 
 describe('applying a Proposal', () => {
@@ -53,7 +52,7 @@ describe('applying a Proposal', () => {
 				op: 'createNode',
 				parentId: null,
 				beforeId: 'n3',
-				node: { id: 'n4', title: 'A turn', intent: 'Turn on the memo', children: [] },
+				node: makeNode({ id: 'n4', title: 'A turn', intent: 'Turn on the memo' }),
 			},
 			{ op: 'setTarget', nodeId: 'n4', expected: null, value: 400 },
 			{
@@ -75,7 +74,7 @@ describe('applying a Proposal', () => {
 				op: 'createNode',
 				parentId: null,
 				beforeId: null,
-				node: { id: 'n4', title: 'A turn', children: [] },
+				node: makeNode({ id: 'n4', title: 'A turn' }),
 			},
 			{
 				op: 'setIntent',
@@ -108,7 +107,7 @@ describe('applying a Proposal', () => {
 				op: 'createNode',
 				parentId: null,
 				beforeId: 'n3',
-				node: { id: 'n4', title: 'A turn', children: [] },
+				node: makeNode({ id: 'n4', title: 'A turn' }),
 			},
 		]
 
@@ -123,7 +122,7 @@ describe('applying a Proposal', () => {
 					op: 'createNode',
 					parentId: null,
 					afterId: 'n2',
-					node: { id: 'n4', title: 'A turn', children: [] },
+					node: makeNode({ id: 'n4', title: 'A turn' }),
 				},
 			],
 			withoutN2,
@@ -162,13 +161,13 @@ describe('the structural ops', () => {
 				op: 'createNode',
 				parentId: 'n2',
 				afterId: null,
-				node: { id: 'n2z', title: 'First', children: [] },
+				node: makeNode({ id: 'n2z', title: 'First' }),
 			},
 			{
 				op: 'createNode',
 				parentId: 'n2',
 				beforeId: null,
-				node: { id: 'n2y', title: 'Last', children: [] },
+				node: makeNode({ id: 'n2y', title: 'Last' }),
 			},
 		])
 
@@ -181,11 +180,11 @@ describe('the structural ops', () => {
 				op: 'createNode',
 				parentId: null,
 				beforeId: null,
-				node: {
+				node: makeNode({
 					id: 'n4',
 					title: 'A turn',
 					children: [makeNode({ id: 'n4a', title: 'Its first part' })],
-				},
+				}),
 			},
 		])
 
@@ -198,7 +197,7 @@ describe('the structural ops', () => {
 				op: 'createNode',
 				parentId: null,
 				beforeId: null,
-				node: { id: 'n2a', title: 'A second n2a', children: [] },
+				node: makeNode({ id: 'n2a', title: 'A second n2a' }),
 			},
 		])
 
@@ -212,7 +211,7 @@ describe('the structural ops', () => {
 				op: 'createNode',
 				parentId: 'n2',
 				afterId: 'n3',
-				node: { id: 'n4', title: 'A turn', children: [] },
+				node: makeNode({ id: 'n4', title: 'A turn' }),
 			},
 		])
 
@@ -262,7 +261,7 @@ describe('the structural ops', () => {
 		const next = applied([{ op: 'mergeNodes', nodeId: 'n2', intoId: 'n3' }])
 
 		expect(ids(next.outline)).toEqual(['n1', 'n3'])
-		expect(titles(next.outline)).toEqual(['Opening', 'Close'])
+		expect(next.outline.map((node) => node.title)).toEqual(['Opening', 'Close'])
 		expect(ids(next.outline[1].children)).toEqual(['n2a', 'n2b'])
 		expect(next.references.map((reference) => reference.nodeId)).toEqual([
 			'n2a',

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -237,13 +237,13 @@ describe('the structural ops', () => {
 		expect(ids(next.outline[1].children)).toEqual(['n2a', 'n3', 'n2b'])
 	})
 
-	it('refuses to move a node inside its own subtree', () => {
+	it('refuses to move a node under one it contains', () => {
 		const refusal = refused([
 			{ op: 'moveNode', nodeId: 'n2', parentId: 'n2a', beforeId: null },
 		])
 
 		expect(refusal.kind).toBe('invalid')
-		expect(refusal.message).toContain('its own subtree')
+		expect(refusal.message).toContain('a node it contains')
 	})
 
 	it('deletes a node with its subtree, and unplaces the References that sat there', () => {

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import type { Plan, Proposal } from '../../src/shared/plan'
+import type { Plan, ProposalInput } from '../../src/shared/plan'
 import { applyProposal } from '../../src/shared/plan'
 import { makeNode, makePlan, makeReference } from './plan-fixtures'
 
@@ -28,7 +28,7 @@ const plan = makePlan({
 })
 
 /** The Plan a Proposal produced, or a failed assertion naming the refusal. */
-function applied(proposal: Proposal, to: Plan = plan): Plan {
+function applied(proposal: ProposalInput, to: Plan = plan): Plan {
 	const result = applyProposal(to, proposal)
 	if (!result.ok) throw new Error(`Refused: ${result.refusal.message}`)
 
@@ -36,7 +36,7 @@ function applied(proposal: Proposal, to: Plan = plan): Plan {
 }
 
 /** The refusal a Proposal produced, or a failed assertion. */
-function refused(proposal: Proposal, to: Plan = plan) {
+function refused(proposal: ProposalInput, to: Plan = plan) {
 	const result = applyProposal(to, proposal)
 	if (result.ok) throw new Error('The Proposal applied, and the test expected a refusal.')
 
@@ -102,7 +102,7 @@ describe('applying a Proposal', () => {
 
 	it('applies an insert whose anchor survived an unrelated sibling being deleted', () => {
 		const withoutN2 = applied([{ op: 'deleteNode', nodeId: 'n2' }])
-		const insert: Proposal = [
+		const insert: ProposalInput = [
 			{
 				op: 'createNode',
 				parentId: null,
@@ -134,7 +134,7 @@ describe('applying a Proposal', () => {
 	})
 
 	it('refuses a Proposal that does not match the vocabulary', () => {
-		const refusal = refused([{ op: 'setTone', nodeId: 'n1' }] as unknown as Proposal)
+		const refusal = refused([{ op: 'setTone', nodeId: 'n1' }] as unknown as ProposalInput)
 
 		expect(refusal.kind).toBe('malformed')
 		expect(refusal.index).toBe(0)
@@ -172,6 +172,38 @@ describe('the structural ops', () => {
 		])
 
 		expect(ids(first.outline[1].children)).toEqual(['n2z', 'n2a', 'n2b', 'n2y'])
+	})
+
+	it('takes a payload that leaves out children, and stores the Plan spelling', () => {
+		const next = applied([
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: null,
+				node: { id: 'n4', title: 'A turn' },
+			},
+		])
+
+		expect(next.outline[3].children).toEqual([])
+	})
+
+	it('takes a payload stating an empty Adjectives list, and stores it as absent', () => {
+		const next = applied([
+			{
+				op: 'createNode',
+				parentId: null,
+				beforeId: null,
+				node: {
+					id: 'n4',
+					title: 'A turn',
+					adjectives: [],
+					children: [{ id: 'n4a', title: 'Its first part', adjectives: [] }],
+				},
+			},
+		])
+
+		expect(next.outline[3].adjectives).toBeUndefined()
+		expect(next.outline[3].children[0].adjectives).toBeUndefined()
 	})
 
 	it('creates a subtree in one op', () => {
@@ -237,6 +269,15 @@ describe('the structural ops', () => {
 		expect(ids(next.outline[1].children)).toEqual(['n2a', 'n3', 'n2b'])
 	})
 
+	it('refuses to anchor a move to the node being moved, and says so', () => {
+		const refusal = refused([
+			{ op: 'moveNode', nodeId: 'n2', parentId: null, afterId: 'n2' },
+		])
+
+		expect(refusal.kind).toBe('invalid')
+		expect(refusal.message).toContain('cannot anchor n2 to itself')
+	})
+
 	it('refuses to move a node under one it contains', () => {
 		const refusal = refused([
 			{ op: 'moveNode', nodeId: 'n2', parentId: 'n2a', beforeId: null },
@@ -267,6 +308,17 @@ describe('the structural ops', () => {
 			'n2a',
 			null,
 			'n3',
+		])
+	})
+
+	it('merges a child into its own parent, lifting what it held', () => {
+		const next = applied([{ op: 'mergeNodes', nodeId: 'n2a', intoId: 'n2' }])
+
+		expect(ids(next.outline[1].children)).toEqual(['n2b'])
+		expect(next.references.map((reference) => reference.nodeId)).toEqual([
+			'n2',
+			null,
+			'n2',
 		])
 	})
 

--- a/test/shared/plan-ops.test.ts
+++ b/test/shared/plan-ops.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import { proposalOpSchema, proposalSchema } from '../../src/shared/plan'
+
+/** An op that parses, so each test states only the field it is about. */
+const setTitle = {
+	op: 'setTitle',
+	nodeId: 'n1',
+	expected: 'The old title',
+	value: 'The new title',
+}
+
+const createNode = {
+	op: 'createNode',
+	parentId: null,
+	beforeId: null,
+	node: { id: 'n9', title: 'A new node', children: [] },
+}
+
+describe('the op vocabulary', () => {
+	it('parses a content op naming a node', () => {
+		expect(proposalOpSchema.parse(setTitle)).toEqual(setTitle)
+	})
+
+	it('parses a content op naming the Article, where nodeId is null', () => {
+		expect(proposalOpSchema.parse({ ...setTitle, nodeId: null })).toBeDefined()
+	})
+
+	it('refuses an op name outside the vocabulary', () => {
+		expect(proposalOpSchema.safeParse({ ...setTitle, op: 'setTone' }).success).toBe(false)
+	})
+
+	it('refuses one extra field rather than stripping it', () => {
+		const result = proposalOpSchema.safeParse({ ...setTitle, reason: 'it reads better' })
+
+		expect(result.success).toBe(false)
+	})
+
+	it('refuses an extra field inside a piece schema too', () => {
+		const node = { ...createNode.node, wordCount: 400 }
+
+		expect(proposalOpSchema.safeParse({ ...createNode, node }).success).toBe(false)
+	})
+
+	it('holds the piece schemas to their own field rules', () => {
+		const node = { ...createNode.node, voice: '' }
+
+		expect(proposalOpSchema.safeParse({ ...createNode, node }).success).toBe(false)
+	})
+
+	it('takes a whole subtree as one createNode payload', () => {
+		const node = {
+			...createNode.node,
+			children: [{ id: 'n9a', title: 'A child', children: [] }],
+		}
+
+		expect(proposalOpSchema.safeParse({ ...createNode, node }).success).toBe(true)
+	})
+
+	it('takes exactly one anchor', () => {
+		expect(proposalOpSchema.safeParse({ ...createNode, afterId: 'n1' }).success).toBe(
+			false,
+		)
+	})
+
+	it('refuses a structural op stating no anchor', () => {
+		const { beforeId: _anchor, ...unanchored } = createNode
+
+		expect(proposalOpSchema.safeParse(unanchored).success).toBe(false)
+	})
+
+	it('reads a null anchor as first child or last child, not as a missing one', () => {
+		expect(proposalOpSchema.safeParse({ ...createNode, beforeId: null }).success).toBe(
+			true,
+		)
+	})
+
+	it('refuses an expected on a structural op', () => {
+		expect(proposalOpSchema.safeParse({ ...createNode, expected: null }).success).toBe(
+			false,
+		)
+	})
+
+	it('refuses an empty Proposal, which changes nothing', () => {
+		expect(proposalSchema.safeParse([]).success).toBe(false)
+	})
+})

--- a/test/shared/plan-schema.test.ts
+++ b/test/shared/plan-schema.test.ts
@@ -88,6 +88,17 @@ describe('the Plan schema', () => {
 		expect(withNode({ intent: '' })).toBe(false)
 	})
 
+	it('gives a node one way to say it states no Adjectives, and it is not the empty list', () => {
+		const withAdjectives = (adjectives?: string[]) =>
+			planSchema.safeParse(makePlan({ outline: [makeNode({ id: 'n1', adjectives })] }))
+				.success
+
+		expect(withAdjectives(undefined)).toBe(true)
+		expect(withAdjectives([])).toBe(false)
+		// The Article carries the key either way, so there the empty list is it.
+		expect(planSchema.safeParse(makePlan({ adjectives: [] })).success).toBe(true)
+	})
+
 	it('rejects an invalid node however deep it sits', () => {
 		const plan = makePlan({
 			outline: [

--- a/test/worker/smoke.test.ts
+++ b/test/worker/smoke.test.ts
@@ -26,8 +26,7 @@ describe('the Worker', () => {
 		})
 	})
 
-	// The request carries no Cf-Access-Jwt-Assertion header, because localhost
-	// has no Access gate and so nothing may require one.
+	// No Cf-Access-Jwt-Assertion header, per architecture.md §9.
 	it('answers the health route rather than the SPA fallback', async () => {
 		const response = await SELF.fetch('https://harness.test/api/health')
 


### PR DESCRIPTION
Closes #24.

Ten ops in `src/shared/plan/ops.ts` and `applyProposal` in `apply.ts`. Both are pure — the Chat proposes and the client applies, so no Worker takes part.

## What to review, in order

**`ops.ts`** — the vocabulary. Two shapes: a structural op anchors on IDs and states exactly one of `afterId`/`beforeId`; a content op carries `expected` and `value`, compared whole-field, and reads `nodeId: null` as the Article Scope. `createNode` carries `outlineNodeSchema` whole, so a node with nothing under it states `children: []` and one op may create a node with its children.

**`apply.ts`** — the applier. It works on a copy, so the first op to refuse throws the whole Proposal away and the Plan passed in is never touched. A refusal carries `kind`, the op's position in the Proposal, the op name, a sentence for the writer, and `expected`/`found` on a stale field. Four kinds: `malformed`, `missing`, `stale`, `invalid`.

**The tests** — 26 in `plan-apply.test.ts`, 12 in `plan-ops.test.ts`. They cover the four cases the ticket names — a multi-op Proposal applying atomically, one failed `expected` refusing the batch, an insert surviving an unrelated sibling's deletion, an insert failing when its own anchor is gone — plus every op's happy path and its refusal.

## Decisions the ticket asked for, recorded in architecture.md §6

- **The op payloads stay strict**, paired with the retry that carries the validation error. Stripping an unknown field would produce a Proposal the model did not make, and the writer would rule on it without seeing what was dropped. The cost is real: a model that adds the same field every turn thrashes the retry, and the answer is naming the field in the schema rather than loosening every payload.
- **`deleteNode` unplaces the References placed at the node it removes or below it.** The Plan is written whole, so leaving that to a second op makes most deletions produce a Plan that does not parse.
- **`mergeNodes` keeps the target's own fields**, taking the source's children and placed References. Carrying the source's intent note over is a `setIntent` op in the same batch.
- **The applier parses the Plan it produces**, so a Proposal `validateStateChange` would reject is refused here with a reason instead of there with none.

## Two things worth a second opinion

1. `referenceSchema` and `sourceSchema` end up as types the applier reads rather than as op payloads, where the ticket expected all three piece schemas inside payloads. No op carries a whole Reference, because a Reference reaches the Plan by the writer Accepting an Offer, which §3 rule 3 calls CRUD rather than a Proposal. Adding an `addReference` op would close the gap but widen the vocabulary past the ten names, so I left it.
2. A node's `adjectives` accepted both an absent key and an empty list for one state. ADR 0002 already gave the reason against that, about a Reference's `nodeId` — a blob written whole should not carry two spellings — so the schema now takes absent only, architecture.md §4 carries the rule for the whole data model, and the ADR records that it generalises. The applier already normalised the two, so nothing changed for it.

## Also in here

A comment pass over the modules this branch touches, moving specification out of code comments and into the docs that own it: the one-spelling rule, who may write the Plan, and the auth model the Worker restated from §9. What stays in the code is local — why the object schema is named apart from the refined one, why `createNode` claims ids that `checkIds` would catch anyway, why two content ops cannot reach both Scopes through one helper.

`context.md` named `docs/ux-outline.md` as its requirements source. That file was deleted when the architecture landed, so the link has been dead since; it now points at what replaced it.

## Checks

`pnpm test` — 88 tests, 6 files. `pnpm typecheck` and `pnpm lint` clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZhUne4WJr5dyzLyHjAkgW)_