### PR TITLE
#23/35 fixups: Sequence for Offers, rename Kind fields to Type

### DIFF
--- a/context.md
+++ b/context.md
@@ -141,8 +141,11 @@ least one of the two is present; an entry with neither is nothing.
 _Avoid_: source (a source is the attribution _inside_ a Reference), citation, cite
 
 **Quote**:
-A Reference that carries a text. Not a separate entity — the Plan Panel counts References
-and Quotes separately, and that is a display filter rather than a schema fact.
+A Reference of Kind Quote — a passage pulled from the source rather than the attribution
+alone. Not a separate entity: one structure carries both, and the Kind says which. A Quote
+carries a text, and a Reference may carry one without being a Quote, because the Kind is
+stored on the record rather than read off the text. That is what stops the Offer ledger
+and the Plan Panel naming one item two ways.
 _Avoid_: excerpt, passage, snippet, pull quote
 
 **Ledger**:

--- a/context.md
+++ b/context.md
@@ -128,7 +128,7 @@ _Avoid_: level, tier, inheritance chain
 ## Offers and the Ledger
 
 **Offer**:
-Something the Chat turns up and hands to the writer to rule on. Two Kinds so far,
+Something the Chat turns up and hands to the writer to rule on. Two types so far,
 References and Quotes, and Offers stay flat — two Quotes from one publication are two
 Offers, not a Quote nested in something else.
 _Avoid_: offering, result, finding, suggestion, candidate, card
@@ -141,9 +141,9 @@ least one of the two is present; an entry with neither is nothing.
 _Avoid_: source (a source is the attribution _inside_ a Reference), citation, cite
 
 **Quote**:
-A Reference of Kind Quote — a passage pulled from the source rather than the attribution
-alone. Not a separate entity: one structure carries both, and the Kind says which. A Quote
-carries a text, and a Reference may carry one without being a Quote, because the Kind is
+A Reference of type Quote — a passage pulled from the source rather than the attribution
+alone. Not a separate entity: one structure carries both, and the type says which. A Quote
+carries a text, and a Reference may carry one without being a Quote, because the type is
 stored on the record rather than read off the text. That is what stops the Offer ledger
 and the Plan Panel naming one item two ways.
 _Avoid_: excerpt, passage, snippet, pull quote
@@ -210,17 +210,19 @@ notes. The same model in dialogue is the Chat.
 _Avoid_: coach, assistant, agent (an Agent is a Durable Object class)
 
 **Guidance note**:
-One observation from the Guide — a Kind, an anchor to a Section or a paragraph range,
+One observation from the Guide — a type, an anchor to a Section or a paragraph range,
 and a body of one or two sentences. The unit that fills the Notes Panel.
 _Avoid_: finding, suggestion, comment, tip, feedback
 
-**Kind**:
-What sort of thing a record is. For a Guidance note: structure, tone drift, citations,
+**Type**:
+What sort of thing a record is, named after the record it belongs to — an Offer type, a
+note type, a refusal type. For a Guidance note: structure, tone drift, citations,
 repetition, budget, pacing, plan divergence — illustrative rather than a fixed taxonomy,
 and the Notes Panel groups by it. A note about the Voice and a note about an Adjective are
 both tone drift, because the writer reads them the same way. For an Offer: Reference,
