### PR TITLE
Align the showcase with context.md, and settle Tone and Section

### DIFF
--- a/context.md
+++ b/context.md
@@ -147,8 +147,12 @@ _Avoid_: excerpt, passage, snippet, pull quote
 
 **Ledger**:
 The View of an Article's Offers and what the writer decided about each — a query over
-Offers, not a store of its own.
-_Avoid_: inbox, tray, queue, history
+Offers, not a store of its own. Name it the **Offer ledger** wherever the phrase stands on
+its own, in a heading, a story name, or a menu item: a bare "Ledger" makes the reader
+supply the noun, and the qualifier costs one word. Drop to "the Ledger" only in running
+prose that has already named it.
+_Avoid_: source ledger (a source is the attribution inside a Reference), inbox, tray,
+queue, history
 
 **Undecided**:
 The disposition of an Offer the writer has not ruled on. The starting state.

--- a/context.md
+++ b/context.md
@@ -37,7 +37,7 @@ _Avoid_: project, document, piece (except in prose about the writing itself)
 **Panel**:
 One of the columns of the Article screen, and the material it shows. Four today: Chat,
 Plan, Draft, Notes. On a narrow screen the Panels become tabs.
-_Avoid_: layer, pane, section (a Section is part of the Draft), stage (the writer owns
+_Avoid_: layer, pane, section (a Section is part of the Article), stage (the writer owns
 their own process, and we do not name it for them), rail (a rail is a collapsed Panel,
 not a different thing)
 
@@ -50,9 +50,9 @@ The dialogue between the writer and the guide about one Article.
 _Avoid_: conversation, thread
 
 **Plan**:
-The structured plan for one Article — its Outline nodes, its Voice and Adjectives, its
-word-count targets, and the References the writer has Accepted. It is what the
-Chat and the writer co-construct, and it plays the role a plan plays in an agentic coding tool.
+The structured plan for one Article — its Sections, its Tone, its word-count targets, and
+the References the writer has Accepted. It is what the Chat and the writer co-construct,
+and it plays the role a plan plays in an agentic coding tool.
 _Avoid_: **brief** (see below), outline (the Outline is one part of the Plan), context
 stash, spec
 
@@ -72,17 +72,44 @@ _Avoid_: feedback, comments, findings, suggestions, review (a Review produces No
 
 ## Inside the Plan
 
-**Outline node**:
-The unit of structure in the Plan. A node in a tree, carrying a stable ID, a title, an
-intent note, and optionally a word-count target, a Voice, and Adjectives.
-_Avoid_: section (a Section is in the Draft), item, heading, bullet
+**Outline**:
+The Plan's ordered tree of Sections, and the Panel material the writer rearranges. One
+part of the Plan rather than another word for it.
+_Avoid_: structure, TOC, table of contents
+
+**Section**:
+The unit the writer works in — one stretch of the Article, planned in the Outline and
+written in the Draft. Its plan side is stored, carrying a stable ID, a title, an intent
+note, and optionally a word-count target and a Tone. Its prose side is the run of Blocks
+that serves it, inferred rather than stored (see **Boundary**). One word for both, because
+the writer has one thing in mind.
+_Avoid_: node (a Node is the code word — see below), item, heading, bullet, chapter (a
+Chapter is a longer work's unit, and v1 has none)
+
+**Subsection**:
+A Section nested one level inside another. Two levels is what the interface offers.
+Anything deeper wants a word writers already hold — Chapter, for a book — rather than a
+more recursive one, and we would rather add that word later than ask a writer to think in
+trees.
+
+**Node**:
+The code word for the recursive unit a Section and a Subsection are both instances of, and
+the name it keeps in the schema: `OutlineNode` in `src/shared/plan`. Depth picks the word
+the writer reads — 0 is a Section and 1 is a Subsection.
+_Avoid_: the word "node" anywhere the writer can read it
+
+**Tone**:
+The Voice and the Adjectives together — everything saying how the writing should sound, as
+against what it should say. A Section's Tone is its resolved Voice plus its accumulated
+Adjectives, so Tone names the pair and never one of them.
+_Avoid_: Tone for a Voice alone or an Adjective alone, style, register
 
 **Voice**:
 The register the writing is in — "reported feature", "clean and professional",
 "academic". **One applies at a time.** Voices do not compose: switching from one to
 another for a passage replaces it, because blending two registers makes mud rather than a
 third register.
-_Avoid_: tone, style, register, mode
+_Avoid_: tone (a Tone is the Voice and the Adjectives together), style, register, mode
 
 **Adjective**:
 A descriptive term the writing should answer to — "funny", "somber", "high energy",
@@ -93,8 +120,8 @@ _Avoid_: tone word, tag, chip (a chip is how one is rendered), trait
 
 **Scope**:
 Which level a Voice, an Adjective, or a Reference is attached to — House, Article, or
-Outline node. Resolution runs House first and the Outline node last: the nearest Voice
-wins outright, and Adjectives accumulate in that order. Resolved when read, never stored
+Section. Resolution runs House first and the Section last: the nearest Voice wins
+outright, and Adjectives accumulate in that order. Resolved when read, never stored
 resolved.
 _Avoid_: level, tier, inheritance chain
 
@@ -154,23 +181,19 @@ _Avoid_: applied, written, done
 
 ## Inside the Draft
 
-**Section**:
-The stretch of Draft prose serving one Outline node. Approximate and inferred, rather
-than a storage fact.
-_Avoid_: chapter, part, block (a Block is the unit the Draft is stored in)
-
 **Transition**:
 The connective prose between two Sections, belonging to neither.
 
 **Boundary**:
-The place where one Section ends and the next begins. Inferred lazily (for now) and
-reported approximately.
+The place where one Section's prose ends and the next begins. Inferred lazily (for now)
+and reported approximately — the Draft is stored as a flat run of Blocks, so which Section
+a Block serves is read out rather than written down.
 
 **Block**:
 The unit the Draft is stored and synced in, usually one paragraph. Blocks settle lazily
 and hold loosely — a paragraph the writer is in the middle of splitting may stay one
 Block until they move on, and the structure is never enforced against them mid-flow.
-_Avoid_: row, chunk, node (an Outline node is a different thing)
+_Avoid_: row, chunk, node (a Node is the code word for a Section)
 
 ## The guide and its output
 
@@ -185,10 +208,11 @@ and a body of one or two sentences. The unit that fills the Notes Panel.
 _Avoid_: finding, suggestion, comment, tip, feedback
 
 **Kind**:
-What sort of thing a record is. For a Guidance note: structure, voice, citations,
-repetition, budget, tone drift, pacing, plan divergence — illustrative rather than a
-fixed taxonomy, and the Notes Panel groups by it. For an Offer: Reference, Quote, and
-whatever comes later.
+What sort of thing a record is. For a Guidance note: structure, tone drift, citations,
+repetition, budget, pacing, plan divergence — illustrative rather than a fixed taxonomy,
+and the Notes Panel groups by it. A note about the Voice and a note about an Adjective are
+both tone drift, because the writer reads them the same way. For an Offer: Reference,
+Quote, and whatever comes later.
 _Avoid_: category, type, tag, label
 
 **Review**:

--- a/docs/adr/0001-phase-1-storage-shape.md
+++ b/docs/adr/0001-phase-1-storage-shape.md
@@ -45,7 +45,7 @@ has no export path, and D1 has `wrangler d1 export`.
 
 Archived Plans, Drafts, and Finals grow without bound and no client needs them resident,
 so they live in plain D1 tables behind a read endpoint. Only the Chat goes to cold storage
-in R2, which is why un-archiving restores a conversation rather than an Article.
+in R2, which is why un-archiving restores a Chat rather than an Article.
 
 ## Considered options
 
@@ -67,7 +67,7 @@ document per keystroke.
   party-db setup that already runs rather than standing one up.
 - **1a has no article index**, because the index lives in the House. Articles are
   addressed by ID in the URL until 1b arrives.
-- **Every Plan node carries a stable ID from the first commit** — Outline nodes, Accepted
+- **Every Plan node carries a stable ID from the first commit** — Sections, Accepted
   References, and each scoped Voice and Adjective, with children referring to parents by
   ID rather than by position. This makes the phase 2 move a projection of the blob into
   rows rather than a rewrite of every reference in the Plan.

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -62,8 +62,8 @@ be added during that migration.
 
 ## References are flat, and `nodeId` is null until one is placed
 
-An Accepted Reference may sit at an Outline node or nowhere yet, and the Ledger shows
-"accepted, no section yet" as its own group. Nesting References under nodes would leave
+An Accepted Reference may sit at a Section or nowhere yet, and the Ledger shows
+"accepted, no Section yet" as its own group. Nesting References under Sections would leave
 the unplaced ones homeless, forcing a second bucket and one entity in two shapes. Flat
 also makes moving a Reference between Sections a single field, and projects to one table
 with a nullable `node_id`.
@@ -115,8 +115,8 @@ term reads as local emphasis: House `warm, plain` under a node saying `warm` res
 which moves the Plan inside the cacheable prompt prefix — but that edit changed the Plan's
 content anyway, so the prefix was missing regardless.
 
-Resolution runs House, then Article, then Outline node, and happens **at read time**. A
-node's ancestors take part in that same order, so a subsection under a somber middle is
+Resolution runs House, then Article, then Section, and happens **at read time**. A
+Section's ancestors take part in that same order, so a Subsection under a somber middle is
 somber unless it says otherwise.
 Storing resolved values would mean re-walking every node whenever the Article's Voice
 changes, inside a whole-blob write, and it could silently drift. In 1a the Plan carries
@@ -172,7 +172,7 @@ costs, and what to do if a model thrashes the retry, is in `docs/architecture.md
 
 - **The soft size ceiling is around 100 KB; the hard wall is 2 MB.** A SQLite-backed
   Durable Object caps a single row or value at 2 MB, but every write re-serialises the
-  whole Plan and broadcasts it, so cost is per-write. A normal Plan of 30 Outline nodes and
+  whole Plan and broadcasts it, so cost is per-write. A normal Plan of 30 Sections and
   40 References is roughly 40 KB. Growth is driven by References carrying long pulled
   passages, not by the outline.
 - **The relief valve is moving References into SQLite rows.** They are already row-shaped

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ Recorded in [ADR 0001](./adr/0001-phase-1-storage-shape.md).
 Five rules. Apply them to anything new without reopening the question.
 
 1. **Article Agent state holds only the Plan, and only the client writes it.** `setState`
-   replaces the entire blob, so a write meant to change one Outline node rewrites every
+   replaces the entire blob, so a write meant to change one Section rewrites every
    field from whatever version the client last read. A second writer's changes vanish with
    no conflict and no error.
 2. **Every other per-Article record is a SQLite row in the Article Agent**, read and written
@@ -75,7 +75,7 @@ Five rules. Apply them to anything new without reopening the question.
    the writer Declines an Offer and neither erases the other. Adding a per-Article record
    type needs no endpoint, no store, and no sync library.
 3. **A request is an action when it runs a model, and CRUD otherwise.** Actions: sending a
-   Chat turn, running a Review, running research. CRUD: editing an Outline node, editing a
+   Chat turn, running a Review, running research. CRUD: editing a Section, editing a
    Reference, Accepting a Proposal, Declining an Offer, retitling the Article. Accepting is
    CRUD even though a model produced the thing being accepted, because applying it is a
    plain write.
@@ -106,15 +106,15 @@ plan: {
 }
 ```
 
-- **The Outline is a nested tree**, sibling order carried by array position, every node with
+- **The Outline is a nested tree**, sibling order carried by array position, every Section with
   a stable ID that never changes.
-- **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at an
-  Outline node or nowhere yet.
+- **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
+  Section or nowhere yet.
 - **A Quote is a Reference that carries a `text`.** One structure: a pulled passage, an
   attribution, or both, with at least one present.
 - **Voice replaces; Adjectives compose.** One Voice applies at a time and the nearest Scope
-  wins outright. Adjectives accumulate. Resolution runs House, then Article, then Outline
-  node, **at read time**. A node's ancestors take part in that same order, so a subsection
+  wins outright. Adjectives accumulate. Resolution runs House, then Article, then
+  Section, **at read time**. A Section's ancestors take part in that same order, so a Subsection
   under a somber middle is somber unless it says otherwise.
 - **The word-count total is stored and nothing is derived.** The parts may disagree with the
   whole; the gap is information. Auto-distributing the remainder is rejected.
@@ -123,8 +123,8 @@ plan: {
   whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a second
   spelling is a second Plan for the same content. Three fields carry their key always and say
   "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, the
-  Article's `adjectives`, and an Outline node's `children`, both of them the empty list. A
-  node's own `adjectives` is the other way round, and says it by being absent.
+  Article's `adjectives`, and a Section's `children`, both of them the empty list. A
+  Section's own `adjectives` is the other way round, and says it by being absent.
 
 **The schema guards client writes.** `validateStateChange` parses the whole Plan on every
 write, and nothing the model emits ever goes through it — the Chat proposes and the client
@@ -133,8 +133,8 @@ schemas, `outlineNodeSchema`, `referenceSchema`, and `sourceSchema`, reused insi
 Proposal's op payloads. It lives in `src/shared/plan/` with the Scope resolver and the
 word-count arithmetic.
 
-Three invariants sit above the object shape, checked in the same parse: an Outline node id
-is unique among Outline nodes, a Reference id is unique among References, and a placed
+Three invariants sit above the object shape, checked in the same parse: a Section id
+is unique among Sections, a Reference id is unique among References, and a placed
 Reference names a node that exists. The last one means an op that deletes a node unplaces
 its References in the same Proposal, because the Plan is written whole and validated whole.
 
@@ -196,7 +196,7 @@ proposal: [
 - **`expected` is content-addressed staleness** — it names the value the Proposal thinks is
   there, not a version. Compared **whole-field**, because Plan fields are short.
 - **Structural ops anchor on IDs and carry no `expected`.** Exactly one of `afterId` or
-  `beforeId`, so the model anchors to whichever neighbour its insertion relates to: a section
+  `beforeId`, so the model anchors to whichever neighbour its insertion relates to: a Section
   leading into §3 says `before: §3` and survives §2 being deleted. `afterId: null` means
   first child, `beforeId: null` means last child.
 - **If any op's `expected` fails, the whole Proposal is Stale.** The UI must say why rather
@@ -263,12 +263,12 @@ the Article Agent, with one retry that includes the validation error.
 Plan, then the volatile Draft or deltas. Cached input costs $0.26 per million against $1.40
 uncached, so the ordering is a five-fold saving on the repeated part of every pass.
 
-| Pack       | Contents                                                                            |
-| ---------- | ----------------------------------------------------------------------------------- |
-| Chat turn  | The conversation, plus the Plan                                                     |
-| Proposal   | The affected span, plus adjacent Outline node titles and intent notes. Nothing else |
-| Guide pass | The Plan, the Draft or active Section with neighbours, recent deltas. **No Chat**   |
-| Review     | The same, plus the existing Notes. **No Chat**                                      |
+| Pack       | Contents                                                                          |
+| ---------- | --------------------------------------------------------------------------------- |
+| Chat turn  | The Chat transcript, plus the Plan                                                |
+| Proposal   | The affected span, plus adjacent Section titles and intent notes. Nothing else    |
+| Guide pass | The Plan, the Draft or active Section with neighbours, recent deltas. **No Chat** |
+| Review     | The same, plus the existing Notes. **No Chat**                                    |
 
 Research reaches a Review only by being Accepted into the Plan. The Ledger is the bridge, and
 curation is forced rather than assumed.
@@ -376,8 +376,8 @@ Settings and known defects. None is a decision to make; all are things to get ri
   callable" — a silent failure where the missing plugin is a loud one.
 - **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
   completeness server-side with **no orphan timeout**, so a Proposal the writer neither
-  Accepts nor Declines stalls the conversation silently. Surface it in the UI.
-- **Local development** is unsolved: running the Worker with seeded data so an agent
+  Accepts nor Declines stalls the Chat silently. Surface it in the UI.
+- **Local development** is unsolved: running the Worker with seeded data so a coding agent
   executing a build ticket can run what it writes.
 
 ## 12. Out of scope

--- a/src/client/components/ArticleBar.tsx
+++ b/src/client/components/ArticleBar.tsx
@@ -1,20 +1,20 @@
 import { cx } from '../lib/cx'
-import { PaneRail, type PaneId } from './PaneRail'
+import { PanelRail, type PanelId } from './PanelRail'
 
 export interface ArticleBarProps {
 	title: string
 	/** Right-hand status: "draft 1", "round 2", "§3 of 4". */
 	status?: string
-	open: readonly PaneId[]
-	onToggle?: (pane: PaneId) => void
-	/** Draw the rule underneath. Off when the pane below carries its own edge. */
+	open: readonly PanelId[]
+	onToggle?: (Panel: PanelId) => void
+	/** Draw the rule underneath. Off when the Panel below carries its own edge. */
 	divided?: boolean
 	className?: string
 }
 
 /**
  * The article window's own bar — quieter than {@link TitleBar} because it sits
- * above a writing surface. Title and status recede; the pane rail is the only
+ * above a writing surface. Title and status recede; the Panel rail is the only
  * thing with any weight.
  */
 export function ArticleBar({
@@ -34,7 +34,7 @@ export function ArticleBar({
 			)}
 		>
 			<span className="min-w-0 flex-1 truncate text-[0.8125rem] text-faint">{title}</span>
-			<PaneRail open={open} onToggle={onToggle} />
+			<PanelRail open={open} onToggle={onToggle} />
 			<span className="min-w-0 flex-1 truncate text-right text-[0.75rem] whitespace-nowrap text-faint">
 				{status}
 			</span>

--- a/src/client/components/ArticleCard.tsx
+++ b/src/client/components/ArticleCard.tsx
@@ -12,7 +12,7 @@ export interface ArticleCardProps {
 
 /**
  * An in-progress article. The progress bar is deliberately unlabelled — the
- * phase word underneath is the honest signal; the bar is just a shape.
+ * status word underneath is the honest signal; the bar is just a shape.
  */
 export function ArticleCard({ article, variant = 'card', className }: ArticleCardProps) {
 	const compact = variant === 'column'
@@ -39,12 +39,12 @@ export function ArticleCard({ article, variant = 'card', className }: ArticleCar
 				</p>
 			) : null}
 			<ProgressBar value={article.progress} className="mt-0.5" />
-			<p className="text-[0.6875rem] text-faint">{article.phaseLabel}</p>
+			<p className="text-[0.6875rem] text-faint">{article.statusLabel}</p>
 			{article.voice || article.chips?.length ? (
 				<div className="flex flex-wrap gap-1.5">
-					{article.voice ? <Chip tone="outline">{article.voice}</Chip> : null}
+					{article.voice ? <Chip variant="outline">{article.voice}</Chip> : null}
 					{article.chips?.map((chip) => (
-						<Chip key={chip} tone={article.needsAttention ? 'accent' : 'default'}>
+						<Chip key={chip} variant={article.needsAttention ? 'accent' : 'default'}>
 							{chip}
 						</Chip>
 					))}

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -2,7 +2,7 @@ import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
 import { cx } from '../lib/cx'
 
-export type ButtonTone = 'default' | 'accent' | 'quiet' | 'link'
+export type ButtonVariant = 'default' | 'accent' | 'quiet' | 'link'
 export type ButtonSize = 'sm' | 'md'
 
 export interface ButtonProps extends Omit<
@@ -13,12 +13,12 @@ export interface ButtonProps extends Omit<
 	 * `accent` is the yellow one. A screen should have at most one — it marks
 	 * the single thing the app wants you to do next.
 	 */
-	tone?: ButtonTone
+	variant?: ButtonVariant
 	size?: ButtonSize
 	children?: ReactNode
 }
 
-const toneClass: Record<ButtonTone, string> = {
+const variantClass: Record<ButtonVariant, string> = {
 	default: 'border border-edge bg-surface text-ink hover:border-ink/40 hover:bg-hush',
 	accent: 'border border-accent-edge bg-accent text-accent-ink hover:brightness-[0.97]',
 	quiet:
@@ -32,7 +32,7 @@ const sizeClass: Record<ButtonSize, string> = {
 }
 
 export function Button({
-	tone = 'default',
+	variant = 'default',
 	size = 'md',
 	className,
 	children,
@@ -44,8 +44,8 @@ export function Button({
 			type={type}
 			className={cx(
 				'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter]',
-				tone === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
-				toneClass[tone],
+				variant === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
+				variantClass[variant],
 				className,
 			)}
 			{...rest}

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -4,14 +4,14 @@ import { cx } from '../lib/cx'
 import { Button } from './Button'
 
 export interface ChatMessageProps {
-	from: 'me' | 'agent'
+	from: 'me' | 'guide'
 	children: ReactNode
 	className?: string
 }
 
 /**
- * One turn. Yours is a bounded block; the agent's runs loose against the pane
- * so the sources and controls it returns can sit at full width underneath it.
+ * One turn. Yours is a bounded block; the guide's runs loose against the Panel
+ * so the references and controls it returns can sit at full width underneath it.
  */
 export function ChatMessage({ from, children, className }: ChatMessageProps) {
 	if (from === 'me') {
@@ -58,12 +58,12 @@ export function ChatComposer({
 	)
 }
 
-export interface ChatSuggestionsProps {
+export interface ChatRepliesProps {
 	children: ReactNode
 	className?: string
 }
 
-/** The reply chips an agent turn can end with. */
-export function ChatSuggestions({ children, className }: ChatSuggestionsProps) {
+/** The reply chips a guide turn can end with. */
+export function ChatReplies({ children, className }: ChatRepliesProps) {
 	return <div className={cx('flex flex-wrap gap-1.5', className)}>{children}</div>
 }

--- a/src/client/components/Check.tsx
+++ b/src/client/components/Check.tsx
@@ -8,7 +8,7 @@ export interface CheckProps {
 }
 
 /**
- * The square tick used for accepting a source, a finding, or a note.
+ * The square tick used for accepting a Reference, an Offer, or a Guidance note.
  *
  * Checked is the accented state — accepting something is the one decision
  * these lists are asking for, so the yellow belongs here.

--- a/src/client/components/Chip.tsx
+++ b/src/client/components/Chip.tsx
@@ -2,18 +2,18 @@ import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
 import { cx } from '../lib/cx'
 
-export type ChipTone = 'default' | 'accent' | 'outline' | 'muted' | 'solid'
+export type ChipVariant = 'default' | 'accent' | 'outline' | 'muted' | 'solid'
 
 export interface ChipProps extends Omit<ButtonHTMLAttributes<HTMLElement>, 'children'> {
-	tone?: ChipTone
+	variant?: ChipVariant
 	/** Renders as a button. Off by default — most chips are labels. */
 	interactive?: boolean
-	/** Dims the chip without changing its tone (unresolved, cut, not-yet). */
+	/** Dims the chip without changing its variant (unresolved, declined, not-yet). */
 	dimmed?: boolean
 	children?: ReactNode
 }
 
-const toneClass: Record<ChipTone, string> = {
+const variantClass: Record<ChipVariant, string> = {
 	default: 'border-edge bg-hush text-muted',
 	accent: 'border-accent-edge bg-accent text-accent-ink',
 	outline: 'border-edge bg-transparent text-muted',
@@ -28,7 +28,7 @@ const toneClass: Record<ChipTone, string> = {
  * Chips are read-only labels unless `interactive` is set.
  */
 export function Chip({
-	tone = 'default',
+	variant = 'default',
 	interactive = false,
 	dimmed = false,
 	className,
@@ -41,7 +41,7 @@ export function Chip({
 			{...(interactive ? { type: 'button' as const } : {})}
 			className={cx(
 				'inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-[0.1875rem] text-[0.6875rem] leading-none font-medium whitespace-nowrap',
-				toneClass[tone],
+				variantClass[variant],
 				dimmed && 'opacity-45',
 				interactive && 'transition-colors hover:border-ink/30 hover:text-ink',
 				className,

--- a/src/client/components/Divider.tsx
+++ b/src/client/components/Divider.tsx
@@ -18,7 +18,7 @@ export function Divider({ weight = 'hair', className }: DividerProps) {
 	)
 }
 
-export interface SectionHeadingProps {
+export interface GroupHeadingProps {
 	children: React.ReactNode
 	/** "24", "9 · 3 used" — sits after the label, always quiet. */
 	count?: React.ReactNode
@@ -30,12 +30,7 @@ export interface SectionHeadingProps {
  * A run-on heading: label, count, a hairline that eats the remaining width,
  * then an optional link. Used for every list on the desk and in the plan.
  */
-export function SectionHeading({
-	children,
-	count,
-	action,
-	className,
-}: SectionHeadingProps) {
+export function GroupHeading({ children, count, action, className }: GroupHeadingProps) {
 	return (
 		<div className={cx('flex items-center gap-2.5', className)}>
 			<span className="label-meta shrink-0">

--- a/src/client/components/Frame.tsx
+++ b/src/client/components/Frame.tsx
@@ -15,7 +15,7 @@ export interface FrameProps {
 /**
  * The app window. Every screen sits inside one of these: it draws the outer
  * border, the single elevation used in the whole system, and clips its
- * children so panes can run edge to edge.
+ * children so Panels can run edge to edge.
  */
 export function Frame({
 	width = 720,
@@ -39,13 +39,13 @@ export function Frame({
 
 export interface FrameBodyProps {
 	children?: ReactNode
-	/** Lay the children out as horizontal panes rather than stacked blocks. */
+	/** Lay the children out as horizontal Panels rather than stacked blocks. */
 	row?: boolean
 	className?: string
 	style?: CSSProperties
 }
 
-/** The area under the title bar. `row` turns it into the horizontal pane rail. */
+/** The area under the title bar. `row` turns it into the horizontal Panel rail. */
 export function FrameBody({ children, row = false, className, style }: FrameBodyProps) {
 	return (
 		<div

--- a/src/client/components/GuidanceNote.tsx
+++ b/src/client/components/GuidanceNote.tsx
@@ -3,10 +3,10 @@ import type { ReactNode } from 'react'
 import { cx } from '../lib/cx'
 import { Chip } from './Chip'
 
-export interface CoachNoteProps {
+export interface GuidanceNoteProps {
 	/** Where it points: "§3", "§2 ↔ §4". */
 	anchor?: string
-	/** How sure the coach is. `confident` notes are the ones surfaced on a pause. */
+	/** How sure the Guide is. `confident` notes are the ones surfaced on a pause. */
 	confidence?: 'confident' | 'tentative'
 	title: ReactNode
 	body?: ReactNode
@@ -18,11 +18,11 @@ export interface CoachNoteProps {
 }
 
 /**
- * A note from the coach. Notes never edit the prose — they say what they see
- * and wait. `live` is the freshly surfaced one and gets the accent wash; every
- * other note on screen stays quiet.
+ * One Guidance note from the Guide. Notes never edit the prose — they say what
+ * they see and wait. `live` is the freshly surfaced one and gets the accent
+ * wash; every other note on screen stays quiet.
  */
-export function CoachNote({
+export function GuidanceNote({
 	anchor,
 	confidence,
 	title,
@@ -31,7 +31,7 @@ export function CoachNote({
 	accepted = false,
 	actions,
 	className,
-}: CoachNoteProps) {
+}: GuidanceNoteProps) {
 	return (
 		<article
 			className={cx(
@@ -48,7 +48,7 @@ export function CoachNote({
 			{body ? <p className="text-[0.75rem] leading-relaxed text-muted">{body}</p> : null}
 			{actions ? <div className="mt-0.5 flex flex-wrap gap-1.5">{actions}</div> : null}
 			{accepted ? (
-				<Chip tone="outline" className="self-start">
+				<Chip variant="outline" className="self-start">
 					accepted
 				</Chip>
 			) : null}
@@ -65,7 +65,7 @@ export interface NoteDotProps {
 /**
  * The only thing that interrupts a blank writing surface: a small accent dot,
  * shown when you go idle and there is something worth reading. Clicking it
- * opens the notes pane.
+ * opens the notes Panel.
  */
 export function NoteDot({ count, className, onClick }: NoteDotProps) {
 	return (

--- a/src/client/components/OutlineRow.tsx
+++ b/src/client/components/OutlineRow.tsx
@@ -1,9 +1,9 @@
 import { cx } from '../lib/cx'
-import type { OutlineSection } from '../mock/content'
+import type { Section } from '../mock/content'
 import { Chip } from './Chip'
 
 export interface OutlineRowProps {
-	section: OutlineSection
+	section: Section
 	/** Marks the section being written; renders a quiet "now" flag. */
 	current?: boolean
 	/** Accent the word count — used when a review has just changed it. */
@@ -13,7 +13,7 @@ export interface OutlineRowProps {
 	className?: string
 }
 
-/** One row of the outline: number, title, target, and any tone instructions. */
+/** One row of the Outline: number, title, target, and any Tone instructions. */
 export function OutlineRow({
 	section,
 	current = false,
@@ -41,20 +41,20 @@ export function OutlineRow({
 						<span className="shrink-0 text-[0.6875rem] text-faint">now</span>
 					) : null}
 					{dense ? (
-						<Chip tone={changed ? 'accent' : 'default'} className="ml-auto">
+						<Chip variant={changed ? 'accent' : 'default'} className="ml-auto">
 							{section.words}w
 						</Chip>
 					) : null}
 				</div>
 				{!dense ? (
 					<div className="flex flex-wrap gap-1.5">
-						<Chip tone={changed ? 'accent' : 'default'}>{section.words}w</Chip>
+						<Chip variant={changed ? 'accent' : 'default'}>{section.words}w</Chip>
 						{section.adjectives?.map((adjective) => (
-							<Chip key={adjective} tone="outline">
+							<Chip key={adjective} variant="outline">
 								{adjective}
 							</Chip>
 						))}
-						{section.voice ? <Chip tone="outline">voice: {section.voice}</Chip> : null}
+						{section.voice ? <Chip variant="outline">voice: {section.voice}</Chip> : null}
 					</div>
 				) : null}
 			</div>

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -2,9 +2,9 @@ import type { CSSProperties, ReactNode } from 'react'
 
 import { cx } from '../lib/cx'
 
-export interface PaneProps {
+export interface PanelProps {
 	/** `surface` is the writing surface; `sunk` is everything that supports it. */
-	tone?: 'surface' | 'sunk'
+	variant?: 'surface' | 'sunk'
 	/** Fixed width in px, or a flex ratio when omitted. */
 	width?: number | string
 	grow?: number
@@ -16,11 +16,11 @@ export interface PaneProps {
 }
 
 /**
- * One vertical pane in the horizontal rail. Panes never stack — they slide in
+ * One vertical Panel in the horizontal rail. Panels never stack — they slide in
  * and out beside each other, always in chat → plan → draft → notes order.
  */
-export function Pane({
-	tone = 'surface',
+export function Panel({
+	variant = 'surface',
 	width,
 	grow = 1,
 	divider = 'none',
@@ -28,12 +28,12 @@ export function Pane({
 	children,
 	className,
 	style,
-}: PaneProps) {
+}: PanelProps) {
 	return (
 		<section
 			className={cx(
 				'flex min-w-0 flex-col',
-				tone === 'sunk' ? 'bg-sunk' : 'bg-surface',
+				variant === 'sunk' ? 'bg-sunk' : 'bg-surface',
 				divider === 'left' && 'border-l border-edge',
 				divider === 'right' && 'border-r border-edge',
 				padded && 'gap-3.5 p-3.5',
@@ -46,15 +46,15 @@ export function Pane({
 	)
 }
 
-export interface PaneHeaderProps {
+export interface PanelHeaderProps {
 	title: ReactNode
 	meta?: ReactNode
 	actions?: ReactNode
 	className?: string
 }
 
-/** A pane's own header row: name on the left, counts and controls after it. */
-export function PaneHeader({ title, meta, actions, className }: PaneHeaderProps) {
+/** A Panel's own header row: name on the left, counts and controls after it. */
+export function PanelHeader({ title, meta, actions, className }: PanelHeaderProps) {
 	return (
 		<div className={cx('flex items-baseline gap-2.5', className)}>
 			<h3 className="text-[0.875rem] font-semibold text-ink">{title}</h3>

--- a/src/client/components/PanelRail.tsx
+++ b/src/client/components/PanelRail.tsx
@@ -1,24 +1,24 @@
 import { cx } from '../lib/cx'
 
-export const PANES = ['chat', 'plan', 'draft', 'notes'] as const
-export type PaneId = (typeof PANES)[number]
+export const PANELS = ['chat', 'plan', 'draft', 'notes'] as const
+export type PanelId = (typeof PANELS)[number]
 
-export interface PaneRailProps {
-	/** Which panes are on screen. Order is always chat → plan → draft → notes. */
-	open: readonly PaneId[]
+export interface PanelRailProps {
+	/** Which Panels are on screen. Order is always chat → plan → draft → notes. */
+	open: readonly PanelId[]
 	/** Omit to render the rail as a static indicator. */
-	onToggle?: (pane: PaneId) => void
+	onToggle?: (Panel: PanelId) => void
 	className?: string
 }
 
 /**
- * The four-pane toggle: chat · plan · draft · notes.
+ * The four-Panel toggle: chat · plan · draft · notes.
  *
- * Deliberately *not* accented. Which panes are open is state, not a call to
+ * Deliberately *not* accented. Which Panels are open is state, not a call to
  * action, so the active pill is solid ink and the yellow stays free for the
  * one thing on screen that actually wants a decision.
  */
-export function PaneRail({ open, onToggle, className }: PaneRailProps) {
+export function PanelRail({ open, onToggle, className }: PanelRailProps) {
 	return (
 		<div
 			className={cx(
@@ -26,18 +26,18 @@ export function PaneRail({ open, onToggle, className }: PaneRailProps) {
 				className,
 			)}
 			role={onToggle ? 'group' : undefined}
-			aria-label={onToggle ? 'Visible panes' : undefined}
+			aria-label={onToggle ? 'Visible Panels' : undefined}
 		>
-			{PANES.map((pane) => {
-				const isOpen = open.includes(pane)
+			{PANELS.map((Panel) => {
+				const isOpen = open.includes(Panel)
 				const Tag = (onToggle ? 'button' : 'span') as 'button'
 				return (
 					<Tag
-						key={pane}
+						key={Panel}
 						{...(onToggle
 							? {
 									type: 'button' as const,
-									onClick: () => onToggle(pane),
+									onClick: () => onToggle(Panel),
 									'aria-pressed': isOpen,
 								}
 							: {})}
@@ -47,7 +47,7 @@ export function PaneRail({ open, onToggle, className }: PaneRailProps) {
 							onToggle && !isOpen && 'hover:bg-hush hover:text-muted',
 						)}
 					>
-						{pane}
+						{Panel}
 					</Tag>
 				)
 			})}

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -1,19 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 
-import { outline, quotes, sources } from '../mock/content'
+import { outline, quotes, references } from '../mock/content'
 import { Button } from './Button'
 import { Check } from './Check'
 import { Chip } from './Chip'
-import { CoachNote, NoteDot } from './CoachNote'
 import { ExampleBlock, PolarityHeading } from './ExampleBlock'
 import { EmptySlot, Field } from './Field'
+import { GuidanceNote, NoteDot } from './GuidanceNote'
 import { LengthBar } from './LengthBar'
 import { OutlineRow } from './OutlineRow'
-import { PaneRail, type PaneId } from './PaneRail'
+import { PanelRail, type PanelId } from './PanelRail'
 import { ProgressBar } from './ProgressBar'
 import { QuoteRow } from './QuoteRow'
-import { SourceCard } from './SourceCard'
+import { ReferenceCard } from './ReferenceCard'
 
 const meta = {
 	title: 'Primitives/Overview',
@@ -35,18 +35,18 @@ function Row({ label, children }: { label: string; children: React.ReactNode }) 
 export const Buttons: Story = {
 	render: () => (
 		<div className="w-[40rem]">
-			<Row label="Button tones">
-				<Button tone="accent">start drafting →</Button>
+			<Row label="Button variants">
+				<Button variant="accent">start drafting →</Button>
 				<Button>download</Button>
-				<Button tone="quiet">cut</Button>
-				<Button tone="link">see all drafts</Button>
+				<Button variant="quiet">declined</Button>
+				<Button variant="link">see all drafts</Button>
 			</Row>
 			<Row label="Chips">
-				<Chip tone="accent">review ready</Chip>
+				<Chip variant="accent">review ready</Chip>
 				<Chip>700w</Chip>
-				<Chip tone="outline">well researched</Chip>
-				<Chip tone="muted">—</Chip>
-				<Chip dimmed>cut</Chip>
+				<Chip variant="outline">well researched</Chip>
+				<Chip variant="muted">—</Chip>
+				<Chip dimmed>declined</Chip>
 			</Row>
 			<Row label="Check — accepting is the decision these lists ask for">
 				<Check />
@@ -57,24 +57,24 @@ export const Buttons: Story = {
 				<Field label="Length" placeholder="words —" className="w-64" />
 			</Row>
 			<Row label="Empty slot — dashed always means optional and unfilled">
-				<EmptySlot className="w-72">Tick a source in the chat</EmptySlot>
+				<EmptySlot className="w-72">Tick a reference in the chat</EmptySlot>
 			</Row>
 		</div>
 	),
 }
 
-export const PaneToggle: Story = {
-	render: function PaneToggleStory() {
-		const [open, setOpen] = useState<PaneId[]>(['plan', 'draft'])
+export const PanelToggle: Story = {
+	render: function PanelToggleStory() {
+		const [open, setOpen] = useState<PanelId[]>(['plan', 'draft'])
 		return (
 			<div className="flex w-[40rem] flex-col gap-4">
-				<PaneRail
+				<PanelRail
 					open={open}
-					onToggle={(pane) =>
+					onToggle={(Panel) =>
 						setOpen((current) =>
-							current.includes(pane)
-								? current.filter((p) => p !== pane)
-								: [...current, pane],
+							current.includes(Panel)
+								? current.filter((p) => p !== Panel)
+								: [...current, Panel],
 						)
 					}
 				/>
@@ -114,9 +114,9 @@ export const Progress: Story = {
 export const Research: Story = {
 	render: () => (
 		<div className="flex w-[34rem] flex-col gap-4">
-			<SourceCard source={sources[0]} />
-			<SourceCard source={sources[2]} variant="ledger" />
-			<SourceCard source={sources[4]} variant="ledger" compact />
+			<ReferenceCard reference={references[0]} />
+			<ReferenceCard reference={references[2]} variant="ledger" />
+			<ReferenceCard reference={references[4]} variant="ledger" compact />
 			<QuoteRow quote={quotes[0]} showUsage />
 			<QuoteRow quote={quotes[2]} showUsage />
 		</div>
@@ -126,7 +126,7 @@ export const Research: Story = {
 export const Notes: Story = {
 	render: () => (
 		<div className="flex w-[16rem] flex-col gap-3">
-			<CoachNote
+			<GuidanceNote
 				anchor="§3"
 				confidence="confident"
 				live
@@ -134,22 +134,22 @@ export const Notes: Story = {
 				body="You're supposed to be moving into the human cost."
 				actions={
 					<>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							accept
 						</Chip>
-						<Chip tone="muted" interactive>
+						<Chip variant="muted" interactive>
 							dismiss
 						</Chip>
 					</>
 				}
 			/>
-			<CoachNote
+			<GuidanceNote
 				anchor="whole piece"
 				confidence="tentative"
 				title="220 words over target"
 				body="With §4 still to write, something in §3 has to give."
 			/>
-			<CoachNote title="Attribute the £4,100 figure in-sentence" accepted />
+			<GuidanceNote title="Attribute the £4,100 figure in-sentence" accepted />
 			<NoteDot count={3} className="self-start" />
 		</div>
 	),

--- a/src/client/components/ProgressBar.tsx
+++ b/src/client/components/ProgressBar.tsx
@@ -1,10 +1,10 @@
 import { cx } from '../lib/cx'
 
 export interface ProgressBarProps {
-	/** 0–1. Values above 1 clamp the fill but flip the tone to `attention`. */
+	/** 0–1. Values above 1 clamp the fill but flip the variant to `attention`. */
 	value: number
 	/** `attention` is the accented state — used when you are over target. */
-	tone?: 'quiet' | 'attention'
+	variant?: 'quiet' | 'attention'
 	thickness?: number
 	label?: string
 	className?: string
@@ -17,14 +17,14 @@ export interface ProgressBarProps {
  */
 export function ProgressBar({
 	value,
-	tone = 'quiet',
+	variant = 'quiet',
 	thickness = 3,
 	label,
 	className,
 }: ProgressBarProps) {
 	const over = value > 1
 	const filled = Math.max(0, Math.min(1, value))
-	const accented = tone === 'attention' || over
+	const accented = variant === 'attention' || over
 
 	return (
 		<div

--- a/src/client/components/QuoteRow.tsx
+++ b/src/client/components/QuoteRow.tsx
@@ -22,7 +22,7 @@ export function QuoteRow({
 }: QuoteRowProps) {
 	return (
 		<div className={cx('flex items-start gap-2.5', dimmed && 'opacity-50', className)}>
-			<Chip tone={quote.section ? 'default' : 'muted'} className="mt-px">
+			<Chip variant={quote.section ? 'default' : 'muted'} className="mt-px">
 				{quote.section ?? '—'}
 			</Chip>
 			<blockquote

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -1,14 +1,14 @@
 import { cx } from '../lib/cx'
-import type { Source } from '../mock/content'
+import type { Reference } from '../mock/content'
 import { Button } from './Button'
 import { Check } from './Check'
 import { Chip } from './Chip'
 
-export interface SourceCardProps {
-	source: Source
+export interface ReferenceCardProps {
+	reference: Reference
 	/**
-	 * `offer` is how a source arrives in the chat (keep / cut).
-	 * `ledger` is the same source once it has a state (tick to accept).
+	 * `offer` is how a Reference arrives in the chat, to Accept or Decline.
+	 * `ledger` is the same Reference once it carries a disposition.
 	 */
 	variant?: 'offer' | 'ledger'
 	/** Hide the summary line — the ledger runs tighter than the chat. */
@@ -16,7 +16,7 @@ export interface SourceCardProps {
 	className?: string
 }
 
-/** The star that marks a source as coming from your favourites. */
+/** The star that marks a reference as coming from your favourites. */
 function FavouriteMark({ kind }: { kind: 'author' | 'publication' }) {
 	return (
 		<span className="inline-flex items-center gap-1 text-accent-ink">
@@ -31,55 +31,60 @@ function FavouriteMark({ kind }: { kind: 'author' | 'publication' }) {
  * the ledger while you decide, and in the plan once it is accepted — the state
  * changes, the row does not.
  */
-export function SourceCard({
-	source,
+export function ReferenceCard({
+	reference,
 	variant = 'offer',
 	compact = false,
 	className,
-}: SourceCardProps) {
-	const cut = source.state === 'cut'
+}: ReferenceCardProps) {
+	const declined = reference.state === 'declined'
 
 	return (
 		<article
 			className={cx(
 				'flex gap-2.5 rounded-lg border border-edge bg-surface p-2.5',
-				cut && 'opacity-50',
+				declined && 'opacity-50',
 				className,
 			)}
 		>
-			{variant === 'ledger' && !cut ? (
-				<Check checked={source.state === 'accepted'} label={`Accept ${source.title}`} />
+			{variant === 'ledger' && !declined ? (
+				<Check
+					checked={reference.state === 'accepted'}
+					label={`Accept ${reference.title}`}
+				/>
 			) : null}
-			{variant === 'ledger' && cut ? (
-				<span className="label-meta mt-0.5 shrink-0">cut</span>
+			{variant === 'ledger' && declined ? (
+				<span className="label-meta mt-0.5 shrink-0">declined</span>
 			) : null}
 
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">
-					{source.title}
+					{reference.title}
 				</h4>
 				<p className="flex flex-wrap items-center gap-x-1.5 text-[0.6875rem] text-faint">
-					{source.favourite ? <FavouriteMark kind={source.favourite} /> : null}
-					{[source.author, source.outlet, source.year].filter(Boolean).map((part, i) => (
-						<span key={part as string}>
-							{i > 0 || source.favourite ? <span aria-hidden>· </span> : null}
-							{part}
-						</span>
-					))}
+					{reference.favourite ? <FavouriteMark kind={reference.favourite} /> : null}
+					{[reference.author, reference.outlet, reference.year]
+						.filter(Boolean)
+						.map((part, i) => (
+							<span key={part as string}>
+								{i > 0 || reference.favourite ? <span aria-hidden>· </span> : null}
+								{part}
+							</span>
+						))}
 				</p>
-				{!compact && source.summary ? (
-					<p className="text-[0.75rem] leading-relaxed text-muted">{source.summary}</p>
+				{!compact && reference.summary ? (
+					<p className="text-[0.75rem] leading-relaxed text-muted">{reference.summary}</p>
 				) : null}
-				{source.quotes ? (
+				{reference.quotes ? (
 					<div className="mt-0.5 flex flex-wrap gap-1.5">
-						{Array.from({ length: source.quotes }, (_, i) => (
-							<Chip key={i} tone="outline" interactive>
+						{Array.from({ length: reference.quotes }, (_, i) => (
+							<Chip key={i} variant="outline" interactive>
 								quote {i + 1}
 							</Chip>
 						))}
 					</div>
 				) : null}
-				{variant === 'ledger' && source.state === 'undecided' ? (
+				{variant === 'ledger' && reference.state === 'undecided' ? (
 					<span className="text-[0.6875rem] text-faint">undecided</span>
 				) : null}
 			</div>
@@ -87,13 +92,13 @@ export function SourceCard({
 			{variant === 'offer' ? (
 				<div className="flex shrink-0 flex-col gap-1.5">
 					<Button size="sm">keep</Button>
-					<Button size="sm" tone="quiet">
-						cut
+					<Button size="sm" variant="quiet">
+						declined
 					</Button>
 				</div>
 			) : null}
-			{variant === 'ledger' && cut ? (
-				<Button size="sm" tone="link" className="self-start">
+			{variant === 'ledger' && declined ? (
+				<Button size="sm" variant="link" className="self-start">
 					restore
 				</Button>
 			) : null}

--- a/src/client/components/TitleBar.tsx
+++ b/src/client/components/TitleBar.tsx
@@ -9,7 +9,7 @@ export interface TitleBarProps {
 	title: ReactNode
 	/** Quiet text after the title — "· board", "· all articles". */
 	subtitle?: ReactNode
-	/** Right-hand side: buttons, pane pills, filters. */
+	/** Right-hand side: buttons, Panel pills, filters. */
 	actions?: ReactNode
 	className?: string
 }

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -45,7 +45,7 @@ A thing gets the accent when it is **the one decision the screen is waiting
 on**, or **the one item that has changed and you might not have noticed**.
 
 - The primary action, where there is one — `start drafting →`, `mark published`.
-- The state of an accepted decision — a ticked `Check`, a kept source.
+- The state of an accepted decision — a ticked `Check`, an accepted reference.
 - Something the app just did to your work — a reference that has crossed over
   from the chat, a word target a review has revised.
 - The note surfaced after a pause, and only that note.
@@ -54,8 +54,8 @@ on**, or **the one item that has changed and you might not have noticed**.
 
 ## What does not
 
-- **Which panes, tabs or filters are selected.** The `PaneRail`'s active pill and
-  `Chip tone="solid"` are ink. Where you are is state, not a request.
+- **Which Panels, tabs or filters are selected.** The `PanelRail`'s active pill and
+  `Chip variant="solid"` are ink. Where you are is state, not a request.
 - **Progress.** Bars are ink at 30% — a shape, not an alarm. The exception is
   going _over_ target, which flips to `accent-edge` because it is genuinely news.
 - **Ordinary emphasis.** Headings are weight and size. Metadata is `--color-faint`.

--- a/src/client/mock/content.ts
+++ b/src/client/mock/content.ts
@@ -10,8 +10,8 @@ export interface Article {
 	id: string
 	title: string
 	blurb: string
-	phase: 'planning' | 'drafting' | 'self-edit' | 'submitted' | 'published'
-	phaseLabel: string
+	status: 'planning' | 'drafting' | 'self-edit' | 'submitted' | 'published'
+	statusLabel: string
 	progress: number
 	voice?: string
 	chips?: string[]
@@ -23,8 +23,8 @@ export const activeArticles: Article[] = [
 		id: 'batteries',
 		title: 'The Long Tail of Batteries',
 		blurb: 'What happens to a cell after the warranty runs out, and who is counting.',
-		phase: 'drafting',
-		phaseLabel: 'drafting',
+		status: 'drafting',
+		statusLabel: 'drafting',
 		progress: 0.62,
 		voice: 'wry',
 		chips: ['3 notes'],
@@ -33,8 +33,8 @@ export const activeArticles: Article[] = [
 		id: 'cities',
 		title: 'Why Cities Stopped Building',
 		blurb: 'Permitting is not a queue. It is a series of small, reasonable refusals.',
-		phase: 'planning',
-		phaseLabel: 'planning chat',
+		status: 'planning',
+		statusLabel: 'planning chat',
 		progress: 0.2,
 		chips: ['12 refs'],
 	},
@@ -42,8 +42,8 @@ export const activeArticles: Article[] = [
 		id: 'slow-software',
 		title: 'Notes on Slow Software',
 		blurb: 'In praise of programs that do one thing and then stop.',
-		phase: 'self-edit',
-		phaseLabel: 'self-edit · round 2',
+		status: 'self-edit',
+		statusLabel: 'self-edit · round 2',
 		progress: 0.95,
 		chips: ['review ready'],
 		needsAttention: true,
@@ -111,7 +111,7 @@ export const portfolioBacklist = [
 
 export const ARTICLE_TITLE = 'Why Cities Stopped Building'
 
-export interface OutlineSection {
+export interface Section {
 	n: number
 	title: string
 	words: number
@@ -120,7 +120,7 @@ export interface OutlineSection {
 	state?: 'done' | 'current' | 'planned'
 }
 
-export const outline: OutlineSection[] = [
+export const outline: Section[] = [
 	{
 		n: 1,
 		title: 'The year the cranes stopped',
@@ -146,7 +146,7 @@ export const outline: OutlineSection[] = [
 	},
 ]
 
-export const outlineRevised: OutlineSection[] = [
+export const outlineRevised: Section[] = [
 	{ n: 1, title: 'The year the cranes stopped', words: 300 },
 	{ n: 2, title: 'How review became the process', words: 700 },
 	{ n: 3, title: 'Who actually pays for the delay', words: 700 },
@@ -157,7 +157,7 @@ export const outlineRevised: OutlineSection[] = [
 	},
 ]
 
-export interface Source {
+export interface Reference {
 	id: string
 	title: string
 	author?: string
@@ -166,12 +166,12 @@ export interface Source {
 	favourite?: 'author' | 'publication'
 	summary?: string
 	quotes?: number
-	state: 'undecided' | 'accepted' | 'cut'
+	state: 'undecided' | 'accepted' | 'declined'
 	section?: string
 	used?: boolean
 }
 
-export const sources: Source[] = [
+export const references: Reference[] = [
 	{
 		id: 's1',
 		title: 'Permit throughput in six mid-sized cities',
@@ -223,7 +223,7 @@ export const sources: Source[] = [
 		outlet: 'The Evening Ledger',
 		year: '2022',
 		summary: 'Assertive, unsourced. Covers ground we already have better evidence for.',
-		state: 'cut',
+		state: 'declined',
 	},
 ]
 

--- a/src/client/screens/article/BlankPlanScreen.tsx
+++ b/src/client/screens/article/BlankPlanScreen.tsx
@@ -2,7 +2,7 @@ import { ArticleBar } from '../../components/ArticleBar'
 import { ChatComposer, ChatMessage } from '../../components/Chat'
 import { EmptySlot } from '../../components/Field'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Pane } from '../../components/Pane'
+import { Panel } from '../../components/Panel'
 import { ARTICLE_TITLE } from '../../mock/content'
 import { PlanBlock, PlanLength } from './PlanBlocks'
 
@@ -16,19 +16,19 @@ export function BlankPlanScreen() {
 		<Frame width={760}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="new" />
 			<FrameBody row className="min-h-[20rem]">
-				<Pane divider="right" className="gap-3">
+				<Panel divider="right" className="gap-3">
 					<ChatMessage from="me">
 						I want to write about why permitting got so slow, using this city as the case.
 						Roughly feature length. Start by finding me the numbers.
 					</ChatMessage>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						Before I search — is this the story of the process, or the story of the people
-						stuck in it? That changes which sources are worth your time.
+						stuck in it? That changes which references are worth your time.
 					</ChatMessage>
 					<ChatComposer />
-				</Pane>
+				</Panel>
 
-				<Pane tone="sunk">
+				<Panel variant="sunk">
 					<PlanLength />
 					<PlanBlock title="Outline" meta="empty">
 						<EmptySlot className="min-h-[3.5rem]">
@@ -37,7 +37,7 @@ export function BlankPlanScreen() {
 						</EmptySlot>
 					</PlanBlock>
 					<PlanBlock title="References" meta="0">
-						<EmptySlot>Tick a source in the chat</EmptySlot>
+						<EmptySlot>Tick a reference in the chat</EmptySlot>
 					</PlanBlock>
 					<PlanBlock title="Quotes" meta="0">
 						<EmptySlot>Or paste your own</EmptySlot>
@@ -46,7 +46,7 @@ export function BlankPlanScreen() {
 						Scrolls. Nothing here is locked, and nothing has to be finished before you
 						write.
 					</p>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/ChatAndDraftScreen.tsx
+++ b/src/client/screens/article/ChatAndDraftScreen.tsx
@@ -1,14 +1,14 @@
 import { ArticleBar } from '../../components/ArticleBar'
-import { ChatComposer, ChatMessage, ChatSuggestions } from '../../components/Chat'
+import { ChatComposer, ChatMessage, ChatReplies } from '../../components/Chat'
 import { Chip } from '../../components/Chip'
 import { DraftSurface } from '../../components/DraftSurface'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Pane } from '../../components/Pane'
+import { Panel } from '../../components/Panel'
 import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
 
 /**
  * 3(c) — Chat beside the draft, for when you hit something mid-sentence that
- * needs looking up. The chat pane never takes more than half the window, and
+ * needs looking up. The chat Panel never takes more than half the window, and
  * whatever it produces lands in the plan rather than in the prose.
  */
 export function ChatAndDraftScreen() {
@@ -16,24 +16,24 @@ export function ChatAndDraftScreen() {
 		<Frame width={760}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'draft']} status="§3" />
 			<FrameBody row className="min-h-[19rem]">
-				<Pane tone="sunk" divider="right" width="40%" className="gap-3">
+				<Panel variant="sunk" divider="right" width="40%" className="gap-3">
 					<ChatMessage from="me">
 						Is there a number for what a stalled mid-rise costs per week?
 					</ChatMessage>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						Municipal Review put it at £4,100 in 2021 — it's already in your ledger,
 						undecided. Two more recent estimates exist if you want them.
 					</ChatMessage>
-					<ChatSuggestions>
-						<Chip tone="accent" interactive>
+					<ChatReplies>
+						<Chip variant="accent" interactive>
 							add to plan
 						</Chip>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							not now
 						</Chip>
-					</ChatSuggestions>
+					</ChatReplies>
 					<ChatComposer placeholder="Ask without leaving the sentence…" />
-				</Pane>
+				</Panel>
 				<DraftSurface paragraphs={draftParagraphs.slice(0, 3)} measure="narrow" caret />
 			</FrameBody>
 		</Frame>

--- a/src/client/screens/article/ChatWithReferencesScreen.tsx
+++ b/src/client/screens/article/ChatWithReferencesScreen.tsx
@@ -1,46 +1,46 @@
 import { ArticleBar } from '../../components/ArticleBar'
 import { ChatComposer, ChatMessage } from '../../components/Chat'
-import { SectionHeading } from '../../components/Divider'
+import { GroupHeading } from '../../components/Divider'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Pane } from '../../components/Pane'
-import { SourceCard } from '../../components/SourceCard'
-import { ARTICLE_TITLE, sources } from '../../mock/content'
+import { Panel } from '../../components/Panel'
+import { ReferenceCard } from '../../components/ReferenceCard'
+import { ARTICLE_TITLE, references } from '../../mock/content'
 
 /**
- * 2(d) — A turn that returned a lot, with the chat pane at full width. Keeping
+ * 2(d) — A turn that returned a lot, with the chat Panel at full width. Keeping
  * one sends it straight across into the plan; nothing waits in a holding pen.
  */
-export function ChatWithSourcesScreen() {
+export function ChatWithReferencesScreen() {
 	return (
 		<Frame width={700}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat']} status="research" />
 			<FrameBody>
-				<Pane className="gap-3">
+				<Panel className="gap-3">
 					<ChatMessage from="me">
 						Find me everything on approval times in comparable cities. Cast wide, I'll
-						cut.
+						declined.
 					</ChatMessage>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						Seventeen worth showing you. Two are from your favourites, and I've ranked
 						those first.
 					</ChatMessage>
 
-					<SectionHeading
+					<GroupHeading
 						count="17 found"
 						action={
 							<span className="text-[0.6875rem] text-faint">
-								keep 9 · cut 5 · undecided 3
+								keep 9 · declined 5 · undecided 3
 							</span>
 						}
 					>
-						Sources
-					</SectionHeading>
+						References
+					</GroupHeading>
 
 					<div className="flex flex-col gap-2">
-						<SourceCard source={sources[0]} />
-						<SourceCard source={sources[1]} />
-						<SourceCard source={sources[2]} />
-						<SourceCard source={sources[4]} />
+						<ReferenceCard reference={references[0]} />
+						<ReferenceCard reference={references[1]} />
+						<ReferenceCard reference={references[2]} />
+						<ReferenceCard reference={references[4]} />
 					</div>
 
 					<p className="text-[0.6875rem] text-faint">
@@ -48,7 +48,7 @@ export function ChatWithSourcesScreen() {
 						either way.
 					</p>
 					<ChatComposer placeholder="More like the throughput study, but for transit…" />
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/DraftOnlyScreen.tsx
+++ b/src/client/screens/article/DraftOnlyScreen.tsx
@@ -1,7 +1,7 @@
 import { ArticleBar } from '../../components/ArticleBar'
-import { NoteDot } from '../../components/CoachNote'
 import { DraftSurface } from '../../components/DraftSurface'
 import { Frame, FrameBody } from '../../components/Frame'
+import { NoteDot } from '../../components/GuidanceNote'
 import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
 
 /**

--- a/src/client/screens/article/Drafting.stories.tsx
+++ b/src/client/screens/article/Drafting.stories.tsx
@@ -48,7 +48,7 @@ export const C_ChatAndDraft: Story = {
 		<div className="flex flex-col">
 			<ChatAndDraftScreen />
 			<Annotation>
-				The chat pane never takes more than half. Anything it produces lands in the plan,
+				The chat Panel never takes more than half. Anything it produces lands in the plan,
 				not in the prose — the writing stays yours.
 			</Annotation>
 		</div>

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -3,10 +3,10 @@ import { Chip } from '../../components/Chip'
 import { EmptySlot } from '../../components/Field'
 import { Frame, FrameBody } from '../../components/Frame'
 import { MetaLabel } from '../../components/MetaLabel'
-import { Pane } from '../../components/Pane'
+import { Panel } from '../../components/Panel'
 import { QuoteRow } from '../../components/QuoteRow'
-import { SourceCard } from '../../components/SourceCard'
-import { ARTICLE_TITLE, quotes, sources } from '../../mock/content'
+import { ReferenceCard } from '../../components/ReferenceCard'
+import { ARTICLE_TITLE, quotes, references } from '../../mock/content'
 
 /**
  * 2(f) — The ledger, as two equal halves. Left is what has been offered and
@@ -21,7 +21,7 @@ export function LedgerDrawerScreen() {
 		<Frame width={820}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="ledger" />
 			<FrameBody row className="min-h-[22rem]">
-				<Pane divider="right" padded={false}>
+				<Panel divider="right" padded={false}>
 					<header className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
 						<h3 className="text-[0.875rem] font-semibold text-ink">Offered</h3>
 						<span className="text-[0.75rem] text-faint">17 · 9 accepted</span>
@@ -34,30 +34,30 @@ export function LedgerDrawerScreen() {
 					</header>
 					<div className="flex flex-col gap-2.5 p-3.5">
 						<div className="flex flex-wrap gap-1.5">
-							<Chip tone="solid" interactive>
+							<Chip variant="solid" interactive>
 								all
 							</Chip>
-							<Chip tone="outline" interactive>
+							<Chip variant="outline" interactive>
 								undecided
 							</Chip>
-							<Chip tone="outline" interactive>
+							<Chip variant="outline" interactive>
 								accepted
 							</Chip>
-							<Chip tone="outline" interactive>
-								cut
+							<Chip variant="outline" interactive>
+								declined
 							</Chip>
 						</div>
-						<SourceCard source={sources[0]} variant="ledger" compact />
-						<SourceCard source={sources[1]} variant="ledger" compact />
-						<SourceCard source={sources[2]} variant="ledger" compact />
-						<SourceCard source={sources[4]} variant="ledger" compact />
+						<ReferenceCard reference={references[0]} variant="ledger" compact />
+						<ReferenceCard reference={references[1]} variant="ledger" compact />
+						<ReferenceCard reference={references[2]} variant="ledger" compact />
+						<ReferenceCard reference={references[4]} variant="ledger" compact />
 						<p className="text-[0.6875rem] text-faint">
 							+ 13 more · accepting one sends it across →
 						</p>
 					</div>
-				</Pane>
+				</Panel>
 
-				<Pane tone="sunk" padded={false}>
+				<Panel variant="sunk" padded={false}>
 					<header className="flex items-center gap-2.5 border-b border-edge px-3.5 py-2.5">
 						<h3 className="text-[0.875rem] font-semibold text-ink">In the plan</h3>
 						<span className="text-[0.75rem] text-faint">9 accepted · 3 used</span>
@@ -79,7 +79,7 @@ export function LedgerDrawerScreen() {
 
 						<div className="flex flex-col gap-2">
 							<MetaLabel>§4 · What a faster city would look like</MetaLabel>
-							<EmptySlot className="ml-2">Drop an accepted source here</EmptySlot>
+							<EmptySlot className="ml-2">Drop an accepted reference here</EmptySlot>
 						</div>
 
 						<div className="flex flex-col gap-1.5">
@@ -90,7 +90,7 @@ export function LedgerDrawerScreen() {
 							</p>
 						</div>
 					</div>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -13,7 +13,7 @@ import { ARTICLE_TITLE, quotes, references } from '../../mock/content'
  * nothing else; right is the plan, with accepted items sitting under the
  * section they belong to and marked used or ready.
  *
- * It is the same list at every stage — early on most rows read "offered",
+ * It is the same list at every stage — early on most rows read "undecided",
  * later most read "used". That is why there is no separate triage screen.
  */
 export function LedgerDrawerScreen() {

--- a/src/client/screens/article/LedgerPopoverScreen.tsx
+++ b/src/client/screens/article/LedgerPopoverScreen.tsx
@@ -59,7 +59,7 @@ export function LedgerPopoverScreen() {
 	return (
 		<Frame width={340}>
 			<div className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
-				<h3 className="text-[0.875rem] font-semibold text-ink">Ledger</h3>
+				<h3 className="text-[0.875rem] font-semibold text-ink">Offer ledger</h3>
 				<span className="text-[0.75rem] text-faint">17</span>
 				<button
 					type="button"

--- a/src/client/screens/article/LedgerPopoverScreen.tsx
+++ b/src/client/screens/article/LedgerPopoverScreen.tsx
@@ -7,14 +7,14 @@ interface Group {
 	label: string
 	count: number
 	items: Array<{ text: string; section?: string }>
-	tone?: 'used' | 'plain' | 'cut'
+	variant?: 'used' | 'plain' | 'declined'
 }
 
 const groups: Group[] = [
 	{
 		label: 'Used in the draft',
 		count: 3,
-		tone: 'used',
+		variant: 'used',
 		items: [
 			{ section: '§2', text: 'Permit throughput in six mid-sized cities' },
 			{ section: '§2', text: '“We did not decide to stop building…”' },
@@ -43,9 +43,9 @@ const groups: Group[] = [
 		items: [{ text: 'Transit-adjacent density pilot' }],
 	},
 	{
-		label: 'Cut',
+		label: 'Declined',
 		count: 5,
-		tone: 'cut',
+		variant: 'declined',
 		items: [{ text: 'Why nobody builds anymore (opinion)' }],
 	},
 ]
@@ -72,13 +72,16 @@ export function LedgerPopoverScreen() {
 				{groups.map((group) => (
 					<section
 						key={group.label}
-						className={cx('flex flex-col gap-1.5', group.tone === 'cut' && 'opacity-50')}
+						className={cx(
+							'flex flex-col gap-1.5',
+							group.variant === 'declined' && 'opacity-50',
+						)}
 					>
 						<MetaLabel count={group.count}>{group.label}</MetaLabel>
 						{group.items.map((item) => (
 							<div key={item.text} className="flex items-start gap-2">
 								{item.section ? (
-									<Chip tone={group.tone === 'used' ? 'accent' : 'outline'}>
+									<Chip variant={group.variant === 'used' ? 'accent' : 'outline'}>
 										{item.section}
 									</Chip>
 								) : null}

--- a/src/client/screens/article/MarginNotesScreen.tsx
+++ b/src/client/screens/article/MarginNotesScreen.tsx
@@ -1,7 +1,7 @@
 import { ArticleBar } from '../../components/ArticleBar'
 import { Chip } from '../../components/Chip'
-import { CoachNote } from '../../components/CoachNote'
 import { Frame, FrameBody } from '../../components/Frame'
+import { GuidanceNote } from '../../components/GuidanceNote'
 import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
 
 /**
@@ -25,7 +25,7 @@ export function MarginNotesScreen() {
 					<div className="prose-draft min-w-0 flex-1 border-l-2 border-accent-edge pl-4">
 						<p className="text-[0.9375rem]">{draftParagraphs[1]}</p>
 					</div>
-					<CoachNote
+					<GuidanceNote
 						anchor="§3"
 						confidence="confident"
 						live
@@ -33,10 +33,10 @@ export function MarginNotesScreen() {
 						body="The permit-process argument already landed. §3 is meant to be the cost of the delay to people."
 						actions={
 							<>
-								<Chip tone="outline" interactive>
+								<Chip variant="outline" interactive>
 									accept
 								</Chip>
-								<Chip tone="muted" interactive>
+								<Chip variant="muted" interactive>
 									×
 								</Chip>
 							</>

--- a/src/client/screens/article/MidChatScreen.tsx
+++ b/src/client/screens/article/MidChatScreen.tsx
@@ -1,9 +1,9 @@
 import { ArticleBar } from '../../components/ArticleBar'
 import { ChatComposer, ChatMessage } from '../../components/Chat'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Pane } from '../../components/Pane'
-import { SourceCard } from '../../components/SourceCard'
-import { ARTICLE_TITLE, outline, quotes, sources } from '../../mock/content'
+import { Panel } from '../../components/Panel'
+import { ReferenceCard } from '../../components/ReferenceCard'
+import { ARTICLE_TITLE, outline, quotes, references } from '../../mock/content'
 import {
 	PlanBlock,
 	PlanLength,
@@ -13,35 +13,35 @@ import {
 } from './PlanBlocks'
 
 /**
- * 2(b) — Mid-conversation. Ticking a source in the chat sends it straight into
+ * 2(b) — Mid-chat. Ticking a reference in the chat sends it straight into
  * References; there is no interstitial approval screen. Meanwhile section 3 is
  * being typed by hand in the plan, which is equally allowed.
  */
-export function MidConversationScreen() {
+export function MidChatScreen() {
 	return (
 		<Frame width={800}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
 			<FrameBody row className="min-h-[24rem]">
-				<Pane divider="right" className="gap-3">
+				<Panel divider="right" className="gap-3">
 					<ChatMessage from="me">
 						The process, then — but I want one developer in it so it isn't all
 						spreadsheets.
 					</ChatMessage>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						Two that carry the argument, both from your favourites:
 					</ChatMessage>
 					<div className="flex flex-col gap-2">
-						<SourceCard source={sources[0]} variant="ledger" />
-						<SourceCard source={sources[3]} variant="ledger" compact />
+						<ReferenceCard reference={references[0]} variant="ledger" />
+						<ReferenceCard reference={references[3]} variant="ledger" compact />
 					</div>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						The throughput study has a line that would open §2 well. I've pulled it into
 						quotes.
 					</ChatMessage>
 					<ChatComposer />
-				</Pane>
+				</Panel>
 
-				<Pane tone="sunk">
+				<Panel variant="sunk">
 					<PlanLength words={2400} voice="Reported feature" />
 					<PlanBlock title="Outline" meta="3 of ~4">
 						<PlanOutline
@@ -52,14 +52,14 @@ export function MidConversationScreen() {
 					</PlanBlock>
 					<PlanBlock title="References" meta="5">
 						<PlanReferences
-							sources={[sources[0], sources[1]]}
-							justAddedId={sources[0].id}
+							references={[references[0], references[1]]}
+							justAddedId={references[0].id}
 						/>
 					</PlanBlock>
 					<PlanBlock title="Quotes" meta="3">
 						<PlanQuotes quotes={[quotes[0], quotes[2]]} />
 					</PlanBlock>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/NotesRailScreen.tsx
+++ b/src/client/screens/article/NotesRailScreen.tsx
@@ -2,10 +2,10 @@ import { ArticleBar } from '../../components/ArticleBar'
 import { Button } from '../../components/Button'
 import { Check } from '../../components/Check'
 import { Chip } from '../../components/Chip'
-import { CoachNote } from '../../components/CoachNote'
 import { DraftSurface } from '../../components/DraftSurface'
 import { Frame, FrameBody } from '../../components/Frame'
-import { PaneHeader } from '../../components/Pane'
+import { GuidanceNote } from '../../components/GuidanceNote'
+import { PanelHeader } from '../../components/Panel'
 import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
 
 /**
@@ -20,8 +20,8 @@ export function NotesRailScreen() {
 				<DraftSurface paragraphs={draftParagraphs} measure="narrow" caret />
 
 				<aside className="flex w-[13rem] shrink-0 flex-col gap-3 border-l border-edge bg-sunk p-3.5">
-					<PaneHeader title="Notes" meta="3 new" />
-					<CoachNote
+					<PanelHeader title="Notes" meta="3 new" />
+					<GuidanceNote
 						anchor="§3"
 						confidence="confident"
 						live
@@ -29,23 +29,23 @@ export function NotesRailScreen() {
 						body="You're supposed to be moving into the human cost."
 						actions={
 							<>
-								<Chip tone="outline" interactive>
+								<Chip variant="outline" interactive>
 									accept
 								</Chip>
-								<Chip tone="muted" interactive>
+								<Chip variant="muted" interactive>
 									dismiss
 								</Chip>
 							</>
 						}
 					/>
-					<CoachNote
+					<GuidanceNote
 						anchor="whole piece"
 						confidence="tentative"
 						title="220 words over target"
 						body="With §4 still to write, something in §3 has to give."
 					/>
 
-					<PaneHeader title="Accepted" meta="2" className="mt-1" />
+					<PanelHeader title="Accepted" meta="2" className="mt-1" />
 					<ul className="flex flex-col gap-2">
 						<li className="flex items-start gap-2">
 							<Check />
@@ -61,7 +61,7 @@ export function NotesRailScreen() {
 						</li>
 					</ul>
 
-					<Button size="sm" tone="quiet" className="mt-auto self-start">
+					<Button size="sm" variant="quiet" className="mt-auto self-start">
 						hide notes
 					</Button>
 				</aside>

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -78,20 +78,20 @@ export const E_PlanSheet: Story = {
 }
 
 export const F_LedgerDrawer: Story = {
-	name: '2(f) The Ledger',
+	name: '2(f) Offer ledger',
 	render: () => (
 		<div className="flex flex-col">
 			<LedgerDrawerScreen />
 			<Annotation>
-				The same list at every stage — early on most rows read "offered", later most read
-				"used". That is precisely why there is no separate triage screen.
+				The same list at every stage — early on most rows read "undecided", later most
+				read "used". That is precisely why there is no separate triage screen.
 			</Annotation>
 		</div>
 	),
 }
 
 export const G_LedgerPopover: Story = {
-	name: '2(g) Ledger from the composer',
+	name: '2(g) Offer ledger from the composer',
 	render: () => (
 		<div className="flex flex-col">
 			<LedgerPopoverScreen />

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -2,10 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Annotation } from '../../components/Annotation'
 import { BlankPlanScreen } from './BlankPlanScreen'
-import { ChatWithSourcesScreen } from './ChatWithSourcesScreen'
+import { ChatWithReferencesScreen } from './ChatWithReferencesScreen'
 import { LedgerDrawerScreen } from './LedgerDrawerScreen'
 import { LedgerPopoverScreen } from './LedgerPopoverScreen'
-import { MidConversationScreen } from './MidConversationScreen'
+import { MidChatScreen } from './MidChatScreen'
 import { PlanSheetScreen } from './PlanSheetScreen'
 import { ReadyToDraftScreen } from './ReadyToDraftScreen'
 
@@ -32,12 +32,12 @@ export const A_BlankPlan: Story = {
 }
 
 export const B_MidConversation: Story = {
-	name: '2(b) Mid-conversation',
+	name: '2(b) Mid-chat',
 	render: () => (
 		<div className="flex flex-col">
-			<MidConversationScreen />
+			<MidChatScreen />
 			<Annotation>
-				Ticking a source in the chat sends it across into References immediately — the
+				Ticking a reference in the chat sends it across into References immediately — the
 				wash on the newly added reference is the only thing marking the change. Section 3
 				is being typed by hand at the same time, which is equally allowed.
 			</Annotation>
@@ -51,8 +51,8 @@ export const C_ReadyToDraft: Story = {
 		<div className="flex flex-col">
 			<ReadyToDraftScreen />
 			<Annotation>
-				The button is a suggestion, not a gate — it appears once the plan has a length and
-				at least one section, and the draft pill was clickable long before it showed up.
+				The button is a nudge, not a gate — it appears once the plan has a length and at
+				least one section, and the draft pill was clickable long before it showed up.
 			</Annotation>
 		</div>
 	),
@@ -60,7 +60,7 @@ export const C_ReadyToDraft: Story = {
 
 export const D_ChatWithSources: Story = {
 	name: '2(d) A turn that returned a lot',
-	render: () => <ChatWithSourcesScreen />,
+	render: () => <ChatWithReferencesScreen />,
 }
 
 export const E_PlanSheet: Story = {
@@ -69,16 +69,16 @@ export const E_PlanSheet: Story = {
 		<div className="flex flex-col">
 			<PlanSheetScreen />
 			<Annotation>
-				Outline, references and quotes are stacked, never columned: inside a phase the eye
-				should only have to travel one way. The bar beside the outline is the shape of the
-				piece — 300 / 700 / 900 / 500 of 2,400.
+				Outline, references and quotes are stacked, never columned: inside a status the
+				eye should only have to travel one way. The bar beside the outline is the shape of
+				the piece — 300 / 700 / 900 / 500 of 2,400.
 			</Annotation>
 		</div>
 	),
 }
 
 export const F_LedgerDrawer: Story = {
-	name: '2(f) Source ledger',
+	name: '2(f) The Ledger',
 	render: () => (
 		<div className="flex flex-col">
 			<LedgerDrawerScreen />

--- a/src/client/screens/article/PlanBlocks.tsx
+++ b/src/client/screens/article/PlanBlocks.tsx
@@ -3,17 +3,17 @@ import type { ReactNode } from 'react'
 import { Chip } from '../../components/Chip'
 import { EmptySlot, Field } from '../../components/Field'
 import { OutlineRow } from '../../components/OutlineRow'
-import { PaneHeader } from '../../components/Pane'
+import { PanelHeader } from '../../components/Panel'
 import { QuoteRow } from '../../components/QuoteRow'
 import { cx } from '../../lib/cx'
-import type { OutlineSection, Quote, Source } from '../../mock/content'
+import type { Section, Quote, Reference } from '../../mock/content'
 
 export interface PlanLengthProps {
 	words?: number
 	voice?: string
 }
 
-/** The target. Empty until you or the agent puts a number in it. */
+/** The target. Empty until you or the Chat puts a number in it. */
 export function PlanLength({ words, voice }: PlanLengthProps) {
 	return (
 		<div className="flex items-center gap-2.5">
@@ -23,7 +23,7 @@ export function PlanLength({ words, voice }: PlanLengthProps) {
 				value={words ? `${words.toLocaleString()} words` : undefined}
 				placeholder="words —"
 			/>
-			{voice ? <Chip tone="outline">voice: {voice}</Chip> : null}
+			{voice ? <Chip variant="outline">voice: {voice}</Chip> : null}
 		</div>
 	)
 }
@@ -38,14 +38,14 @@ export interface PlanBlockProps {
 export function PlanBlock({ title, meta, children, className }: PlanBlockProps) {
 	return (
 		<div className={cx('flex flex-col gap-2', className)}>
-			<PaneHeader title={title} meta={meta} />
+			<PanelHeader title={title} meta={meta} />
 			{children}
 		</div>
 	)
 }
 
 export interface PlanOutlineProps {
-	sections: OutlineSection[]
+	sections: Section[]
 	/** A section still being typed in by hand. */
 	typing?: string
 	dense?: boolean
@@ -96,30 +96,34 @@ export function PlanOutline({
 }
 
 export interface PlanReferencesProps {
-	sources: Source[]
-	/** Marks the source that has just crossed over from the chat. */
+	references: Reference[]
+	/** Marks the reference that has just crossed over from the chat. */
 	justAddedId?: string
 }
 
-export function PlanReferences({ sources, justAddedId }: PlanReferencesProps) {
+export function PlanReferences({ references, justAddedId }: PlanReferencesProps) {
 	return (
 		<div className="flex flex-col gap-1.5">
-			{sources.map((source) => (
+			{references.map((reference) => (
 				<div
-					key={source.id}
+					key={reference.id}
 					className={cx(
 						'flex flex-col gap-0.5 rounded-md border p-2',
-						source.id === justAddedId
+						reference.id === justAddedId
 							? 'border-accent-edge bg-accent-soft'
 							: 'border-edge bg-surface',
 					)}
 				>
-					{source.id === justAddedId ? <p className="label-meta">★ just added</p> : null}
+					{reference.id === justAddedId ? (
+						<p className="label-meta">★ just added</p>
+					) : null}
 					<p className="text-[0.75rem] leading-snug font-medium text-ink">
-						{source.title}
+						{reference.title}
 					</p>
 					<p className="text-[0.6875rem] text-faint">
-						{[source.outlet, source.year, source.section].filter(Boolean).join(' · ')}
+						{[reference.outlet, reference.year, reference.section]
+							.filter(Boolean)
+							.join(' · ')}
 					</p>
 				</div>
 			))}

--- a/src/client/screens/article/PlanRail.tsx
+++ b/src/client/screens/article/PlanRail.tsx
@@ -1,10 +1,10 @@
 import { Chip } from '../../components/Chip'
 import { ProgressBar } from '../../components/ProgressBar'
 import { cx } from '../../lib/cx'
-import type { OutlineSection } from '../../mock/content'
+import type { Section } from '../../mock/content'
 
 export interface PlanRailProps {
-	sections: OutlineSection[]
+	sections: Section[]
 	/** Written words per section, in the same order. */
 	written: number[]
 	/** Chips at the foot of the rail: refs, quotes, notes. */
@@ -46,7 +46,7 @@ export function PlanRail({ sections, written, counts, className }: PlanRailProps
 						<ProgressBar
 							value={written[i] / section.words}
 							label={`${section.title} progress`}
-							tone={written[i] / section.words > 1 ? 'attention' : 'quiet'}
+							variant={written[i] / section.words > 1 ? 'attention' : 'quiet'}
 						/>
 					</div>
 				)
@@ -60,7 +60,7 @@ export function PlanRail({ sections, written, counts, className }: PlanRailProps
 			{counts?.length ? (
 				<div className="flex flex-wrap gap-1.5">
 					{counts.map((count) => (
-						<Chip key={count} tone="outline">
+						<Chip key={count} variant="outline">
 							{count}
 						</Chip>
 					))}

--- a/src/client/screens/article/PlanSheetScreen.tsx
+++ b/src/client/screens/article/PlanSheetScreen.tsx
@@ -4,14 +4,14 @@ import { Chip } from '../../components/Chip'
 import { Divider } from '../../components/Divider'
 import { Frame, FrameBody } from '../../components/Frame'
 import { LengthBar } from '../../components/LengthBar'
-import { Pane, PaneHeader } from '../../components/Pane'
+import { Panel, PanelHeader } from '../../components/Panel'
 import { QuoteRow } from '../../components/QuoteRow'
-import { ARTICLE_TITLE, outline, quotes, sources } from '../../mock/content'
+import { ARTICLE_TITLE, outline, quotes, references } from '../../mock/content'
 import { PlanOutline } from './PlanBlocks'
 
 /**
  * 2(e) — The plan on its own, full width. Outline, references and quotes are
- * stacked rather than columned: within a phase the eye should only travel
+ * stacked rather than columned: within a status the eye should only travel
  * down. The bar beside the outline is the shape of the piece — each section's
  * height is its share of the 2,400 words.
  */
@@ -20,12 +20,12 @@ export function PlanSheetScreen() {
 		<Frame width={680}>
 			<ArticleBar title={ARTICLE_TITLE} open={['plan']} status="draft 1" />
 			<FrameBody>
-				<Pane className="gap-5 p-5">
+				<Panel className="gap-5 p-5">
 					<section className="flex flex-col gap-3">
-						<PaneHeader
+						<PanelHeader
 							title="Outline"
 							meta="2,400 words target"
-							actions={<Chip tone="outline">voice: Reported feature</Chip>}
+							actions={<Chip variant="outline">voice: Reported feature</Chip>}
 						/>
 						<div className="flex items-start gap-5">
 							<PlanOutline sections={outline} className="flex-1" />
@@ -47,21 +47,21 @@ export function PlanSheetScreen() {
 					<Divider weight="strong" />
 
 					<section className="flex flex-col gap-3">
-						<PaneHeader title="References" meta="12 · 9 kept" />
+						<PanelHeader title="References" meta="12 · 9 kept" />
 						<div className="grid grid-cols-3 gap-2.5">
-							{[sources[0], sources[1], sources[3]].map((source) => (
+							{[references[0], references[1], references[3]].map((reference) => (
 								<div
-									key={source.id}
+									key={reference.id}
 									className="flex flex-col gap-1 rounded-md border border-edge bg-sunk p-2.5"
 								>
 									<p className="text-[0.75rem] leading-snug font-medium text-ink">
-										{source.title}
+										{reference.title}
 									</p>
 									<p className="text-[0.6875rem] text-faint">
-										{[source.outlet, source.year].filter(Boolean).join(' · ')}
+										{[reference.outlet, reference.year].filter(Boolean).join(' · ')}
 									</p>
 									<p className="mt-auto pt-1 text-[0.6875rem] text-muted">
-										{source.section ?? 'unassigned'}
+										{reference.section ?? 'unassigned'}
 									</p>
 								</div>
 							))}
@@ -71,7 +71,7 @@ export function PlanSheetScreen() {
 					<Divider weight="strong" />
 
 					<section className="flex flex-col gap-3">
-						<PaneHeader title="Quotes" meta="8 saved" />
+						<PanelHeader title="Quotes" meta="8 saved" />
 						<div className="flex flex-col gap-3">
 							{quotes.map((quote) => (
 								<QuoteRow key={quote.id} quote={quote} />
@@ -83,9 +83,9 @@ export function PlanSheetScreen() {
 					</section>
 
 					<div className="flex items-center gap-3 pt-1">
-						<Button tone="accent">start writing →</Button>
+						<Button variant="accent">start writing →</Button>
 					</div>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/ReadyToDraftScreen.tsx
+++ b/src/client/screens/article/ReadyToDraftScreen.tsx
@@ -2,13 +2,13 @@ import { ArticleBar } from '../../components/ArticleBar'
 import { Button } from '../../components/Button'
 import { ChatComposer, ChatMessage } from '../../components/Chat'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Pane } from '../../components/Pane'
+import { Panel } from '../../components/Panel'
 import { ARTICLE_TITLE, outline } from '../../mock/content'
 import { PlanBlock, PlanLength, PlanOutline } from './PlanBlocks'
 
 /**
- * 2(c) — Scrolled to the end of the conversation. "Start drafting" appears
- * once the plan has a length and at least one section. It is a suggestion, not
+ * 2(c) — Scrolled to the end of the chat. "Start drafting" appears
+ * once the plan has a length and at least one section. It is a nudge, not
  * a gate: the draft pill was available all along.
  */
 export function ReadyToDraftScreen() {
@@ -16,24 +16,24 @@ export function ReadyToDraftScreen() {
 		<Frame width={780}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
 			<FrameBody row className="min-h-[21rem]">
-				<Pane divider="right" className="gap-3">
+				<Panel divider="right" className="gap-3">
 					<p className="text-center text-[0.6875rem] text-faint">
-						↑ earlier in this conversation
+						↑ earlier in this chat
 					</p>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						That gives §3 the human cost and keeps the numbers in §2 where they belong.
 					</ChatMessage>
 					<ChatMessage from="me">
 						Good. Leave §4 short — I don't want to write a manifesto.
 					</ChatMessage>
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						Four sections, 2,400 words, thirteen references and eight quotes saved. Ready
 						when you are.
 					</ChatMessage>
 					<ChatComposer />
-				</Pane>
+				</Panel>
 
-				<Pane tone="sunk" padded={false}>
+				<Panel variant="sunk" padded={false}>
 					<div className="flex flex-1 flex-col gap-3.5 p-3.5">
 						<PlanLength words={2400} />
 						<PlanBlock title="Outline" meta="4 sections">
@@ -42,10 +42,10 @@ export function ReadyToDraftScreen() {
 						<p className="text-[0.75rem] text-muted">13 references · 8 quotes</p>
 					</div>
 					<div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
-						<Button tone="accent">start drafting →</Button>
+						<Button variant="accent">start drafting →</Button>
 						<span className="text-[0.75rem] text-faint">or keep talking</span>
 					</div>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/finish/ArchiveScreen.tsx
+++ b/src/client/screens/finish/ArchiveScreen.tsx
@@ -1,5 +1,5 @@
 import { Button } from '../../components/Button'
-import { SectionHeading } from '../../components/Divider'
+import { GroupHeading } from '../../components/Divider'
 import { Field } from '../../components/Field'
 import { Frame, FrameBody } from '../../components/Frame'
 import { MetaLabel } from '../../components/MetaLabel'
@@ -20,7 +20,7 @@ export function ArchiveScreen() {
 			/>
 			<FrameBody className="gap-4 p-4">
 				<section className="flex flex-col gap-2.5">
-					<SectionHeading count={2}>Submitted</SectionHeading>
+					<GroupHeading count={2}>Submitted</GroupHeading>
 					<div className="flex flex-col gap-2.5 rounded-lg border border-edge p-3">
 						<div className="flex items-baseline gap-2.5">
 							<h3 className="text-[0.875rem] font-semibold text-ink">
@@ -31,7 +31,7 @@ export function ArchiveScreen() {
 							</span>
 						</div>
 						<div className="flex items-center gap-2.5">
-							<Button tone="accent" size="sm">
+							<Button variant="accent" size="sm">
 								mark published
 							</Button>
 							<Field size="sm" placeholder="where it ran (url)" className="flex-1" />
@@ -44,7 +44,7 @@ export function ArchiveScreen() {
 				</section>
 
 				<section className="flex flex-col gap-2.5">
-					<SectionHeading count={9}>Published</SectionHeading>
+					<GroupHeading count={9}>Published</GroupHeading>
 					<div className="grid grid-cols-2 gap-2.5">
 						{publishedArticles.map((article) => (
 							<article

--- a/src/client/screens/finish/FinishScreen.tsx
+++ b/src/client/screens/finish/FinishScreen.tsx
@@ -2,7 +2,7 @@ import { Button } from '../../components/Button'
 import { Chip } from '../../components/Chip'
 import { Frame, FrameBody } from '../../components/Frame'
 import { MetaLabel } from '../../components/MetaLabel'
-import { Pane } from '../../components/Pane'
+import { Panel } from '../../components/Panel'
 import { TitleBar } from '../../components/TitleBar'
 import { ARTICLE_TITLE } from '../../mock/content'
 
@@ -16,15 +16,15 @@ export function FinishScreen() {
 		<Frame width={560}>
 			<TitleBar back={ARTICLE_TITLE} title="Finish" />
 			<FrameBody>
-				<Pane className="gap-4 p-4">
+				<Panel className="gap-4 p-4">
 					<div className="flex items-center gap-2">
-						<Chip tone="solid" interactive>
+						<Chip variant="solid" interactive>
 							markdown
 						</Chip>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							html
 						</Chip>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							docx
 						</Chip>
 						<span className="ml-1 text-[0.75rem] text-faint">footnotes included</span>
@@ -34,15 +34,15 @@ export function FinishScreen() {
 						<MetaLabel>House style — footnote template</MetaLabel>
 						<div className="flex flex-col gap-2 rounded-md border border-edge bg-sunk p-2.5">
 							<div className="flex flex-wrap items-center gap-1.5">
-								<Chip tone="default">author</Chip>
+								<Chip variant="default">author</Chip>
 								<span className="text-[0.75rem] text-muted">,</span>
-								<Chip tone="default">title</Chip>
+								<Chip variant="default">title</Chip>
 								<span className="text-[0.75rem] text-muted">,</span>
-								<Chip tone="default">publication</Chip>
+								<Chip variant="default">publication</Chip>
 								<span className="text-[0.75rem] text-muted">(</span>
-								<Chip tone="default">date</Chip>
+								<Chip variant="default">date</Chip>
 								<span className="text-[0.75rem] text-muted">),</span>
-								<Chip tone="default">url</Chip>
+								<Chip variant="default">url</Chip>
 							</div>
 							<p className="text-[0.6875rem] text-faint">
 								Drag the fields into order; type literal text between them.
@@ -67,30 +67,30 @@ export function FinishScreen() {
 					<div className="flex flex-wrap gap-2">
 						<Button>download</Button>
 						<Button>copy</Button>
-						<Button tone="accent">mark as sent →</Button>
+						<Button variant="accent">mark as sent →</Button>
 					</div>
 
 					<div className="flex items-center gap-3 rounded-md border border-edge bg-sunk p-2.5">
 						<div className="flex min-w-0 flex-1 flex-col gap-1.5">
 							<MetaLabel>Remind me to chase it</MetaLabel>
 							<div className="flex flex-wrap gap-1.5">
-								<Chip tone="outline" interactive>
+								<Chip variant="outline" interactive>
 									3 days
 								</Chip>
-								<Chip tone="default" interactive>
+								<Chip variant="default" interactive>
 									1 week
 								</Chip>
-								<Chip tone="outline" interactive>
+								<Chip variant="outline" interactive>
 									2 weeks
 								</Chip>
-								<Chip tone="outline" interactive>
+								<Chip variant="outline" interactive>
 									a date…
 								</Chip>
 							</div>
 						</div>
 						<Button size="sm">set</Button>
 					</div>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/finish/ShowcaseScreen.tsx
+++ b/src/client/screens/finish/ShowcaseScreen.tsx
@@ -51,7 +51,7 @@ export function ShowcaseScreen() {
 
 				<div className="flex items-center gap-2.5 border-t border-edge pt-3">
 					<span className="text-[0.75rem] text-muted">joarness.app/em</span>
-					<Chip tone="accent" className="ml-auto">
+					<Chip variant="accent" className="ml-auto">
 						public · on
 					</Chip>
 				</div>

--- a/src/client/screens/global/BoardScreen.tsx
+++ b/src/client/screens/global/BoardScreen.tsx
@@ -13,7 +13,7 @@ const columns = [
 ] as const
 
 /**
- * 1(b) — Board by phase. A familiar layout for the same articles; the only
+ * 1(b) — Board by status. A familiar layout for the same articles; the only
  * thing it adds over the desk is where each piece sits in the loop.
  */
 export function BoardScreen() {
@@ -22,12 +22,12 @@ export function BoardScreen() {
 			<TitleBar
 				back="Desk"
 				title="Board"
-				subtitle="by phase"
+				subtitle="by status"
 				actions={<Button size="sm">+ new</Button>}
 			/>
 			<FrameBody row className="gap-3 p-4">
 				{columns.map((column) => {
-					const items = activeArticles.filter((article) => article.phase === column.key)
+					const items = activeArticles.filter((article) => article.status === column.key)
 					return (
 						<div key={column.key} className="flex min-w-0 flex-1 flex-col gap-2">
 							<MetaLabel count={items.length}>{column.label}</MetaLabel>

--- a/src/client/screens/global/DeskScreen.tsx
+++ b/src/client/screens/global/DeskScreen.tsx
@@ -1,6 +1,6 @@
 import { ArticleCard } from '../../components/ArticleCard'
 import { Button } from '../../components/Button'
-import { SectionHeading } from '../../components/Divider'
+import { GroupHeading } from '../../components/Divider'
 import { Frame, FrameBody } from '../../components/Frame'
 import { ListRow } from '../../components/ListRow'
 import { TitleBar } from '../../components/TitleBar'
@@ -17,7 +17,7 @@ export function DeskScreen() {
 				title="Desk"
 				actions={
 					<>
-						<Button tone="quiet" size="sm">
+						<Button variant="quiet" size="sm">
 							settings
 						</Button>
 						<Button size="sm">+ new article</Button>
@@ -26,16 +26,16 @@ export function DeskScreen() {
 			/>
 			<FrameBody className="gap-6 p-4">
 				<div className="flex flex-col gap-3">
-					<SectionHeading
+					<GroupHeading
 						count={activeArticles.length}
 						action={
-							<Button tone="quiet" size="sm">
+							<Button variant="quiet" size="sm">
 								board view
 							</Button>
 						}
 					>
 						In progress
-					</SectionHeading>
+					</GroupHeading>
 					<div className="flex flex-wrap gap-3">
 						{activeArticles.map((article) => (
 							<ArticleCard key={article.id} article={article} />
@@ -44,17 +44,17 @@ export function DeskScreen() {
 				</div>
 
 				<div className="flex flex-col gap-1">
-					<SectionHeading
+					<GroupHeading
 						count={24}
 						action={
-							<Button tone="link" size="sm">
+							<Button variant="link" size="sm">
 								see all drafts
 							</Button>
 						}
 						className="mb-1.5"
 					>
 						Older drafts
-					</SectionHeading>
+					</GroupHeading>
 					{olderDrafts.map((draft) => (
 						<ListRow
 							key={draft.id}
@@ -68,14 +68,14 @@ export function DeskScreen() {
 				</div>
 
 				<div className="flex flex-col gap-1">
-					<SectionHeading
+					<GroupHeading
 						count={9}
 						action={
 							<span className="flex items-center gap-3">
-								<Button tone="link" size="sm">
+								<Button variant="link" size="sm">
 									portfolio
 								</Button>
-								<Button tone="link" size="sm">
+								<Button variant="link" size="sm">
 									see all
 								</Button>
 							</span>
@@ -83,7 +83,7 @@ export function DeskScreen() {
 						className="mb-1.5"
 					>
 						Published
-					</SectionHeading>
+					</GroupHeading>
 					{publishedArticles.map((article) => (
 						<ListRow
 							key={article.id}

--- a/src/client/screens/global/FavouriteSourcesScreen.tsx
+++ b/src/client/screens/global/FavouriteSourcesScreen.tsx
@@ -33,9 +33,9 @@ export function FavouriteSourcesScreen() {
 				<div className="flex flex-col gap-2">
 					<PolarityHeading polarity="yes">Prefer for</PolarityHeading>
 					<div className="flex flex-wrap gap-1.5">
-						<Chip tone="outline">policy</Chip>
-						<Chip tone="outline">primary data</Chip>
-						<Chip tone="outline">interviews</Chip>
+						<Chip variant="outline">policy</Chip>
+						<Chip variant="outline">primary data</Chip>
+						<Chip variant="outline">interviews</Chip>
 					</div>
 				</div>
 				<div className="flex flex-col gap-2">
@@ -51,7 +51,7 @@ export function FavouriteSourcesScreen() {
 			<div className="flex flex-col gap-2">
 				<MetaLabel count="14 times">Pulled in research</MetaLabel>
 				<div className="flex items-center gap-2.5">
-					<Chip tone="accent">★ rank first</Chip>
+					<Chip variant="accent">★ rank first</Chip>
 					<p className="text-[0.75rem] text-muted">
 						Ahead of equally relevant results, never instead of better ones.
 					</p>

--- a/src/client/screens/global/SettingsShell.tsx
+++ b/src/client/screens/global/SettingsShell.tsx
@@ -48,7 +48,7 @@ export function SettingsShell({
 				back="Desk"
 				title="Writer settings"
 				actions={TABS.map((name) => (
-					<Chip key={name} tone={name === tab ? 'solid' : 'outline'} interactive>
+					<Chip key={name} variant={name === tab ? 'solid' : 'outline'} interactive>
 						{name}
 					</Chip>
 				))}
@@ -106,7 +106,7 @@ export interface RuleBlockProps {
 	children: ReactNode
 }
 
-/** The prompt / definition box: what the agent is actually handed. */
+/** The prompt / definition box: what the Guide is actually handed. */
 export function RuleBlock({ label, children }: RuleBlockProps) {
 	return (
 		<div className="flex flex-col gap-1.5">
@@ -134,7 +134,7 @@ export function ScoreTest({ score, paragraph }: ScoreTestProps) {
 				<p className="label-meta">Paste to test a paragraph</p>
 				<p className="truncate text-[0.75rem] text-muted">{paragraph}</p>
 			</div>
-			<Chip tone="accent">{score}</Chip>
+			<Chip variant="accent">{score}</Chip>
 		</div>
 	)
 }

--- a/src/client/screens/global/TableScreen.tsx
+++ b/src/client/screens/global/TableScreen.tsx
@@ -52,13 +52,13 @@ export function TableScreen() {
 				title="All articles"
 				actions={
 					<>
-						<Chip tone="solid" interactive>
+						<Chip variant="solid" interactive>
 							open
 						</Chip>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							drafts
 						</Chip>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							published
 						</Chip>
 					</>
@@ -81,7 +81,7 @@ export function TableScreen() {
 						</span>
 						<span className="w-20">
 							{row.attention ? (
-								<Chip tone="accent">{row.status}</Chip>
+								<Chip variant="accent">{row.status}</Chip>
 							) : (
 								<span className="text-[0.75rem] text-muted">{row.status}</span>
 							)}

--- a/src/client/screens/global/VoicesScreen.tsx
+++ b/src/client/screens/global/VoicesScreen.tsx
@@ -7,7 +7,7 @@ import {
 } from './SettingsShell'
 
 /**
- * 1(d) — Settings · voices. A voice is a tiny prompt that tells an agent how
+ * 1(d) — Settings · voices. A Voice is a tiny prompt that tells the Guide how
  * to assess a piece of writing. An article has a dominant one; sections can
  * override it.
  */
@@ -27,7 +27,7 @@ export function VoicesScreen() {
 		>
 			<SettingsDetailHeader title="Reported feature" usage="4 articles · 2 sections" />
 
-			<RuleBlock label="Prompt — how an agent assesses this style">
+			<RuleBlock label="Prompt — how the Guide assesses this Voice">
 				Reported, not argued. Every claim is attributed in the sentence that makes it.
 				Scene before analysis. Sentences average under twenty-five words; no more than one
 				subordinate clause deep. First person is allowed but rationed — roughly once a

--- a/src/client/screens/review/FullReviewScreen.tsx
+++ b/src/client/screens/review/FullReviewScreen.tsx
@@ -3,17 +3,17 @@ import { Button } from '../../components/Button'
 import { Check } from '../../components/Check'
 import { Frame, FrameBody } from '../../components/Frame'
 import { MetaLabel } from '../../components/MetaLabel'
-import { Pane, PaneHeader } from '../../components/Pane'
+import { Panel, PanelHeader } from '../../components/Panel'
 import { ARTICLE_TITLE } from '../../mock/content'
 
-interface Finding {
+interface Note {
 	id: string
 	text: string
 	anchor: string
 	accepted?: boolean
 }
 
-const structure: Finding[] = [
+const structure: Note[] = [
 	{
 		id: 'f1',
 		text: 'The crane-index image carries §1 and then carries §4 again. The second use costs you the ending.',
@@ -27,11 +27,11 @@ const structure: Finding[] = [
 	},
 ]
 
-const other: Finding[] = [
+const other: Note[] = [
 	{
 		id: 'f3',
 		text: '§3 drifts into Newsletter aside — three asides in four paragraphs, where the piece is marked Reported feature.',
-		anchor: 'voice',
+		anchor: 'tone drift',
 	},
 	{
 		id: 'f4',
@@ -40,15 +40,15 @@ const other: Finding[] = [
 	},
 ]
 
-function FindingRow({ finding }: { finding: Finding }) {
+function NoteRow({ note }: { note: Note }) {
 	return (
 		<li className="flex items-start gap-2.5">
-			<Check checked={finding.accepted} label={`Accept: ${finding.text}`} />
+			<Check checked={note.accepted} label={`Accept: ${note.text}`} />
 			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-				<p className="text-[0.8125rem] leading-relaxed text-ink">{finding.text}</p>
+				<p className="text-[0.8125rem] leading-relaxed text-ink">{note.text}</p>
 				<p className="text-[0.6875rem] text-faint">
-					{finding.anchor}
-					{finding.accepted ? ' · accepted' : ''}
+					{note.anchor}
+					{note.accepted ? ' · accepted' : ''}
 				</p>
 			</div>
 		</li>
@@ -65,8 +65,8 @@ export function FullReviewScreen() {
 		<Frame width={720}>
 			<ArticleBar title={ARTICLE_TITLE} open={['notes']} status="round 2" />
 			<FrameBody>
-				<Pane className="gap-4 p-5">
-					<PaneHeader title="Review of draft 2" meta="2,610 words · 6 findings" />
+				<Panel className="gap-4 p-5">
+					<PanelHeader title="Review of draft 2" meta="2,610 words · 6 notes" />
 
 					<div className="flex flex-col gap-1.5">
 						<MetaLabel>The shape of it</MetaLabel>
@@ -81,26 +81,26 @@ export function FullReviewScreen() {
 						<section className="flex flex-col gap-2.5">
 							<MetaLabel count={2}>Structure</MetaLabel>
 							<ul className="flex flex-col gap-2.5">
-								{structure.map((finding) => (
-									<FindingRow key={finding.id} finding={finding} />
+								{structure.map((note) => (
+									<NoteRow key={note.id} note={note} />
 								))}
 							</ul>
 						</section>
 						<section className="flex flex-col gap-2.5">
-							<MetaLabel>Voice · 1 · Citations · 3</MetaLabel>
+							<MetaLabel>Tone drift · 1 · Citations · 3</MetaLabel>
 							<ul className="flex flex-col gap-2.5">
-								{other.map((finding) => (
-									<FindingRow key={finding.id} finding={finding} />
+								{other.map((note) => (
+									<NoteRow key={note.id} note={note} />
 								))}
 							</ul>
 						</section>
 					</div>
 
 					<div className="flex items-center gap-2.5 border-t border-edge pt-3.5">
-						<Button tone="accent">keep 3, back to the draft →</Button>
+						<Button variant="accent">keep 3, back to the draft →</Button>
 						<Button>send notes to chat</Button>
 					</div>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/review/NotesToChatScreen.tsx
+++ b/src/client/screens/review/NotesToChatScreen.tsx
@@ -1,10 +1,10 @@
 import { ArticleBar } from '../../components/ArticleBar'
 import { Button } from '../../components/Button'
-import { ChatComposer, ChatMessage, ChatSuggestions } from '../../components/Chat'
+import { ChatComposer, ChatMessage, ChatReplies } from '../../components/Chat'
 import { Chip } from '../../components/Chip'
 import { Frame, FrameBody } from '../../components/Frame'
 import { MetaLabel } from '../../components/MetaLabel'
-import { Pane, PaneHeader } from '../../components/Pane'
+import { Panel, PanelHeader } from '../../components/Panel'
 import { ARTICLE_TITLE, outlineRevised } from '../../mock/content'
 import { PlanOutline } from '../article/PlanBlocks'
 
@@ -19,7 +19,7 @@ export function NotesToChatScreen() {
 		<Frame width={800}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="after review 2" />
 			<FrameBody row className="min-h-[21rem]">
-				<Pane divider="right" className="gap-3">
+				<Panel divider="right" className="gap-3">
 					<ChatMessage from="me">
 						<MetaLabel className="mb-1.5">4 accepted notes, pasted in</MetaLabel>
 						<ol className="flex list-decimal flex-col gap-1 pl-4">
@@ -30,33 +30,33 @@ export function NotesToChatScreen() {
 						</ol>
 					</ChatMessage>
 
-					<ChatMessage from="agent">
+					<ChatMessage from="guide">
 						Notes 1 and 2 are the same problem: §3 is doing §4's job. If §3 loses the
 						throughput quote and §4 absorbs the argument, the unused quotes stop being
-						unused — one gets cut for good. Want me to redo the outline that way?
+						unused — one gets declined for good. Want me to redo the outline that way?
 					</ChatMessage>
 
-					<ChatSuggestions>
-						<Chip tone="accent" interactive>
+					<ChatReplies>
+						<Chip variant="accent" interactive>
 							yes, update the plan
 						</Chip>
-						<Chip tone="outline" interactive>
+						<Chip variant="outline" interactive>
 							leave it, I'll do it
 						</Chip>
-					</ChatSuggestions>
+					</ChatReplies>
 
 					<ChatComposer />
-				</Pane>
+				</Panel>
 
-				<Pane tone="sunk" padded={false}>
+				<Panel variant="sunk" padded={false}>
 					<div className="flex flex-1 flex-col gap-3.5 p-3.5">
-						<PaneHeader title="Plan" meta="revised just now" />
+						<PanelHeader title="Plan" meta="revised just now" />
 						<PlanOutline sections={outlineRevised} dense changedFrom={3} />
 
 						<div className="flex flex-col gap-2">
 							<MetaLabel>Quotes</MetaLabel>
 							<div className="flex items-center gap-2.5">
-								<Chip tone="accent">3 / 4</Chip>
+								<Chip variant="accent">3 / 4</Chip>
 								<span className="text-[0.75rem] text-faint">was 3 / 5</span>
 							</div>
 							<div className="flex items-start gap-2.5 opacity-55">
@@ -75,7 +75,7 @@ export function NotesToChatScreen() {
 						<Button>back to the draft →</Button>
 						<span className="text-[0.75rem] text-faint">round 3 whenever</span>
 					</div>
-				</Pane>
+				</Panel>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/review/PanelCombosScreen.tsx
+++ b/src/client/screens/review/PanelCombosScreen.tsx
@@ -1,74 +1,74 @@
 import { Frame, FrameBody } from '../../components/Frame'
-import { PaneRail, type PaneId } from '../../components/PaneRail'
+import { PanelRail, type PanelId } from '../../components/PanelRail'
 import { cx } from '../../lib/cx'
 
 interface Combo {
-	open: PaneId[]
-	widths: Array<{ pane: PaneId; flex: number }>
+	open: PanelId[]
+	widths: Array<{ Panel: PanelId; flex: number }>
 }
 
 const combos: Combo[] = [
 	{
 		open: ['chat', 'plan'],
 		widths: [
-			{ pane: 'chat', flex: 1 },
-			{ pane: 'plan', flex: 1 },
+			{ Panel: 'chat', flex: 1 },
+			{ Panel: 'plan', flex: 1 },
 		],
 	},
 	{
 		open: ['plan', 'draft'],
 		widths: [
-			{ pane: 'plan', flex: 0.38 },
-			{ pane: 'draft', flex: 1 },
+			{ Panel: 'plan', flex: 0.38 },
+			{ Panel: 'draft', flex: 1 },
 		],
 	},
 	{
 		open: ['draft', 'notes'],
 		widths: [
-			{ pane: 'draft', flex: 1 },
-			{ pane: 'notes', flex: 0.26 },
+			{ Panel: 'draft', flex: 1 },
+			{ Panel: 'notes', flex: 0.26 },
 		],
 	},
 	{
 		open: ['chat', 'notes'],
 		widths: [
-			{ pane: 'chat', flex: 0.5 },
-			{ pane: 'notes', flex: 0.5 },
+			{ Panel: 'chat', flex: 0.5 },
+			{ Panel: 'notes', flex: 0.5 },
 		],
 	},
 	{
 		open: ['plan', 'draft', 'notes'],
 		widths: [
-			{ pane: 'plan', flex: 0.24 },
-			{ pane: 'draft', flex: 1 },
-			{ pane: 'notes', flex: 0.24 },
+			{ Panel: 'plan', flex: 0.24 },
+			{ Panel: 'draft', flex: 1 },
+			{ Panel: 'notes', flex: 0.24 },
 		],
 	},
 ]
 
 /**
- * 4(e) — Recap: which panes can be open at once. Order never changes, panes
- * never stack, and the two support panes are always the narrow ones.
+ * 4(e) — Recap: which Panels can be open at once. Order never changes, Panels
+ * never stack, and the two support Panels are always the narrow ones.
  */
-export function PaneCombosScreen() {
+export function PanelCombosScreen() {
 	return (
 		<Frame width={360}>
 			<FrameBody className="gap-4 p-4">
 				{combos.map((combo, i) => (
 					<div key={i} className="flex flex-col gap-2">
-						<PaneRail open={combo.open} />
+						<PanelRail open={combo.open} />
 						<div className="flex h-10 overflow-hidden rounded-md border border-edge">
-							{combo.widths.map(({ pane, flex }, j) => (
+							{combo.widths.map(({ Panel, flex }, j) => (
 								<div
-									key={pane}
+									key={Panel}
 									style={{ flex }}
 									className={cx(
 										'grid place-items-center text-[0.625rem] text-faint',
 										j > 0 && 'border-l border-edge',
-										pane === 'draft' ? 'bg-surface' : 'bg-sunk',
+										Panel === 'draft' ? 'bg-surface' : 'bg-sunk',
 									)}
 								>
-									{pane}
+									{Panel}
 								</div>
 							))}
 						</div>

--- a/src/client/screens/review/PanelsRecapScreen.tsx
+++ b/src/client/screens/review/PanelsRecapScreen.tsx
@@ -5,18 +5,18 @@ import { TitleBar } from '../../components/TitleBar'
 import { cx } from '../../lib/cx'
 import { ARTICLE_TITLE } from '../../mock/content'
 
-const layers = [
+const panels = [
 	{
 		n: 1,
 		name: 'Chat',
-		body: 'Research and suggestions. Nothing it produces reaches the prose directly.',
+		body: 'Research and Offers. Nothing it produces reaches the prose directly.',
 		flex: 1,
 		accent: false,
 	},
 	{
 		n: 2,
-		name: 'Plan & sources',
-		body: 'Outline, targets, voices, references, quotes. Editable by hand at any time.',
+		name: 'Plan',
+		body: 'Outline, targets, Tone, References, Quotes. Editable by hand at any time.',
 		flex: 1.15,
 		accent: false,
 	},
@@ -29,8 +29,8 @@ const layers = [
 	},
 	{
 		n: 4,
-		name: 'Coach',
-		body: 'Reads 3 against 2 and returns notes, which feed back into 2.',
+		name: 'Notes',
+		body: 'The Guide reads 3 against 2 and writes Guidance notes, which feed back into 2.',
 		flex: 1,
 		accent: true,
 	},
@@ -43,28 +43,28 @@ const states: Array<{ label: string; on: number[] }> = [
 	{ label: '"I\'m done" — the plan alone, zoomed, fill in the blanks', on: [2] },
 	{ label: 'Drafting — most of the time, this alone', on: [3] },
 	{ label: 'Checking myself against the plan', on: [2, 3] },
-	{ label: 'Drafting + coach — after a pause, or on demand', on: [3, 4] },
-	{ label: 'Review round — back to chat, the self-crit lands in layer 2', on: [1, 2] },
+	{ label: 'Drafting + the Guide — after a pause, or on demand', on: [3, 4] },
+	{ label: 'Review round — back to chat, the self-crit lands in Panel 2', on: [1, 2] },
 ]
 
 /**
- * 4(f) — Recap: what moves between the four panes. One horizontal rail; layers
+ * 4(f) — Recap: what moves between the four Panels. One horizontal rail; Panels
  * slide in and out beside each other and never stack.
  */
-export function LayersRecapScreen() {
+export function PanelsRecapScreen() {
 	return (
 		<Frame width={800}>
 			<TitleBar
 				title={ARTICLE_TITLE}
-				subtitle="one horizontal rail · layers slide, never stack"
+				subtitle="one horizontal rail · Panels slide, never stack"
 			/>
 			<FrameBody className="gap-5 p-4">
 				<div className="flex items-stretch">
-					{layers.map((layer, i) => (
+					{panels.map((panel, i) => (
 						<div
-							key={layer.n}
+							key={panel.n}
 							className="flex items-stretch"
-							style={{ flex: layer.flex }}
+							style={{ flex: panel.flex }}
 						>
 							{i > 0 ? (
 								<div className="flex w-14 shrink-0 flex-col items-center justify-center gap-1 px-1">
@@ -79,15 +79,15 @@ export function LayersRecapScreen() {
 							<div
 								className={cx(
 									'flex min-w-0 flex-1 flex-col gap-1.5 rounded-lg border p-2.5',
-									layer.accent
+									panel.accent
 										? 'border-accent-edge bg-accent-soft'
 										: 'border-edge bg-sunk',
 								)}
 							>
-								<MetaLabel>Layer {layer.n}</MetaLabel>
-								<h3 className="text-[0.875rem] font-semibold text-ink">{layer.name}</h3>
+								<MetaLabel>Panel {panel.n}</MetaLabel>
+								<h3 className="text-[0.875rem] font-semibold text-ink">{panel.name}</h3>
 								<p className="text-[0.6875rem] leading-relaxed text-muted">
-									{layer.body}
+									{panel.body}
 								</p>
 							</div>
 						</div>
@@ -99,13 +99,13 @@ export function LayersRecapScreen() {
 					{states.map((state) => (
 						<div key={state.label} className="flex items-center gap-3">
 							<div className="flex w-[8.5rem] shrink-0 gap-0.5">
-								{layers.map((layer) => (
+								{panels.map((panel) => (
 									<span
-										key={layer.n}
-										style={{ flex: layer.flex }}
+										key={panel.n}
+										style={{ flex: panel.flex }}
 										className={cx(
 											'h-2.5 rounded-sm',
-											state.on.includes(layer.n) ? 'bg-accent' : 'bg-rule',
+											state.on.includes(panel.n) ? 'bg-accent' : 'bg-rule',
 										)}
 									/>
 								))}
@@ -116,11 +116,11 @@ export function LayersRecapScreen() {
 				</div>
 
 				<div className="flex flex-wrap items-center gap-2">
-					<Chip tone="outline">outline</Chip>
-					<Chip tone="outline">voices</Chip>
-					<Chip tone="outline">refs</Chip>
+					<Chip variant="outline">Outline</Chip>
+					<Chip variant="outline">Tone</Chip>
+					<Chip variant="outline">References</Chip>
 					<span className="text-[0.6875rem] text-faint">
-						everything the coach knows about this piece lives in layer 2 — which is why
+						everything the Guide knows about this piece lives in Panel 2 — which is why
 						editing it by hand changes the advice
 					</span>
 				</div>

--- a/src/client/screens/review/PhoneNotesScreen.tsx
+++ b/src/client/screens/review/PhoneNotesScreen.tsx
@@ -1,11 +1,11 @@
 import { Chip } from '../../components/Chip'
-import { CoachNote } from '../../components/CoachNote'
 import { Frame, FrameBody } from '../../components/Frame'
+import { GuidanceNote } from '../../components/GuidanceNote'
 import { MetaLabel } from '../../components/MetaLabel'
 import { draftShort } from '../../mock/content'
 
 /**
- * 4(d) — The phone. A form factor, not a phase: read the draft, triage the
+ * 4(d) — The phone. A form factor, not a status: read the draft, triage the
  * notes, and nothing else. No writing happens here.
  */
 export function PhoneNotesScreen() {
@@ -17,18 +17,18 @@ export function PhoneNotesScreen() {
 			</div>
 			<FrameBody className="gap-3.5 px-3.5 pb-4">
 				<div className="flex gap-1.5">
-					<Chip tone="solid" interactive>
+					<Chip variant="solid" interactive>
 						notes 3
 					</Chip>
-					<Chip tone="outline" interactive>
+					<Chip variant="outline" interactive>
 						read
 					</Chip>
-					<Chip tone="outline" interactive>
+					<Chip variant="outline" interactive>
 						plan
 					</Chip>
 				</div>
 
-				<CoachNote
+				<GuidanceNote
 					anchor="§3"
 					confidence="confident"
 					live
@@ -36,16 +36,16 @@ export function PhoneNotesScreen() {
 					body="§3 is meant to move to the cost of the delay."
 					actions={
 						<>
-							<Chip tone="outline" interactive>
+							<Chip variant="outline" interactive>
 								accept
 							</Chip>
-							<Chip tone="muted" interactive>
+							<Chip variant="muted" interactive>
 								later
 							</Chip>
 						</>
 					}
 				/>
-				<CoachNote
+				<GuidanceNote
 					anchor="whole piece"
 					confidence="tentative"
 					title="220 words over target"

--- a/src/client/screens/review/ReviewRailScreen.tsx
+++ b/src/client/screens/review/ReviewRailScreen.tsx
@@ -8,8 +8,8 @@ import { MetaLabel } from '../../components/MetaLabel'
 import { ARTICLE_TITLE, draftParagraphs } from '../../mock/content'
 
 /**
- * 4(b) — Back in the draft with the review's findings in the rail. The
- * findings became a checklist; the prose has gone quiet behind it because you
+ * 4(b) — Back in the draft with the Review's notes in the rail. The
+ * notes became a checklist; the prose has gone quiet behind it because you
  * are reading, not writing, for a moment.
  */
 export function ReviewRailScreen() {
@@ -63,10 +63,10 @@ export function ReviewRailScreen() {
 									2 of 5 planned quotes unused
 								</p>
 								<div className="flex flex-wrap gap-1.5">
-									<Chip tone="outline" interactive>
+									<Chip variant="outline" interactive>
 										ledger
 									</Chip>
-									<Chip tone="muted" interactive>
+									<Chip variant="muted" interactive>
 										fine as is
 									</Chip>
 								</div>
@@ -76,7 +76,7 @@ export function ReviewRailScreen() {
 
 					<div className="mt-auto flex flex-wrap gap-2">
 						<Button size="sm">send notes to chat</Button>
-						<Button size="sm" tone="quiet">
+						<Button size="sm" variant="quiet">
 							finish →
 						</Button>
 					</div>

--- a/src/client/screens/review/Reviews.stories.tsx
+++ b/src/client/screens/review/Reviews.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react-vite'
 
 import { Annotation } from '../../components/Annotation'
 import { FullReviewScreen } from './FullReviewScreen'
-import { LayersRecapScreen } from './LayersRecapScreen'
 import { NotesToChatScreen } from './NotesToChatScreen'
-import { PaneCombosScreen } from './PaneCombosScreen'
+import { PanelCombosScreen } from './PanelCombosScreen'
+import { PanelsRecapScreen } from './PanelsRecapScreen'
 import { PhoneNotesScreen } from './PhoneNotesScreen'
 import { ReviewRailScreen } from './ReviewRailScreen'
 
@@ -23,14 +23,14 @@ export const A_FullReview: Story = {
 			<FullReviewScreen />
 			<Annotation>
 				Only this pass is full screen — you asked for it, so it gets the window once.
-				Accepted findings then live in the notes rail while you write.
+				Accepted notes then live in the Notes rail while you write.
 			</Annotation>
 		</div>
 	),
 }
 
 export const B_ReviewRail: Story = {
-	name: '4(b) Findings in the rail',
+	name: '4(b) Notes in the rail',
 	render: () => <ReviewRailScreen />,
 }
 
@@ -55,18 +55,18 @@ export const D_Phone: Story = {
 		<div className="flex flex-col">
 			<PhoneNotesScreen />
 			<Annotation>
-				A form factor, not a phase. Read and triage; no writing happens here.
+				A form factor, not a status. Read and triage; no writing happens here.
 			</Annotation>
 		</div>
 	),
 }
 
-export const E_PaneCombos: Story = {
-	name: '4(e) Recap · pane combinations',
-	render: () => <PaneCombosScreen />,
+export const E_PanelCombos: Story = {
+	name: '4(e) Recap · Panel combinations',
+	render: () => <PanelCombosScreen />,
 }
 
-export const F_LayersRecap: Story = {
-	name: '4(f) Recap · the four layers',
-	render: () => <LayersRecapScreen />,
+export const F_PanelsRecap: Story = {
+	name: '4(f) Recap · the four Panels',
+	render: () => <PanelsRecapScreen />,
 }

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -94,7 +94,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 				if (taken.has(id)) {
 					return refuse(
 						'invalid',
-						`${op.op} would leave two Outline nodes carrying the id ${id}.`,
+						`${op.op} would leave two Sections carrying the id ${id}.`,
 					)
 				}
 				taken.add(id)

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -118,7 +118,7 @@ function checkIds(plan: Plan, ctx: z.RefinementCtx) {
 	const walk = (nodes: OutlineNode[], path: Path) => {
 		nodes.forEach((node, index) => {
 			const nodePath = [...path, index]
-			claim(nodeIds, node.id, [...nodePath, 'id'], 'Outline nodes')
+			claim(nodeIds, node.id, [...nodePath, 'id'], 'Sections')
 			walk(node.children, [...nodePath, 'children'])
 		})
 	}
@@ -132,7 +132,7 @@ function checkIds(plan: Plan, ctx: z.RefinementCtx) {
 			ctx.addIssue({
 				code: 'custom',
 				path: ['references', index, 'nodeId'],
-				message: `Reference ${reference.id} is placed at ${reference.nodeId}, which no Outline node carries.`,
+				message: `Reference ${reference.id} is placed at ${reference.nodeId}, which no Section carries.`,
 			})
 		}
 	})

--- a/src/shared/plan/scope.ts
+++ b/src/shared/plan/scope.ts
@@ -5,7 +5,7 @@ import type { OutlineNode, Plan } from './schema'
  * Adjectives cascade and combine.
  */
 
-/** What one Scope states. Taken from the Outline node so the House, the Article,
+/** What one Scope states. Taken from the Section so the House, the Article,
  * and a node cannot drift apart as terms are added. */
 export type ScopeTerms = Pick<OutlineNode, 'voice' | 'adjectives'>
 
@@ -40,7 +40,7 @@ export function resolveArticleScope(plan: Plan, house: ScopeTerms = {}): Resolve
 	return resolveScope([house, plan])
 }
 
-/** What applies at one Outline node: House, the Article, then every ancestor
+/** What applies at one Section: House, the Article, then every ancestor
  * from the outermost down to the node itself. Returns null when the Plan
  * carries no node with that id. */
 export function resolveNodeScope(
@@ -54,7 +54,7 @@ export function resolveNodeScope(
 	return resolveScope([house, plan, ...path])
 }
 
-/** The chain of Outline nodes from the outermost down to `nodeId`, or null when
+/** The chain of Sections from the outermost down to `nodeId`, or null when
  * no node carries that id. The node itself is the last element. */
 export function findNodePath(
 	outline: readonly OutlineNode[],

--- a/test/shared/plan-fixtures.ts
+++ b/test/shared/plan-fixtures.ts
@@ -6,7 +6,7 @@ export function makePlan(overrides: Partial<Plan> = {}): Plan {
 	return { ...emptyPlan('The article'), ...overrides }
 }
 
-/** An Outline node. `children` is always present, so a test states only the
+/** An Section. `children` is always present, so a test states only the
  * fields it is about. */
 export function makeNode(node: Partial<OutlineNode> & { id: string }): OutlineNode {
 	return { title: `Node ${node.id}`, children: [], ...node }

--- a/test/shared/plan-schema.test.ts
+++ b/test/shared/plan-schema.test.ts
@@ -64,19 +64,19 @@ describe('the Plan schema', () => {
 		expect(planSchema.safeParse(makePlan({ adjectives: [''] })).success).toBe(false)
 	})
 
-	it('accepts an Outline node with an empty title, because one is typed after it is made', () => {
+	it('accepts a Section with an empty title, because one is typed after it is made', () => {
 		const plan = makePlan({ outline: [makeNode({ id: 'n1', title: '' })] })
 
 		expect(planSchema.safeParse(plan).success).toBe(true)
 	})
 
-	it('rejects an Outline node with no id', () => {
+	it('rejects a Section with no id', () => {
 		const plan = makePlan({ outline: [makeNode({ id: '' })] })
 
 		expect(planSchema.safeParse(plan).success).toBe(false)
 	})
 
-	it('holds an Outline node to the same field rules as the Plan', () => {
+	it('holds a Section to the same field rules as the Plan', () => {
 		const withNode = (fields: Partial<OutlineNode>) =>
 			planSchema.safeParse(makePlan({ outline: [makeNode({ id: 'n1', ...fields })] }))
 				.success
@@ -116,7 +116,7 @@ describe('the Plan schema', () => {
 		expect(firstIssuePath(result)).toBe('outline.0.children.0.children.0.target')
 	})
 
-	it('rejects two Outline nodes carrying one id, however deep', () => {
+	it('rejects two Sections carrying one id, however deep', () => {
 		const plan = makePlan({
 			outline: [
 				makeNode({ id: 'n1', children: [makeNode({ id: 'shared' })] }),
@@ -142,7 +142,7 @@ describe('the Plan schema', () => {
 		expect(firstIssuePath(result)).toBe('references.1.id')
 	})
 
-	it('rejects a Reference placed at an Outline node that is not there', () => {
+	it('rejects a Reference placed at a Section that is not there', () => {
 		const plan = makePlan({
 			outline: [makeNode({ id: 'n1' })],
 			references: [

--- a/test/shared/plan-scope.test.ts
+++ b/test/shared/plan-scope.test.ts
@@ -51,7 +51,7 @@ describe('the Scope resolver', () => {
 		})
 	})
 
-	it('lets the nearest Outline node win the Voice outright, across all three Scopes', () => {
+	it('lets the nearest Section win the Voice outright, across all three Scopes', () => {
 		expect(resolveNodeScope(plan, 'n1', house)).toEqual({
 			voice: 'academic',
 			adjectives: ['well researched', 'funny', 'somber'],

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -16,7 +16,7 @@ function createOffer(name: string, content: OfferContent): Promise<Offer> {
 	return runInDurableObject(stub, (agent) => agent.createOffer(content))
 }
 
-/** A Plan that parses: one Outline node, and one Reference placed at it. */
+/** A Plan that parses: one Section, and one Reference placed at it. */
 const plan = makePlan({
 	title: 'The permit queue',
 	totalTarget: 1200,
@@ -96,7 +96,7 @@ describe('the Plan in Article Agent state', () => {
 		const frame = await writer.next('plan_refused')
 
 		expect(isPlanRefused(frame)).toBe(true)
-		expect(frame.error).toContain('which no Outline node carries')
+		expect(frame.error).toContain('which no Section carries')
 	})
 })
 


### PR DESCRIPTION
The showcase predates context.md and used words it forbids. Renaming it
turned up two collisions the dictionary had to settle first.

**Tone enters the dictionary** as the Voice and the Adjectives together —
the word a writer already has for the pair. That freed nothing on its own,
because `tone` was the design-system variant prop on Chip, Button,
ProgressBar, and Panel. Those become `variant`, which ArticleCard and
ReferenceCard already used for the same idea: which version of this
component to render.

**Section replaces Outline node**, and merges with the Draft-side Section
that context.md defined separately. One unit with a stored plan side and an
inferred prose side, because the writer has one thing in mind and the split
existed only for storage. Node stays as the code word: `OutlineNode` keeps
its name in the schema, and depth picks what the writer reads — 0 is a
Section, 1 is a Subsection, and a Chapter arrives if longer works ever do.
The Proposal op vocabulary is untouched.

The rest is the rename the showcase needed: pane to Panel, coach to Guide,
unqualified agent to the Guide or the Chat, the four layers to the four
Panels, findings to Guidance notes, cut to Declined, conversation to Chat,
and the Reference sense of "source" to Reference. The source that is an
attribution keeps the word, so the House's favourite publications and
authors are unchanged.

Files renamed: Pane, PaneRail, CoachNote, SourceCard, PaneCombosScreen,
LayersRecapScreen, ChatWithSourcesScreen, MidConversationScreen. Four
Storybook story names change with them; the deck numbers do not.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UK28hsunSc43jYSuSoh6Lr