-Quote, and whatever comes later.
-_Avoid_: category, type, tag, label
+Quote, and whatever comes later. The field is `type` throughout, and it reads the way the
+phrase does: `offer.type`, not "the kind of an Offer".
+_Avoid_: kind, category, tag, label
 
 **Review**:
 An intentional pass by the Guide over the whole Article or a chosen Scope, producing a

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -17,7 +17,7 @@ plan: {
   title, totalTarget,
   voice, adjectives: [],
   outline: [ { id, title, intent?, target?, voice?, adjectives?: [], children: [] } ],
-  references: [ { id, kind, provenance, text?, source?, nodeId, note? } ],
+  references: [ { id, type, provenance, text?, source?, nodeId, note? } ],
 }
 ```
 
@@ -78,18 +78,18 @@ carry, so deleting a node unplaces its References in the same Proposal.
 Adjectives took both an absent key and an empty list — and `docs/architecture.md` §4 now
 carries it as a rule of the data model.
 
-## Provenance names what kind of thing a Reference came from
+## Provenance names what sort of thing a Reference came from
 
-`{ kind: 'offer', offerId }` for a Reference copied from an Offer, and `{ kind: 'writer' }`
+`{ type: 'offer', offerId }` for a Reference copied from an Offer, and `{ type: 'writer' }`
 for one the writer typed in. The writer case has to be sayable: a Reference reaching the
 Plan without passing through the Chat is ordinary, and the Ledger deduplicates on
 Provenance, so "came from nowhere in particular" needs a name rather than an empty field.
 
-It is a flat object with a `kind` rather than a discriminated union, because `generateObject`
+It is a flat object with a `type` rather than a discriminated union, because `generateObject`
 handles a flat object more reliably than an `anyOf`. The pairing rule — `offer` names an
 `offerId` and `writer` names none — is a refinement instead.
 
-## A Quote is a Reference of that Kind
+## A Quote is a Reference of that type
 
 One structure, not two. It holds a `text` — a passage pulled from the source, whether a
 quotation, a clip, or a key pullout — or a `source` — the attribution, each field optional
@@ -97,17 +97,17 @@ inside it because a book has no url and a leaked memo has no author. **At least 
 two is present.**
 
 **Amended:** this section first said a Quote is a Reference that carries a text, and that
-the Plan Panel's separate counts are a display filter rather than a schema fact. The Kind
+the Plan Panel's separate counts are a display filter rather than a schema fact. The type
 is now a stored field on `referenceSchema`, and a Reference may carry a text without being
 a Quote.
 
-What changed the answer is that #23 gave the Offer a `kind` column, which the Ledger reads.
-Deriving the Kind in the Plan and storing it on the Offer means one item is labelled twice
-by two rules: Accepting a `kind: 'reference'` Offer that carries a text would drop the Kind
+What changed the answer is that #23 gave the Offer a `type` column, which the Ledger reads.
+Deriving the type in the Plan and storing it on the Offer means one item is labelled twice
+by two rules: Accepting a `type: 'reference'` Offer that carries a text would drop the type
 on the way in, and the Plan Panel would then call a Quote what the Ledger called a
 Reference. Storing it in both places is what removes the second rule.
 
-The cost is that the Kind can now be wrong in a way it could not be when it was derived —
+The cost is that the type can now be wrong in a way it could not be when it was derived —
 so `referenceSchema` refines that a Quote carries a text, and `offerContentSchema` refines
 the same for an Offer. `context.md` carries the vocabulary.
 

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -17,7 +17,7 @@ plan: {
   title, totalTarget,
   voice, adjectives: [],
   outline: [ { id, title, intent?, target?, voice?, adjectives?: [], children: [] } ],
-  references: [ { id, provenance, text?, source?, nodeId, note? } ],
+  references: [ { id, kind, provenance, text?, source?, nodeId, note? } ],
 }
 ```
 
@@ -89,13 +89,27 @@ It is a flat object with a `kind` rather than a discriminated union, because `ge
 handles a flat object more reliably than an `anyOf`. The pairing rule — `offer` names an
 `offerId` and `writer` names none — is a refinement instead.
 
-## A Quote is a Reference that carries a text
+## A Quote is a Reference of that Kind
 
 One structure, not two. It holds a `text` — a passage pulled from the source, whether a
 quotation, a clip, or a key pullout — or a `source` — the attribution, each field optional
 inside it because a book has no url and a leaked memo has no author. **At least one of the
-two is present.** The Plan Panel's separate "References" and "Quotes" counts are a display
-filter.
+two is present.**
+
+**Amended:** this section first said a Quote is a Reference that carries a text, and that
+the Plan Panel's separate counts are a display filter rather than a schema fact. The Kind
+is now a stored field on `referenceSchema`, and a Reference may carry a text without being
+a Quote.
+
+What changed the answer is that #23 gave the Offer a `kind` column, which the Ledger reads.
+Deriving the Kind in the Plan and storing it on the Offer means one item is labelled twice
+by two rules: Accepting a `kind: 'reference'` Offer that carries a text would drop the Kind
+on the way in, and the Plan Panel would then call a Quote what the Ledger called a
+Reference. Storing it in both places is what removes the second rule.
+
+The cost is that the Kind can now be wrong in a way it could not be when it was derived —
+so `referenceSchema` refines that a Quote carries a text, and `offerContentSchema` refines
+the same for an Offer. `context.md` carries the vocabulary.
 
 **Consequence:** three quotes from one publication carry three copies of the attribution,
 so correcting a year is three edits. This is the same denormalisation #11 accepted when it

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ plan: {
   title, totalTarget,
   voice, adjectives: [],
   outline: [ { id, title, intent?, target?, voice?, adjectives?: [], children: [] } ],
-  references: [ { id, kind, provenance, text?, source?, nodeId, note? } ],
+  references: [ { id, type, provenance, text?, source?, nodeId, note? } ],
 }
 ```
 
@@ -110,8 +110,8 @@ plan: {
   a stable ID that never changes.
 - **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
   Section or nowhere yet.
-- **A Quote is a Reference of that `kind`.** One structure: a pulled passage, an
-  attribution, or both, with at least one present. The Kind is **stored, not derived from
+- **A Quote is a Reference of that `type`.** One structure: a pulled passage, an
+  attribution, or both, with at least one present. The type is **stored, not derived from
   the text**, so an Offer and the Reference it was Accepted into carry one answer and the
   Offer ledger and the Plan Panel cannot label an item differently. A Quote carries a text;
   a Reference may carry one without being a Quote. Amended in
@@ -219,7 +219,7 @@ says so with a `setIntent` op in the same batch.
 
 **The applier refuses with a reason**, in `src/shared/plan/apply.ts`. `applyProposal` returns
 either a new Plan or a refusal naming which op failed, its position in the Proposal, and what
-it expected against what it found. It sorts refusals into four kinds, listed on `RefusalKind`
+it expected against what it found. It sorts refusals into four types, listed on `RefusalType`
 where they cannot drift away from the union. It also parses the Plan it produces, so a
 Proposal the Article Agent would reject is refused here, where there is a reason to show,
 rather than there, where there is none.
@@ -342,7 +342,7 @@ Decided now so 1a cannot paint itself into a corner. Not built.
   persisting to SQLite embedded in the Durable Object. Findings #7 and #18 are suspended, not
   withdrawn — correct, not load-bearing until then, and not to be assumed before.
 - **Notes is the fourth Panel.** A **Review** is an intentional pass producing a batch of
-  Guidance notes at once, accumulating in numbered **Rounds**, grouped by **Kind**, which the
+  Guidance notes at once, accumulating in numbered **Rounds**, grouped by **type**, which the
   writer selects among and hands back to the Chat.
 - **The guide loop is client-initiated. There is no server-side timer anywhere in v1.** The
   client knows when typing stopped; the server cannot tell "still thinking" from "left the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ plan: {
   title, totalTarget,
   voice, adjectives: [],
   outline: [ { id, title, intent?, target?, voice?, adjectives?: [], children: [] } ],
-  references: [ { id, provenance, text?, source?, nodeId, note? } ],
+  references: [ { id, kind, provenance, text?, source?, nodeId, note? } ],
 }
 ```
 
@@ -110,8 +110,12 @@ plan: {
   a stable ID that never changes.
 - **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
   Section or nowhere yet.
-- **A Quote is a Reference that carries a `text`.** One structure: a pulled passage, an
-  attribution, or both, with at least one present.
+- **A Quote is a Reference of that `kind`.** One structure: a pulled passage, an
+  attribution, or both, with at least one present. The Kind is **stored, not derived from
+  the text**, so an Offer and the Reference it was Accepted into carry one answer and the
+  Offer ledger and the Plan Panel cannot label an item differently. A Quote carries a text;
+  a Reference may carry one without being a Quote. Amended in
+  [ADR 0002](./adr/0002-the-plan-data-model.md).
 - **Voice replaces; Adjectives compose.** One Voice applies at a time and the nearest Scope
   wins outright. Adjectives accumulate. Resolution runs House, then Article, then
   Section, **at read time**. A Section's ancestors take part in that same order, so a Subsection

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -17,11 +17,11 @@ export interface ReferenceCardProps {
 }
 
 /** The star that marks a reference as coming from your favourites. */
-function FavouriteMark({ kind }: { kind: 'author' | 'publication' }) {
+function FavouriteMark({ type }: { type: 'author' | 'publication' }) {
 	return (
 		<span className="inline-flex items-center gap-1 text-accent-ink">
 			<span aria-hidden>★</span>
-			<span>favourite {kind}</span>
+			<span>favourite {type}</span>
 		</span>
 	)
 }
@@ -62,7 +62,7 @@ export function ReferenceCard({
 					{reference.title}
 				</h4>
 				<p className="flex flex-wrap items-center gap-x-1.5 text-[0.6875rem] text-faint">
-					{reference.favourite ? <FavouriteMark kind={reference.favourite} /> : null}
+					{reference.favourite ? <FavouriteMark type={reference.favourite} /> : null}
 					{[reference.author, reference.outlet, reference.year]
 						.filter(Boolean)
 						.map((part, i) => (

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -5,7 +5,6 @@ import {
 	type Disposition,
 	type Offer,
 	type OfferContent,
-	type OfferKind,
 	offerContentSchema,
 	type Ruling,
 	rulingSchema,
@@ -13,6 +12,7 @@ import {
 import {
 	emptyPlan,
 	type Plan,
+	type ReferenceKind,
 	type PlanRefused,
 	planSchema,
 	type Source,
@@ -24,7 +24,7 @@ import {
 type OfferRow = {
 	seq: number
 	id: string
-	kind: OfferKind
+	kind: ReferenceKind
 	disposition: Disposition
 	text: string | null
 	source: string | null

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -12,7 +12,7 @@ import {
 import {
 	emptyPlan,
 	type Plan,
-	type ReferenceKind,
+	type ReferenceType,
 	type PlanRefused,
 	planSchema,
 	type Source,
@@ -24,7 +24,7 @@ import {
 type OfferRow = {
 	seq: number
 	id: string
-	kind: ReferenceKind
+	type: ReferenceType
 	disposition: Disposition
 	text: string | null
 	source: string | null
@@ -36,7 +36,7 @@ type OfferRow = {
 function toOffer(row: OfferRow): Offer {
 	return {
 		id: row.id,
-		kind: row.kind,
+		type: row.type,
 		disposition: row.disposition,
 		text: row.text ?? undefined,
 		source: row.source === null ? undefined : (JSON.parse(row.source) as Source),
@@ -65,7 +65,7 @@ export class ArticleAgent extends Agent<Env, Plan> {
 			CREATE TABLE IF NOT EXISTS offer (
 				seq INTEGER PRIMARY KEY AUTOINCREMENT,
 				id TEXT NOT NULL UNIQUE,
-				kind TEXT NOT NULL,
+				type TEXT NOT NULL,
 				disposition TEXT NOT NULL,
 				text TEXT,
 				source TEXT,
@@ -121,10 +121,10 @@ export class ArticleAgent extends Agent<Env, Plan> {
 		}
 
 		this.sql`
-			INSERT INTO offer (id, kind, disposition, text, source, note, created_at, decided_at)
+			INSERT INTO offer (id, type, disposition, text, source, note, created_at, decided_at)
 			VALUES (
 				${offer.id},
-				${offer.kind},
+				${offer.type},
 				${offer.disposition},
 				${offer.text ?? null},
 				${offer.source === undefined ? null : JSON.stringify(offer.source)},

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -22,6 +22,7 @@ import {
  * than checking it, and this class is the table's only writer, so the columns
  * are stated as what `createOffer` parsed before writing them. */
 type OfferRow = {
+	seq: number
 	id: string
 	kind: OfferKind
 	disposition: Disposition
@@ -62,7 +63,8 @@ export class ArticleAgent extends Agent<Env, Plan> {
 	onStart(): void {
 		this.sql`
 			CREATE TABLE IF NOT EXISTS offer (
-				id TEXT PRIMARY KEY,
+				seq INTEGER PRIMARY KEY AUTOINCREMENT,
+				id TEXT NOT NULL UNIQUE,
 				kind TEXT NOT NULL,
 				disposition TEXT NOT NULL,
 				text TEXT,
@@ -95,10 +97,14 @@ export class ArticleAgent extends Agent<Env, Plan> {
 		throw new Error(`The Plan does not parse. ${reason}`)
 	}
 
-	/** Every Offer on this Article, oldest first. */
+	/** Every Offer on this Article, in the order they were recorded.
+	 *
+	 * `seq` orders it, not `created_at`: a Worker's clock does not advance
+	 * across local writes, so a research turn that records four Offers stamps
+	 * them with one or two milliseconds between them. */
 	@callable()
 	listOffers(): Offer[] {
-		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY created_at, id`.map(toOffer)
+		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY seq`.map(toOffer)
 	}
 
 	/** Record something the Chat turned up. It starts Undecided.

--- a/src/shared/offer.ts
+++ b/src/shared/offer.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { referenceKindSchema, sourceSchema } from './plan/schema'
+import { referenceTypeSchema, sourceSchema } from './plan/schema'
 
 /**
  * An Offer, as coined in context.md. Stored in the Article Agent's SQLite,
@@ -19,7 +19,7 @@ export type Ruling = z.infer<typeof rulingSchema>
  * the Article Agent's to set, so they are not here. */
 export const offerContentSchema = z
 	.strictObject({
-		kind: referenceKindSchema,
+		type: referenceTypeSchema,
 		text: z.string().min(1).optional(),
 		source: sourceSchema.optional(),
 		note: z.string().min(1).optional(),
@@ -27,8 +27,8 @@ export const offerContentSchema = z
 	.refine((offer) => offer.text !== undefined || offer.source !== undefined, {
 		error: 'An Offer carries a text, a source, or both. One with neither is nothing.',
 	})
-	.refine((offer) => offer.kind !== 'quote' || offer.text !== undefined, {
-		error: 'An Offer of Kind quote carries a text.',
+	.refine((offer) => offer.type !== 'quote' || offer.text !== undefined, {
+		error: 'An Offer of type quote carries a text.',
 	})
 
 export type OfferContent = z.infer<typeof offerContentSchema>

--- a/src/shared/offer.ts
+++ b/src/shared/offer.ts
@@ -1,15 +1,12 @@
 import { z } from 'zod'
 
-import { sourceSchema } from './plan/schema'
+import { referenceKindSchema, sourceSchema } from './plan/schema'
 
 /**
  * An Offer, as coined in context.md. Stored in the Article Agent's SQLite,
  * Offers are kept as a flat list of References and Quotes turned up from
  * research.
  */
-
-export const offerKinds = ['reference', 'quote'] as const
-export type OfferKind = (typeof offerKinds)[number]
 
 /** How far the writer has got with one Offer. Every Offer starts Undecided. */
 export const dispositions = ['undecided', 'accepted', 'declined'] as const
@@ -22,7 +19,7 @@ export type Ruling = z.infer<typeof rulingSchema>
  * the Article Agent's to set, so they are not here. */
 export const offerContentSchema = z
 	.strictObject({
-		kind: z.enum(offerKinds),
+		kind: referenceKindSchema,
 		text: z.string().min(1).optional(),
 		source: sourceSchema.optional(),
 		note: z.string().min(1).optional(),
@@ -31,8 +28,7 @@ export const offerContentSchema = z
 		error: 'An Offer carries a text, a source, or both. One with neither is nothing.',
 	})
 	.refine((offer) => offer.kind !== 'quote' || offer.text !== undefined, {
-		error:
-			'A Quote is a Reference that carries a text, so an Offer of kind quote has one.',
+		error: 'An Offer of Kind quote carries a text.',
 	})
 
 export type OfferContent = z.infer<typeof offerContentSchema>

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -19,10 +19,10 @@ import { planSchema } from './schema'
  * - `invalid` — the ops resolve, but applying them would leave something that is
  *   not a Plan.
  */
-export type RefusalKind = 'malformed' | 'missing' | 'stale' | 'invalid'
+export type RefusalType = 'malformed' | 'missing' | 'stale' | 'invalid'
 
 export type Refusal = {
-	kind: RefusalKind
+	type: RefusalType
 	/** Which op refused, counting from 0, and null when the refusal is about the
 	 * Proposal as a whole. */
 	index: number | null
@@ -60,8 +60,8 @@ export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
 }
 
 function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
-	const refuse = (kind: RefusalKind, message: string): Refusal => ({
-		kind,
+	const refuse = (type: RefusalType, message: string): Refusal => ({
+		type,
 		index,
 		op: op.op,
 		message,
@@ -369,7 +369,7 @@ function malformed(error: z.ZodError): Refusal {
 	const index = typeof issue.path[0] === 'number' ? issue.path[0] : null
 
 	return {
-		kind: 'malformed',
+		type: 'malformed',
 		index,
 		op: null,
 		message: `An op does not match the vocabulary${at(issue.path.slice(1))}: ${issue.message}`,
@@ -380,7 +380,7 @@ function invalidPlan(error: z.ZodError): Refusal {
 	const issue = error.issues[0]
 
 	return {
-		kind: 'invalid',
+		type: 'invalid',
 		index: null,
 		op: null,
 		message: `The Proposal would leave a Plan the schema refuses${at(issue.path)}: ${issue.message}`,

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -15,11 +15,11 @@ export const adjectiveSchema = z.string().min(1)
 export const intentSchema = z.string().min(1)
 export const targetSchema = z.number().int().positive()
 
-/** Which Kind of Reference this is. Stored on the record rather than derived
+/** Which type of Reference this is. Stored on the record rather than derived
  * from whether a text is present, so an Offer and the Reference it was copied
  * into carry one answer and the two Panels cannot label it differently. */
-export const referenceKindSchema = z.enum(['reference', 'quote'])
-export type ReferenceKind = z.infer<typeof referenceKindSchema>
+export const referenceTypeSchema = z.enum(['reference', 'quote'])
+export type ReferenceType = z.infer<typeof referenceTypeSchema>
 
 // strictObject throughout: the Plan has one writer, so an unknown key is a bug
 // rather than a forward-compatible extension — §3, rule 1.
@@ -40,13 +40,13 @@ export const sourceSchema = z
 /** Where a record came from. */
 export const provenanceSchema = z
 	.strictObject({
-		kind: z.enum(['writer', 'offer']),
+		type: z.enum(['writer', 'offer']),
 		offerId: idSchema.optional(),
 	})
 	.refine(
-		(provenance) => (provenance.kind === 'offer') === (provenance.offerId !== undefined),
+		(provenance) => (provenance.type === 'offer') === (provenance.offerId !== undefined),
 		{
-			error: 'Provenance of kind offer names an offerId, and kind writer names none.',
+			error: 'Provenance of type offer names an offerId, and type writer names none.',
 		},
 	)
 
@@ -54,7 +54,7 @@ export const provenanceSchema = z
 export const referenceSchema = z
 	.strictObject({
 		id: idSchema,
-		kind: referenceKindSchema,
+		type: referenceTypeSchema,
 		provenance: provenanceSchema,
 		text: z.string().min(1).optional(),
 		source: sourceSchema.optional(),
@@ -64,8 +64,8 @@ export const referenceSchema = z
 	.refine((reference) => reference.text !== undefined || reference.source !== undefined, {
 		error: 'A Reference carries a text, a source, or both. One with neither is nothing.',
 	})
-	.refine((reference) => reference.kind !== 'quote' || reference.text !== undefined, {
-		error: 'A Reference of Kind quote carries a text.',
+	.refine((reference) => reference.type !== 'quote' || reference.text !== undefined, {
+		error: 'A Reference of type quote carries a text.',
 	})
 
 /** The unit of structure in the Plan. */

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -15,6 +15,12 @@ export const adjectiveSchema = z.string().min(1)
 export const intentSchema = z.string().min(1)
 export const targetSchema = z.number().int().positive()
 
+/** Which Kind of Reference this is. Stored on the record rather than derived
+ * from whether a text is present, so an Offer and the Reference it was copied
+ * into carry one answer and the two Panels cannot label it differently. */
+export const referenceKindSchema = z.enum(['reference', 'quote'])
+export type ReferenceKind = z.infer<typeof referenceKindSchema>
+
 // strictObject throughout: the Plan has one writer, so an unknown key is a bug
 // rather than a forward-compatible extension — §3, rule 1.
 
@@ -48,6 +54,7 @@ export const provenanceSchema = z
 export const referenceSchema = z
 	.strictObject({
 		id: idSchema,
+		kind: referenceKindSchema,
 		provenance: provenanceSchema,
 		text: z.string().min(1).optional(),
 		source: sourceSchema.optional(),
@@ -56,6 +63,9 @@ export const referenceSchema = z
 	})
 	.refine((reference) => reference.text !== undefined || reference.source !== undefined, {
 		error: 'A Reference carries a text, a source, or both. One with neither is nothing.',
+	})
+	.refine((reference) => reference.kind !== 'quote' || reference.text !== undefined, {
+		error: 'A Reference of Kind quote carries a text.',
 	})
 
 /** The unit of structure in the Plan. */

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -84,7 +84,7 @@ describe('applying a Proposal', () => {
 			},
 		])
 
-		expect(refusal.kind).toBe('stale')
+		expect(refusal.type).toBe('stale')
 		expect(refusal.index).toBe(1)
 		expect(refusal.op).toBe('setIntent')
 		expect(refusal.expected).toBe('Open on the dawn raid')
@@ -128,7 +128,7 @@ describe('applying a Proposal', () => {
 			withoutN2,
 		)
 
-		expect(refusal.kind).toBe('missing')
+		expect(refusal.type).toBe('missing')
 		expect(refusal.op).toBe('createNode')
 		expect(refusal.message).toContain('after n2')
 	})
@@ -136,7 +136,7 @@ describe('applying a Proposal', () => {
 	it('refuses a Proposal that does not match the vocabulary', () => {
 		const refusal = refused([{ op: 'setTone', nodeId: 'n1' }] as unknown as ProposalInput)
 
-		expect(refusal.kind).toBe('malformed')
+		expect(refusal.type).toBe('malformed')
 		expect(refusal.index).toBe(0)
 	})
 
@@ -149,7 +149,7 @@ describe('applying a Proposal', () => {
 			broken,
 		)
 
-		expect(refusal.kind).toBe('invalid')
+		expect(refusal.type).toBe('invalid')
 		expect(refusal.message).toContain('references.0.nodeId')
 	})
 })
@@ -233,7 +233,7 @@ describe('the structural ops', () => {
 			},
 		])
 
-		expect(refusal.kind).toBe('invalid')
+		expect(refusal.type).toBe('invalid')
 		expect(refusal.message).toContain('n2a')
 	})
 
@@ -247,7 +247,7 @@ describe('the structural ops', () => {
 			},
 		])
 
-		expect(refusal.kind).toBe('missing')
+		expect(refusal.type).toBe('missing')
 		expect(refusal.message).toContain('node n2 does not carry')
 	})
 
@@ -274,7 +274,7 @@ describe('the structural ops', () => {
 			{ op: 'moveNode', nodeId: 'n2', parentId: null, afterId: 'n2' },
 		])
 
-		expect(refusal.kind).toBe('invalid')
+		expect(refusal.type).toBe('invalid')
 		expect(refusal.message).toContain('cannot anchor n2 to itself')
 	})
 
@@ -283,7 +283,7 @@ describe('the structural ops', () => {
 			{ op: 'moveNode', nodeId: 'n2', parentId: 'n2a', beforeId: null },
 		])
 
-		expect(refusal.kind).toBe('invalid')
+		expect(refusal.type).toBe('invalid')
 		expect(refusal.message).toContain('a node it contains')
 	})
 
@@ -325,7 +325,7 @@ describe('the structural ops', () => {
 	it('refuses to merge a node into one it contains', () => {
 		const refusal = refused([{ op: 'mergeNodes', nodeId: 'n2', intoId: 'n2b' }])
 
-		expect(refusal.kind).toBe('invalid')
+		expect(refusal.type).toBe('invalid')
 		expect(refusal.message).toContain('which it contains')
 	})
 })
@@ -375,7 +375,7 @@ describe('the content ops', () => {
 			{ op: 'setAdjectives', nodeId: null, expected: ['warm', 'funny'], value: [] },
 		])
 
-		expect(refusal.kind).toBe('stale')
+		expect(refusal.type).toBe('stale')
 		expect(refusal.found).toEqual(['funny'])
 	})
 
@@ -397,7 +397,7 @@ describe('the content ops', () => {
 			{ op: 'placeReference', referenceId: 'r2', expected: null, value: 'gone' },
 		])
 
-		expect(refusal.kind).toBe('missing')
+		expect(refusal.type).toBe('missing')
 		expect(refusal.message).toContain('node gone')
 	})
 
@@ -406,7 +406,7 @@ describe('the content ops', () => {
 			{ op: 'placeReference', referenceId: 'r1', expected: null, value: 'n1' },
 		])
 
-		expect(refusal.kind).toBe('stale')
+		expect(refusal.type).toBe('stale')
 		expect(refusal.found).toBe('n2a')
 	})
 
@@ -415,7 +415,7 @@ describe('the content ops', () => {
 			{ op: 'setTitle', nodeId: 'gone', expected: '', value: 'A title' },
 		])
 
-		expect(refusal.kind).toBe('missing')
+		expect(refusal.type).toBe('missing')
 		expect(refusal.op).toBe('setTitle')
 		expect(refusal.message).toContain('node gone')
 	})

--- a/test/shared/plan-fixtures.ts
+++ b/test/shared/plan-fixtures.ts
@@ -15,5 +15,5 @@ export function makeNode(node: Partial<OutlineNode> & { id: string }): OutlineNo
 /** A Reference the writer wrote themselves, unplaced. It carries neither a text
  * nor a source, so a test states whichever the invariant it is about needs. */
 export function makeReference(reference: Partial<Reference> & { id: string }): Reference {
-	return { provenance: { kind: 'writer' }, nodeId: null, ...reference }
+	return { kind: 'reference', provenance: { kind: 'writer' }, nodeId: null, ...reference }
 }

--- a/test/shared/plan-fixtures.ts
+++ b/test/shared/plan-fixtures.ts
@@ -15,5 +15,5 @@ export function makeNode(node: Partial<OutlineNode> & { id: string }): OutlineNo
 /** A Reference the writer wrote themselves, unplaced. It carries neither a text
  * nor a source, so a test states whichever the invariant it is about needs. */
 export function makeReference(reference: Partial<Reference> & { id: string }): Reference {
-	return { kind: 'reference', provenance: { kind: 'writer' }, nodeId: null, ...reference }
+	return { type: 'reference', provenance: { type: 'writer' }, nodeId: null, ...reference }
 }

--- a/test/shared/plan-schema.test.ts
+++ b/test/shared/plan-schema.test.ts
@@ -165,28 +165,28 @@ describe('the Reference invariant', () => {
 		expect(result.success).toBe(true)
 	})
 
-	it('accepts a Quote, which is a Reference of that Kind carrying a text', () => {
+	it('accepts a Quote, which is a Reference of that type carrying a text', () => {
 		const result = referenceSchema.safeParse({
 			...base,
-			kind: 'quote',
+			type: 'quote',
 			text: 'They knew by March.',
 		})
 
 		expect(result.success).toBe(true)
 	})
 
-	// The Kind is stored rather than read off the text, so a text does not make
+	// The type is stored rather than read off the text, so a text does not make
 	// a Reference a Quote and the two Panels cannot disagree about which it is.
 	it('leaves a Reference carrying a text a Reference, not a Quote', () => {
 		const result = referenceSchema.safeParse({ ...base, text: 'They knew by March.' })
 
-		expect(result.success && result.data.kind).toBe('reference')
+		expect(result.success && result.data.type).toBe('reference')
 	})
 
 	it('rejects a Quote carrying no text', () => {
 		const result = referenceSchema.safeParse({
 			...base,
-			kind: 'quote',
+			type: 'quote',
 			source: { publication: 'The Guardian', year: 2024 },
 		})
 
@@ -229,7 +229,7 @@ describe('the Reference invariant', () => {
 		const result = referenceSchema.safeParse({
 			...base,
 			text: 'They knew by March.',
-			provenance: { kind: 'offer' },
+			provenance: { type: 'offer' },
 		})
 
 		expect(result.success).toBe(false)
@@ -239,7 +239,7 @@ describe('the Reference invariant', () => {
 		const result = referenceSchema.safeParse({
 			...base,
 			text: 'They knew by March.',
-			provenance: { kind: 'offer', offerId: 'o1' },
+			provenance: { type: 'offer', offerId: 'o1' },
 		})
 
 		expect(result.success).toBe(true)

--- a/test/shared/plan-schema.test.ts
+++ b/test/shared/plan-schema.test.ts
@@ -159,10 +159,38 @@ describe('the Plan schema', () => {
 describe('the Reference invariant', () => {
 	const base = makeReference({ id: 'r1' })
 
-	it('accepts a Reference carrying only a text — which is a Quote', () => {
+	it('accepts a Reference carrying only a text', () => {
 		const result = referenceSchema.safeParse({ ...base, text: 'They knew by March.' })
 
 		expect(result.success).toBe(true)
+	})
+
+	it('accepts a Quote, which is a Reference of that Kind carrying a text', () => {
+		const result = referenceSchema.safeParse({
+			...base,
+			kind: 'quote',
+			text: 'They knew by March.',
+		})
+
+		expect(result.success).toBe(true)
+	})
+
+	// The Kind is stored rather than read off the text, so a text does not make
+	// a Reference a Quote and the two Panels cannot disagree about which it is.
+	it('leaves a Reference carrying a text a Reference, not a Quote', () => {
+		const result = referenceSchema.safeParse({ ...base, text: 'They knew by March.' })
+
+		expect(result.success && result.data.kind).toBe('reference')
+	})
+
+	it('rejects a Quote carrying no text', () => {
+		const result = referenceSchema.safeParse({
+			...base,
+			kind: 'quote',
+			source: { publication: 'The Guardian', year: 2024 },
+		})
+
+		expect(result.success).toBe(false)
 	})
 
 	it('accepts a Reference carrying only a source', () => {

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -34,13 +34,13 @@ const orphaned = {
 }
 
 const quote = {
-	kind: 'quote' as const,
+	type: 'quote' as const,
 	text: 'We did not decide to stop building.',
 	source: { title: 'Permit throughput in six mid-sized cities', year: 2023 },
 }
 
 const reference = {
-	kind: 'reference' as const,
+	type: 'reference' as const,
 	source: { title: 'Zoning and the missing middle', author: 'A. Weill' },
 	note: 'Primary data for the opening figure.',
 }
@@ -121,7 +121,7 @@ describe('Offers in the Article Agent', () => {
 		const offer = await createOffer('offer-create', quote)
 
 		expect(offer).toMatchObject({
-			kind: 'quote',
+			type: 'quote',
 			disposition: 'undecided',
 			decidedAt: null,
 		})
@@ -132,7 +132,7 @@ describe('Offers in the Article Agent', () => {
 	// one refuses without the Article Agent ever reaching its table.
 	it('refuses an Offer carrying neither a text nor a source', async () => {
 		await expect(
-			createOffer('offer-empty', { kind: 'reference' } as OfferContent),
+			createOffer('offer-empty', { type: 'reference' } as OfferContent),
 		).rejects.toThrow(/text, a source, or both/)
 	})
 
@@ -177,7 +177,7 @@ describe('Offers in the Article Agent', () => {
 
 		const titles = await runInDurableObject(stub, (agent) => {
 			const recorded = ['first', 'second', 'third', 'fourth'].map((title) =>
-				agent.createOffer({ kind: 'reference', source: { title } }),
+				agent.createOffer({ type: 'reference', source: { title } }),
 			)
 
 			return {

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -169,6 +169,26 @@ describe('Offers in the Article Agent', () => {
 		)
 	})
 
+	// A research turn records its Offers in one invocation, where the Worker's
+	// clock barely advances — so `created_at` cannot order them and `seq` does.
+	it('lists a batch recorded in one turn in the order it was recorded', async () => {
+		await openAgentSocket('offer-batch')
+		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-batch'))
+
+		const titles = await runInDurableObject(stub, (agent) => {
+			const recorded = ['first', 'second', 'third', 'fourth'].map((title) =>
+				agent.createOffer({ kind: 'reference', source: { title } }),
+			)
+
+			return {
+				recorded: recorded.map((offer) => offer.source?.title),
+				listed: agent.listOffers().map((offer) => offer.source?.title),
+			}
+		})
+
+		expect(titles.listed).toEqual(titles.recorded)
+	})
+
 	it('keeps its Offers through a hibernation cycle', async () => {
 		const writer = await openAgentSocket('offer-hibernation')
 		const kept = await createOffer('offer-hibernation', quote)


### PR DESCRIPTION
1. The Kind of a Reference — whether it is a Quote or a Reference — is now a stored field rather than derived from the presence of a text. This prevents the Offer ledger and Plan Panel from labeling the same item differently.
2. We rename "Kind" to "Type" because "Kind" is a weird word with ambiguous part of speech and doesn't work as well as "Offer type" "Article type" (example only, not actually used).

https://claude.ai/code/session_01E5CeuVhbhpBJ2aBh6TFyse