### PR TITLE
1a-05 The Chat turn, the model boundary, and Proposal tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,18 @@ CF_REMOTE_BINDINGS=true pnpm dev
 pnpm deploy     # builds the client, then wrangler deploy
 ```
 
+`AI_GATEWAY_ID` names the AI Gateway the model calls log through. Set it from the CLI rather
+than in `wrangler.jsonc`, because a var declared there overwrites the deployed value on every
+deploy:
+
+```sh
+pnpm wrangler secret put AI_GATEWAY_ID
+```
+
+Leaving it unset attaches no Gateway, which is what a deployment without one wants — a
+Gateway that does not exist fails the call. Leave the Gateway itself **unauthenticated**: a
+Workers AI binding call is same-account and carries no place to put a Gateway token.
+
 The Worker needs the Workers Paid plan for the model, and Cloudflare Access gates it at the
 edge. Nothing in the app reads the `Cf-Access-Jwt-Assertion` header — localhost has no
 Access gate, and requiring the header would make the app unrunnable in development.
@@ -54,6 +66,7 @@ Access gate, and requiring the header would make the app unrunnable in developme
 | `src/client/screens/`         | The wireframed screens, built against mock data                       |
 | `src/client/styles/theme.css` | The Tailwind v4 `@theme` tokens                                       |
 | `src/server/`                 | The Hono Worker entry and the `ArticleAgent` Durable Object           |
+| `src/server/llm/`             | The model boundary, the Chat turn's prompt pack, and the tools        |
 | `test/`                       | Tests running in workerd through `@cloudflare/vitest-pool-workers`    |
 | `docs/`                       | The architecture document, the ADRs, and [the UI notes](./docs/ui.md) |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,10 +45,15 @@ Browser — React + Vite + TanStack Router
 about one Article. It is always named in full — an unqualified "agent" could mean this
 object, the Guide, or the Chat.
 
-**The House** arrives at 1b as a single party-db room persisted to D1, holding everything
-that spans Articles. The House is small, constantly read, and exactly CRUD over a few
+**The House** arrives at 1b as a single party-db room persisted to D1, holding the writer's
+own standing material: the Lexicon, the standing rules, the Skills, and House-scoped Voice
+and Adjectives. The House is small, constantly read, and exactly CRUD over a few
 collections, so defining the collections _is_ the API: no endpoints, no query keys, no
 invalidation.
+
+**The House holds what the writer authors and reuses.** Spanning Articles is not on its own
+a reason to put something there, and where a body of accumulated _research_ lives is open —
+issue #40, with the shape it might take in [`later.md`](./later.md).
 
 **Plain D1 tables** hold Archived Plans, Drafts, and Finals, read through a Worker endpoint
 rather than synced. D1 also carries the backup story, because a Durable Object's storage has

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,11 +12,11 @@ model producing prose for the Draft.
 Three stages of usefulness. Build with all three in mind and ship them in order. A refactor
 at a stage boundary is accepted rather than designed around.
 
-| Stage  | What ships              | What it adds                                                                                                                       |
-| ------ | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| **1a** | The Chat and the Plan   | One Article Agent per Article. Useful alone.                                                                                       |
+| Stage  | What ships              | What it adds                                                                                                    |
+| ------ | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **1a** | The Chat and the Plan   | One Article Agent per Article. Useful alone.                                                                    |
 | **1b** | The House               | The Lexicon, the standing rules, the Skills, House-scoped Voice and Adjectives, and the article index. Only useful once 1a exists. |
-| **2**  | The Draft and the Guide | The writing surface, Guidance notes, Reviews.                                                                                      |
+| **2**  | The Draft and the Guide | The writing surface, Guidance notes, Reviews.                                                                   |
 
 **Scale**: one Team of two people. No signup flow. "Only one editor at a time on a Draft" is
 an acceptable constraint.
@@ -168,12 +168,16 @@ keeps its disposition.
 **The Chat is standard, and we adopt rather than invent.** Chat with research, tool calls,
 approved edits, and an output artifact is well-trodden territory.
 
+**The Article Agent extends `AIChatAgent`** from `@cloudflare/ai-chat`, which is where that
+class now lives — importing `agents/ai-chat-agent` throws and says so. It routes a turn to
+`onChatMessage`, and the Chat rides the socket the Plan and the RPC already share.
+
 **The transcript stays in the Agents SDK's own store** and is never mirrored anywhere. The
 server is what consumes it.
 
 **The Chat proposes; the client applies.** The Chat never writes to the Plan.
 
-**Proposals are `execute`-less tools** (AI SDK v6). A tool with no `execute` suspends for the
+**Proposals are `execute`-less tools** (AI SDK v7). A tool with no `execute` suspends for the
 client, which is the Proposal. Four API details, each easy to get wrong:
 
 - Use `addToolOutput`, not the deprecated `addToolResult`, and call it **without `await`** —
@@ -245,12 +249,12 @@ output disappoints, swap the string to `@cf/moonshotai/kimi-k2.6` and move on.**
 **One model serves every call** — the Chat, the ambient Guidance notes, the Review. No
 routing machinery, no per-call-type model selection.
 
-**The swappable boundary is the model instance, not a wrapper API.** AI SDK v6 already
+**The swappable boundary is the model instance, not a wrapper API.** AI SDK v7 already
 provides `generateText`, `streamText`, and `generateObject`; a wrapper would duplicate it and
 break the `execute`-less tool machinery.
 
 ```ts
-// llm/model.ts — the whole boundary
+// src/server/llm/model.ts — the whole boundary
 import { createWorkersAI } from 'workers-ai-provider'
 export const model = (env: Env) =>
   createWorkersAI({ binding: env.AI })('@cf/zai-org/glm-5.2')
@@ -260,19 +264,42 @@ export const model = (env: Env) =>
 no external provider and no key to manage. **Gateway response caching stays off for guide
 passes**, or near-identical requests against different Drafts return stale Notes.
 
+**The Gateway is named by the `AI_GATEWAY_ID` var, set from the CLI rather than checked in.**
+It is deployment configuration rather than repo content, and a var declared in
+`wrangler.jsonc` overwrites the deployed value on every `wrangler deploy`, so declaring it
+there even as a placeholder would wipe it. Unset attaches no Gateway. Its type is in
+`src/server/env.d.ts` and `llm/model.ts` is the only thing that reads it.
+
+**The binding path needs no Gateway token.** `GatewayOptions` carries an id and cache
+settings and has nowhere to put one, because a Workers AI binding call is same-account and
+authenticates itself. So an authenticated Gateway is the one setting to leave off — turn it
+on and these calls have no way to present the header it wants.
+
 **Structured output, never parsed prose.** `generateObject` with a zod schema, validated in
 the Article Agent, with one retry that includes the validation error.
 
-**Prompt packs put the stable prefix first** — system prompt, Lexicon entries in play, the
-Plan, then the volatile Draft or deltas. Cached input costs $0.26 per million against $1.40
-uncached, so the ordering is a five-fold saving on the repeated part of every pass.
+**Prompt packs put the stable part first** — system prompt, then Lexicon entries in play,
+then the standing rules, then everything that changes.
 
-| Pack       | Contents                                                                          |
-| ---------- | --------------------------------------------------------------------------------- |
-| Chat turn  | The Chat transcript, plus the Plan                                                |
-| Proposal   | The affected span, plus adjacent Section titles and intent notes. Nothing else    |
-| Guide pass | The Plan, the Draft or active Section with neighbours, recent deltas. **No Chat** |
-| Review     | The same, plus the existing Notes. **No Chat**                                    |
+**Stable means append-only, and the Plan is not.** A transcript only grows, while the Plan
+changes on every Accepted Proposal, so **the Plan goes after the conversation** and the Draft
+or the deltas go last in the packs that carry those. Put the Plan in front and the product's
+main loop invalidates the whole transcript behind it on every pass.
+
+**Whether that ordering saves money on Workers AI is unverified.** Prefix caching is what
+would make it pay, priced elsewhere at $0.26 per million cached against $1.40 uncached — and
+the `env.AI` binding bills in neurons, so those are not its numbers and nothing here has
+measured it. The ordering stands on the structural argument above either way, and the saving
+is a claim to check on the first real turn rather than one to design around.
+
+Each row below reads in pack order, stable to volatile.
+
+| Pack       | Contents                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| Chat turn  | The Chat transcript, then the Plan                                                          |
+| Proposal   | The affected span, plus adjacent Section titles and intent notes. Nothing else              |
+| Guide pass | The Plan, then the Draft or active Section with neighbours, then recent deltas. **No Chat** |
+| Review     | The same, plus the existing Notes. **No Chat**                                              |
 
 Research reaches a Review only by being Accepted into the Plan. The Ledger is the bridge, and
 curation is forced rather than assumed.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ at a stage boundary is accepted rather than designed around.
 | Stage  | What ships              | What it adds                                                                                                    |
 | ------ | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
 | **1a** | The Chat and the Plan   | One Article Agent per Article. Useful alone.                                                                    |
-| **1b** | The House               | The Lexicon, the standing rules, the Skills, House-scoped Voice and Adjectives, and the article index. Only useful once 1a exists. |
+| **1b** | The House               | The Lexicon, the standing rules, the Skills, and House-scoped Voice and Adjectives. Only useful once 1a exists. |
 | **2**  | The Draft and the Guide | The writing surface, Guidance notes, Reviews.                                                                   |
 
 **Scale**: one Team of two people. No signup flow. "Only one editor at a time on a Draft" is
@@ -35,7 +35,8 @@ Browser — React + Vite + TanStack Router
   └─ Notes Panel  ─┘                            ├─ Agent state (one JSON blob): the Plan
                                                 ├─ SQLite rows: Offers, Notes, Rounds
                    ── party-db WebSocket ──►  The House (one party-db room, → D1)   [1b]
-                   ── HTTP (Hono) ─────────►  Archived reads, export
+                   ── HTTP (Hono) ─────────►  The article index (→ D1)
+                                              Archived reads, export
                                               Workers AI binding → the model
 ```
 
@@ -319,11 +320,11 @@ Start does not join it** — its value is a typed server boundary in both direct
 Agents SDK owns the actions while the two sockets own the reads, leaving about five HTTP
 calls in total.
 
-**Hono** serves those in the same Worker: the Agents SDK's chat route, party-db's lobby and
-write path at 1b, archived reads, and export.
+**Hono** serves those in the same Worker: the Agents SDK's chat route, the article index,
+party-db's lobby and write path at 1b, archived reads, and export.
 
-**TanStack Query** serves only the archived and export reads. Live data is already reactive
-through Article Agent state and, at 1b, party-db's TanStack DB collections.
+**TanStack Query** serves the article index and the archived and export reads. Live data is
+already reactive through Article Agent state and, at 1b, party-db's TanStack DB collections.
 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen. The **Areas** are Articles (with Board and Archive Views), House, and Team.
@@ -339,12 +340,10 @@ client handles them. It becomes work if a party-db transport ever shares that so
 **1a is single-author and its auth is zero code.** One Team, both people read everything, no
 per-user records, so nothing parses a token.
 
-**1a's article index is a throwaway array in `localStorage`** — `{ id, title }`, appended on
-create and pruned liberally. The real index lives in the House and arrives at 1b. This one is
-per browser, so the two people see different lists and an Article created on one machine does
-not appear on another, which is acceptable because 1a is single-author. Keeping it in
-`localStorage` rather than a Durable Object is deliberate: it is visibly not the real store,
-so nobody builds on it. It gains no search, no sorting, no Board View.
+**The article index is a real D1 table, built as the last 1a ticket** — a small table read
+through a Worker endpoint, on the path §2 already has for the Archived reads. It does not
+wait for the House. An Article created on one machine appears on the other, which is what
+makes the index worth having at all. Issue #29.
 
 **Nothing in 1a may require the `Cf-Access-Jwt-Assertion` header.** Localhost has no Access
 gate at all, so in development there is no header and no gate. Read it if present, tolerate

--- a/docs/later.md
+++ b/docs/later.md
@@ -48,6 +48,17 @@ so the writer chooses what a Round is looking for rather than always getting the
 pass. The invocable, writer-authored part comes back if and when the model starts
 producing text.
 
+## The Beat
+
+A subject a writer covers over time, holding the research they build up on it. An Article
+would draw on its Beat and add back to what it holds, leaving the Article's own research
+small enough for a Chat turn.
+
+Today an Article is its own Beat, and nothing has to choose between them. The Beat earns a
+design the moment research accumulates across Articles and a writer wants the second piece
+on a subject to start from what the first one turned up. Where that material lives is the
+open half of #40, and this is the shape it might take.
+
 ## Exemplar pieces
 
 The app already knows what the writer has published. This would let them point at one and

--- a/package.json
+++ b/package.json
@@ -22,11 +22,14 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@cloudflare/ai-chat": "^0.10.1",
     "@tanstack/react-router": "^1.170.20",
     "agents": "^0.20.1",
+    "ai": "^7.0.55",
     "hono": "^4.13.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
+    "workers-ai-provider": "^4.0.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@cloudflare/ai-chat':
+        specifier: ^0.10.1
+        version: 0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)
       '@tanstack/react-router':
         specifier: ^1.170.20
         version: 1.170.20(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       agents:
         specifier: ^0.20.1
-        version: 0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
+        version: 0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
+      ai:
+        specifier: ^7.0.55
+        version: 7.0.55(zod@4.4.3)
       hono:
         specifier: ^4.13.0
         version: 4.13.0
@@ -23,6 +29,9 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      workers-ai-provider:
+        specifier: ^4.0.0
+        version: 4.0.0(@ai-sdk/provider@4.0.6)(ai@7.0.55(zod@4.4.3))
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -89,6 +98,34 @@ packages:
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@ai-sdk/gateway@4.0.43':
+    resolution: {integrity: sha512-7KqJR7+8zKwxuZY7/G12QWRV8MDUMgrAUmR/Al99zN6OGB3KQe1Q9i2lAB8uyTBsxgdZjB07vH+ky+RG5m1aiA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/mcp@2.0.27':
+    resolution: {integrity: sha512-xFy5Uqtvpb4Z2M94ozcTLuM/wYicmvDw7S52RHfz/GtBQE6y1EEcF2ZJQLRC9296+mLy2jyQta1CcNtnBdfbaA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@5.0.23':
+    resolution: {integrity: sha512-mFvAAszenK8Xny3v+4Vntke5IcUkyzjss3gTBOxVWNrSIWmt/FhQ5gCgoJXW7IK11cklRaicMPwOXTnnBtaqFQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.6':
+    resolution: {integrity: sha512-YYXjvs8F3q/BdEn9tBDoDuQACotfR7c5foGw/ADsM6iAVC1JabqEjQSkwHv/Kg2vNIr1c2AVHcQb+JYsYk76Qw==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/react@4.0.58':
+    resolution: {integrity: sha512-vPLR58sTg4C+au9zMFpGCUutp0Uo0wo7WouC6c9xUEx5YJTO17GY+gm7XWGGK5ApFGVoXuxmrVVm1m1nkmFiZg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -250,6 +287,15 @@ packages:
 
   '@cfworker/json-schema@4.1.1':
     resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
+
+  '@cloudflare/ai-chat@0.10.1':
+    resolution: {integrity: sha512-kSycX0kJ93LbGCkA6j6w6nm0tieSE+MiC62EF3KyLWpsElUc0tHt7XcPs5Z300MvZU1oAoQWhRWcRK9pYHbDlQ==}
+    peerDependencies:
+      '@ai-sdk/react': ^3.0.0 || ^4.0.0
+      agents: '>=0.17.1 <1.0.0'
+      ai: ^6.0.0 || ^7.0.0
+      react: ^19.0.0
+      zod: ^4.0.0
 
   '@cloudflare/kv-asset-handler@0.5.0':
     resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
@@ -1645,6 +1691,10 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.5':
     resolution: {integrity: sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1702,6 +1752,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@workflow/serde@4.1.0':
+    resolution: {integrity: sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -1748,6 +1801,12 @@ packages:
         optional: true
       vite:
         optional: true
+
+  ai@7.0.55:
+    resolution: {integrity: sha512-B+oZTUFjrR7eV0mF9DUuaIaWvEoJM28yVvcnbUioqcyYYkvae4eY+KvvRkfti+UojsoKrwKiWHeNk0w+nUyvVg==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -2225,6 +2284,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -2798,12 +2860,21 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.5.0:
+    resolution: {integrity: sha512-W0GomadRJe9OfzIoRX0kZHhDSaRRfdiOUeH6uazgR05SibBhDNwfdTbhAxmFtObvkf59fFymo22mooKukosvNA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3027,6 +3098,22 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workers-ai-provider@4.0.0:
+    resolution: {integrity: sha512-FkhwMP1EP/MKXR8Jv1o7wLVKfTqu0h/PUaEmhZ7gyDiioib5Wsh3oPAKhG+7+SWfU3roTDHaEWlJpkJjpXu+fQ==}
+    peerDependencies:
+      '@ai-sdk/anthropic': ^4.0.0
+      '@ai-sdk/google': ^4.0.0
+      '@ai-sdk/openai': ^4.0.0
+      '@ai-sdk/provider': ^4.0.0
+      ai: ^7.0.0
+    peerDependenciesMeta:
+      '@ai-sdk/anthropic':
+        optional: true
+      '@ai-sdk/google':
+        optional: true
+      '@ai-sdk/openai':
+        optional: true
+
   wrangler@4.119.0:
     resolution: {integrity: sha512-ookClf+zly4DTc8pBMNrwGQzZKH8IpIYTXkjDw3XS7ZvBQ5mLYH6eOvfD5BEpk3U63zTbv91WRlo1UeRSKXa0g==}
     engines: {node: '>=22.0.0'}
@@ -3109,6 +3196,45 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@ai-sdk/gateway@4.0.43(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
+  '@ai-sdk/mcp@2.0.27(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@5.0.23(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.6
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.1.0
+      undici: 7.28.0
+      zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.6':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/mcp': 2.0.27(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      ai: 7.0.55(zod@4.4.3)
+      react: 19.2.8
+      swr: 2.5.0(react@19.2.8)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3314,6 +3440,15 @@ snapshots:
       '@babel/helper-validator-identifier': 8.0.4
 
   '@cfworker/json-schema@4.1.1': {}
+
+  '@cloudflare/ai-chat@0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/react': 4.0.58(react@19.2.8)(zod@4.4.3)
+      agents: 0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
+      ai: 7.0.55(zod@4.4.3)
+      nanoid: 5.1.16
+      react: 19.2.8
+      zod: 4.4.3
 
   '@cloudflare/kv-asset-handler@0.5.0': {}
 
@@ -4340,6 +4475,8 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -4412,6 +4549,8 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@workflow/serde@4.1.0': {}
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -4419,7 +4558,7 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  agents@0.20.1(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3):
+  agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3):
     dependencies:
       '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
@@ -4438,6 +4577,8 @@ snapshots:
       yargs: 18.1.0
       zod: 4.4.3
     optionalDependencies:
+      '@ai-sdk/react': 4.0.58(react@19.2.8)(zod@4.4.3)
+      ai: 7.0.55(zod@4.4.3)
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@babel/core'
@@ -4445,6 +4586,13 @@ snapshots:
       - '@babel/runtime'
       - '@cloudflare/workers-types'
       - rolldown
+
+  ai@7.0.55(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.43(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.6
+      '@ai-sdk/provider-utils': 5.0.23(zod@4.4.3)
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -4884,6 +5032,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-schema@0.4.0: {}
 
   json5@2.2.3: {}
 
@@ -5500,9 +5650,17 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.5.0(react@19.2.8):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
+
+  throttleit@2.1.0: {}
 
   tiny-invariant@1.3.3: {}
 
@@ -5641,6 +5799,11 @@ snapshots:
       '@cloudflare/workerd-linux-64': 1.20260801.1
       '@cloudflare/workerd-linux-arm64': 1.20260801.1
       '@cloudflare/workerd-windows-64': 1.20260801.1
+
+  workers-ai-provider@4.0.0(@ai-sdk/provider@4.0.6)(ai@7.0.55(zod@4.4.3)):
+    dependencies:
+      '@ai-sdk/provider': 4.0.6
+      ai: 7.0.55(zod@4.4.3)
 
   wrangler@4.119.0(@cloudflare/workers-types@5.20260804.1):
     dependencies:

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -1,6 +1,9 @@
-import { Agent, callable, type Connection } from 'agents'
+import { AIChatAgent, type OnChatMessageOptions } from '@cloudflare/ai-chat'
+import { callable, type Connection } from 'agents'
+import { type GenerateTextOnFinishCallback, type LanguageModel, type ToolSet } from 'ai'
 import { z } from 'zod'
 
+import { chatRequestBody } from '../shared/chat'
 import {
 	type Disposition,
 	type Offer,
@@ -17,6 +20,8 @@ import {
 	planSchema,
 	type Source,
 } from '../shared/plan'
+import { chatTurn } from './llm/chat-turn'
+import { model } from './llm/model'
 
 /** One Offer row as SQLite returns it. `this.sql` asserts the row type rather
  * than checking it, and this class is the table's only writer, so the columns
@@ -52,9 +57,11 @@ function missingOffer(id: string): Error {
 
 /**
  * One Article Agent per Article — docs/architecture.md §2, and §3 for what goes
- * in the state blob against what goes in its SQLite.
+ * in the state blob against what goes in its SQLite. `AIChatAgent` adds the
+ * Chat: it keeps the transcript in its own SQLite tables, which nothing
+ * mirrors, and routes a turn to `onChatMessage` below (§6).
  */
-export class ArticleAgent extends Agent<Env, Plan> {
+export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	initialState = emptyPlan()
 
 	/** Runs on every wake, so every statement here has to be idempotent. A new
@@ -78,6 +85,68 @@ export class ArticleAgent extends Agent<Env, Plan> {
 
 	async onRequest(_request: Request): Promise<Response> {
 		return Response.json({ agent: 'ArticleAgent', name: this.name })
+	}
+
+	/** The model a Chat turn runs on. Named for the Chat even though one model
+	 * currently serves every call (§7): "model" alone does not say which of the
+	 * app's several meanings is meant, and a Review or a Guide pass choosing its
+	 * own model later is a likely enough change to leave room for.
+	 *
+	 * `llm/model.ts` is the boundary; this reads it so a workerd test, which has
+	 * no Workers AI binding to reach, can put a scripted model behind it. */
+	chatModel(): LanguageModel {
+		return model(this.env)
+	}
+
+	/**
+	 * One Chat turn. `llm/chat-turn.ts` composes it; this supplies the three
+	 * things only the Article Agent holds — the model, the Plan, and the
+	 * transcript — and hands back the stream.
+	 */
+	async onChatMessage(
+		onFinish: GenerateTextOnFinishCallback<ToolSet>,
+		options?: OnChatMessageOptions,
+	): Promise<Response> {
+		return chatTurn({
+			model: this.chatModel(),
+			plan: this.planForTurn(options?.body),
+			messages: this.messages,
+			abortSignal: options?.abortSignal,
+			onFinish,
+		})
+	}
+
+	/**
+	 * The Plan the turn is about. The client sends it in `body`, never in
+	 * `metadata`, which persists on the `UIMessage` and re-rides every turn
+	 * (§6).
+	 *
+	 * **The body wins over state, and the two can disagree.** A client that
+	 * applies a Proposal and sends the next turn before its `setState` lands
+	 * holds a newer Plan than the Agent stored, and the turn should be about the
+	 * one the writer is looking at. Nothing reconciles them, so the model can be
+	 * shown a Plan this Agent never stored — which is correct here and is a fact
+	 * #26 has to build for.
+	 *
+	 * An absent Plan is ordinary: a turn the client did not originate carries no
+	 * body, and state is the only Plan there is. One that is present and does
+	 * not parse is a bug, and refusing the turn is what says so.
+	 */
+	private planForTurn(body: Record<string, unknown> | undefined): Plan {
+		const sent = chatRequestBody.safeParse(body ?? {})
+		if (!sent.success) {
+			// Same shape as validateStateChange: the frame carries which rule
+			// failed, because whatever renders a thrown turn will not. It goes to
+			// every connection rather than to one, since onChatMessage is not told
+			// which of them sent the turn.
+			const reason = z.prettifyError(sent.error)
+			const refusal: PlanRefused = { type: 'plan_refused', error: reason }
+			this.broadcast(JSON.stringify(refusal))
+
+			throw new Error(`The Plan sent with this turn does not parse. ${reason}`)
+		}
+
+		return sent.data.plan ?? this.state
 	}
 
 	/**

--- a/src/server/env.d.ts
+++ b/src/server/env.d.ts
@@ -1,0 +1,17 @@
+/**
+ * Bindings the Worker reads that `wrangler types` cannot see.
+ *
+ * It generates `Env` from `wrangler.jsonc`, so anything set outside that file —
+ * a var or a secret put there from the CLI or the dashboard — is absent from
+ * the generated type. Declaring it here merges with the generated interface
+ * rather than replacing it.
+ *
+ * Optional, because it genuinely may be unset: a deployment that has not named
+ * a Gateway, and every test, run without one.
+ */
+interface Env {
+	/** The AI Gateway the model calls log through, set from the CLI. Unset
+	 * attaches no Gateway. A Gateway that does not exist fails the call, so an
+	 * unset value is the safe state rather than a degraded one. */
+	AI_GATEWAY_ID?: string
+}

--- a/src/server/llm/chat-turn.ts
+++ b/src/server/llm/chat-turn.ts
@@ -1,0 +1,64 @@
+import {
+	convertToModelMessages,
+	type GenerateTextOnFinishCallback,
+	type LanguageModel,
+	streamText,
+	type ToolSet,
+	type UIMessage,
+} from 'ai'
+
+import type { Plan } from '../../shared/plan'
+import { chatPackMessages, chatSystemPrompt } from './prompt'
+import { repairToolCall } from './repair'
+import { chatTools } from './tools'
+
+/**
+ * One Chat turn, composed away from the Durable Object that hosts it.
+ *
+ * Everything here is a pure function of what it is handed, so a test drives it
+ * with a scripted model and no Article Agent — which is what keeps the model
+ * boundary out of the class's API. The Article Agent supplies the Plan, the
+ * transcript, and the model, because it is the only thing that holds them.
+ */
+export type ChatTurn = {
+	model: LanguageModel
+	plan: Plan
+	messages: UIMessage[]
+	onFinish: GenerateTextOnFinishCallback<ToolSet>
+	abortSignal?: AbortSignal
+}
+
+export async function chatTurn({
+	model,
+	plan,
+	messages,
+	onFinish,
+	abortSignal,
+}: ChatTurn): Promise<Response> {
+	const result = streamText({
+		model,
+		// The guide rules, then the conversation, then the Plan. The transcript is
+		// the append-only part and the Plan is not, so the Plan goes after it —
+		// docs/architecture.md §7. `chatPackMessages` says where exactly.
+		system: chatSystemPrompt(),
+		messages: chatPackMessages(await convertToModelMessages(messages), plan),
+		tools: chatTools,
+		abortSignal,
+		onFinish,
+		repairToolCall: repairToolCall(model),
+	})
+
+	// The UI message stream is what `onChatMessage` has to hand back, and
+	// returning it here keeps the whole turn in one place.
+	//
+	// `onError` overrides the SDK's default, which replaces every error with
+	// "An error occurred." That default guards against leaking a server's
+	// internals to a browser it does not trust, and this one is the writer's own
+	// app: what it would hide is the schema's reason for refusing the model's
+	// tool call, which is exactly what the writer needs to see when a model
+	// thrashes the retry (§6). The same argument as `plan_refused` in
+	// `src/shared/plan/refusal.ts`.
+	return result.toUIMessageStreamResponse({
+		onError: (error) => (error instanceof Error ? error.message : String(error)),
+	})
+}

--- a/src/server/llm/model.ts
+++ b/src/server/llm/model.ts
@@ -1,0 +1,34 @@
+import type { LanguageModel } from 'ai'
+import { createWorkersAI } from 'workers-ai-provider'
+
+/**
+ * The whole model boundary — `docs/architecture.md` §7. One model serves every
+ * call, and this is the only place it is named: swapping the string below is
+ * the entire swap. Do not wrap this in `complete()` / `stream()` /
+ * `structured()`. AI SDK v7 already provides those as `generateText`,
+ * `streamText`, and `generateObject`, and a wrapper would break the
+ * `execute`-less tool machinery a Proposal rides on.
+ *
+ * If glm-5.2's tool calling or structured output disappoints, the documented
+ * swap is `@cf/moonshotai/kimi-k2.6` — same 262k context, same catalogue.
+ */
+const modelId = '@cf/zai-org/glm-5.2'
+
+/**
+ * AI Gateway attaches for logging, and response caching stays off: two guide
+ * passes over different Drafts look near-identical to a cache and would come
+ * back with each other's Notes.
+ *
+ * `AI_GATEWAY_ID` names the Gateway. It is set from the CLI rather than checked
+ * in — `wrangler.jsonc` says why — so an unset value is ordinary and attaches
+ * no Gateway. Leave the Gateway itself unauthenticated: a binding call is
+ * same-account and `GatewayOptions` carries nowhere to put a token.
+ */
+function gatewayFor(env: Env) {
+	return env.AI_GATEWAY_ID ? { id: env.AI_GATEWAY_ID, skipCache: true } : undefined
+}
+
+// The return type is stated rather than inferred: the provider's model class
+// carries private fields, which a project building declarations cannot name.
+export const model = (env: Env): LanguageModel =>
+	createWorkersAI({ binding: env.AI, gateway: gatewayFor(env) })(modelId)

--- a/src/server/llm/prompt.ts
+++ b/src/server/llm/prompt.ts
@@ -1,0 +1,98 @@
+import type { ModelMessage } from 'ai'
+
+import type { Plan } from '../../shared/plan'
+
+/**
+ * The Chat turn's prompt pack — `docs/architecture.md` §7. The pack is the
+ * conversation plus the Plan, in that order: **the transcript is append-only
+ * and the Plan is not**, so the conversation is the stable part and the Plan
+ * is the volatile one.
+ *
+ * That reverses the ordering §7 first stated, which put the Plan in the system
+ * prefix ahead of the conversation. Under that arrangement every Accepted
+ * Proposal changed a prefix the whole transcript sat behind, so the product's
+ * main loop invalidated its own cache on each pass. It is also simply the
+ * clearer structure: the beginning of the Chat stays the beginning of the
+ * context, and the artifact under construction sits where the model reads it
+ * last.
+ */
+
+/** The product's own instructions to the guide, identical on every turn of
+ * every Article, so they sit at the very front of the cached prefix. Not the
+ * **standing rules**, which `context.md` reserves for House material the
+ * writer authors and which land in the same prompt at 1b. */
+const guideRules = [
+	'You are the guide in a writing harness. The writer writes the prose and you help them plan it.',
+	'',
+	'You never write prose for the Draft, and you never write the Plan. You propose changes to the',
+	'Plan with the proposePlanChange tool and the writer Accepts or Declines each one. A turn that',
+	'answers a question, or asks one, carries no tool call at all.',
+	'',
+	'Judge the writing only against the Plan, its intent notes, and the Lexicon. Your own taste is',
+	'borrowed and does not count: a Section that meets its stated intent in a register you would not',
+	'have chosen is right, and saying so is the job. Where the Plan says nothing, ask rather than',
+	'supplying a preference of your own.',
+	'',
+	'One Voice applies at a time and the nearest Scope wins outright, so switching a Voice replaces',
+	'it. Adjectives compose instead, accumulating from the Article down to the Section.',
+].join('\n')
+
+/**
+ * The stable prefix of one Chat turn.
+ *
+ * Two things join the guide rules here, and both arrive with the House at 1b:
+ * the Lexicon entries in play, and the writer's own standing rules. Nothing
+ * goes in either slot until then. The Plan does not belong here — see the
+ * ordering note above.
+ */
+export function chatSystemPrompt(): string {
+	return guideRules
+}
+
+/**
+ * The Plan the turn is about, rendered whole.
+ *
+ * JSON rather than prose, because a Proposal anchors on the ids in it and an op
+ * naming an id the model paraphrased is refused by the applier. Compact rather
+ * than indented: indenting a Plan of a few hundred Sections buys the model
+ * nothing and costs the whitespace in tokens on every turn, and twice on a turn
+ * that retries.
+ *
+ * The `user` role rather than `system`, because a system message after the
+ * first is not portable across providers.
+ */
+function planMessage(plan: Plan): ModelMessage {
+	return {
+		role: 'user',
+		content: [
+			'The Plan for this Article as it stands now:',
+			'```json',
+			JSON.stringify(plan),
+			'```',
+		].join('\n'),
+	}
+}
+
+/**
+ * The conversation with the Plan in it — after every turn but the last, so the
+ * writer's own words are the last thing the model reads.
+ *
+ * Two orderings are defensible and neither has met a real model yet. Appending
+ * the Plan after everything is one message cheaper to cache, and it makes a
+ * JSON blob the final thing in the prompt, which risks a turn that answers the
+ * Plan rather than the question — a model weights the last message as the one
+ * to respond to, and this one opens "The Plan for this Article". Slotting it in
+ * front of the last message costs one message of prefix and follows the
+ * ordinary shape of retrieved context, which precedes the question that needs
+ * it. That is the one taken here, and flipping it is one line. Check it on the
+ * first real turn, before #26 builds a Panel around the answer.
+ */
+export function chatPackMessages(
+	conversation: ModelMessage[],
+	plan: Plan,
+): ModelMessage[] {
+	const last = conversation.length - 1
+	if (last < 0) return [planMessage(plan)]
+
+	return [...conversation.slice(0, last), planMessage(plan), conversation[last]]
+}

--- a/src/server/llm/repair.ts
+++ b/src/server/llm/repair.ts
@@ -1,0 +1,49 @@
+import {
+	generateText,
+	type LanguageModel,
+	type ToolCallRepairFunction,
+	type ToolSet,
+} from 'ai'
+
+/**
+ * One retry of a tool call the schema refused, carrying the validation error
+ * back to the model — `docs/architecture.md` §6 and §7.
+ *
+ * The op payloads are strict, so a model that adds one field fails the whole
+ * call rather than having the field stripped: stripping would produce a
+ * Proposal the model did not make, and the writer would rule on it without
+ * seeing what was dropped. The cost is real. A model that adds the same field
+ * every time thrashes this retry instead of converging, and the answer to that
+ * is naming the field in the schema, not loosening the payload.
+ *
+ * The AI SDK calls this once per refused call, so one retry is the whole
+ * budget. Returning null gives up and lets the turn carry the error.
+ *
+ * The tools come from the callback rather than from an import, so this belongs
+ * to no one pack — §7 lists four, and each of them wants the same retry.
+ */
+export function repairToolCall(model: LanguageModel): ToolCallRepairFunction<ToolSet> {
+	return async ({ system, messages, toolCall, tools, error }) => {
+		const { toolCalls } = await generateText({
+			model,
+			system,
+			messages: [
+				...messages,
+				{
+					role: 'user',
+					content: [
+						`The ${toolCall.toolName} call was refused: ${error.message}`,
+						'Call it again, correcting only what the error names.',
+					].join('\n'),
+				},
+			],
+			tools,
+			toolChoice: 'required',
+		})
+
+		const [call] = toolCalls
+		if (!call || call.toolName !== toolCall.toolName) return null
+
+		return { ...toolCall, input: JSON.stringify(call.input) }
+	}
+}

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -1,0 +1,50 @@
+import { tool, type ToolSet } from 'ai'
+
+import { proposePlanChangeInput, proposePlanChangeTool } from '../../shared/chat'
+
+/**
+ * The tools a Chat turn is given, and the descriptions that teach a model to
+ * use them. The name and the input schema are `src/shared/chat.ts`, because
+ * the Chat Panel matches on both.
+ *
+ * The Proposal tool is **`execute`-less**: a tool with no `execute` suspends
+ * for the client, and that suspension is the Proposal the writer rules on —
+ * `docs/architecture.md` §6. It writes nothing, because the Chat proposes and
+ * the client applies (§3, rule 4).
+ *
+ * Do not reach for `needsApproval` or `toolApproval`. Both gate a server-side
+ * `execute` this product does not have.
+ *
+ * #28 adds an Offer tool here. That one does carry an `execute`, because
+ * recording an Offer is a row on the Article Agent rather than something the
+ * writer rules on mid-turn — so the invariant is per tool rather than for the
+ * registry, and `getCurrentAgent()` from `agents` is how it reaches the
+ * instance without this module taking the Durable Object as a parameter.
+ */
+
+const proposePlanChange = tool({
+	description: [
+		'Propose a change to the Plan for the writer to Accept or Decline.',
+		'The ops apply all-or-nothing, in the order given. You never write the Plan yourself.',
+		'',
+		'A content op - setTitle, setIntent, setTarget, setVoice, setAdjectives - carries an',
+		'"expected" field, the value you believe is there now, compared whole-field. Read it off',
+		'the Plan you were given. On a content op, "nodeId": null means the Article rather than',
+		'one Section.',
+		'',
+		'A structural op - createNode, moveNode - anchors on ids and states exactly one of',
+		'"afterId" and "beforeId": name whichever neighbour the change relates to, so the op',
+		'survives the other neighbour being deleted. "afterId": null means first child, and',
+		'"beforeId": null means last child.',
+		'',
+		'deleteNode unplaces every Reference placed at the node it removes and at any node below',
+		"it. mergeNodes keeps the target's own fields, so carry the source's intent note over",
+		'with a setIntent op in the same batch when you want it kept.',
+	].join('\n'),
+	inputSchema: proposePlanChangeInput,
+})
+
+/** Typed as the whole `ToolSet` rather than inferred: nothing here has an
+ * `execute`, so there is no return type to infer, and the wide type is what
+ * lets the Agent's `onFinish` callback fit `streamText`'s. */
+export const chatTools: ToolSet = { [proposePlanChangeTool]: proposePlanChange }

--- a/src/shared/chat.ts
+++ b/src/shared/chat.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod'
+
+import { planSchema, proposalSchema } from './plan'
+
+/**
+ * What the two ends of a Chat turn agree on. The Article Agent declares the
+ * Proposal tool and reads the request body; the Chat Panel matches the
+ * suspended tool call by name and reads its input. Neither side may state
+ * these on its own, so they live where both can import them — the client
+ * tsconfig carries `src/shared` and nothing else of the server's.
+ *
+ * The model-facing half — what the tool's description tells the model — stays
+ * in `src/server/llm/tools.ts`, because no client reads it.
+ */
+
+/** The name the Proposal tool is registered and matched under. */
+export const proposePlanChangeTool = 'proposePlanChange'
+
+/**
+ * What the model fills in to make a Proposal, and what the client reads off
+ * the suspended call. Strict, like the op payloads inside it: a model that
+ * adds a field fails the whole call and retries with the validation error
+ * rather than having the field silently stripped — `docs/architecture.md` §6.
+ */
+export const proposePlanChangeInput = z.strictObject({ ops: proposalSchema })
+export type ProposePlanChangeInput = z.infer<typeof proposePlanChangeInput>
+
+/**
+ * What the client sends alongside the messages. The Plan rides here because
+ * `body` is request-only, where `metadata` persists on the `UIMessage` and
+ * re-rides every turn (§6).
+ *
+ * Not strict: the Agents SDK hands the turn every body key it did not consume
+ * itself, and this schema speaks for one of them.
+ */
+export const chatRequestBody = z.object({ plan: planSchema.optional() })

--- a/test/worker/agent-socket.ts
+++ b/test/worker/agent-socket.ts
@@ -3,7 +3,7 @@ import { SELF } from 'cloudflare:test'
 /** One JSON frame off the Article Agent's WebSocket. The socket is
  * multiplexed — state, RPC, identity, and MCP frames all ride it — so a test
  * asks for the frame it wants rather than reading the next one. */
-type Frame = { type: string } & Record<string, unknown>
+export type Frame = { type: string } & Record<string, unknown>
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
@@ -42,12 +42,68 @@ export async function openAgentSocket(name: string) {
 		throw new Error(`No ${wanted} frame arrived on the ${name} socket.`)
 	}
 
+	/** Every chunk of one Chat turn's UI message stream, in arrival order: a
+	 * stream is a sequence, so this takes the next chunk each time rather than
+	 * matching on what it holds.
+	 *
+	 * `useAgentChat` is the real client, and it needs React, so this drives the
+	 * same `cf_agent_use_chat_*` frames itself. */
+	async function readChatStream(id: string): Promise<Frame[]> {
+		const chunks: Frame[] = []
+
+		for (;;) {
+			const frame = await take(
+				(candidate) =>
+					candidate.type === 'cf_agent_use_chat_response' && candidate.id === id,
+				'Chat stream chunk',
+			)
+
+			// A frame carries one JSON chunk, except the terminal one the Agent
+			// sends when a turn produced no response at all, which carries prose.
+			if (typeof frame.body === 'string' && frame.body.startsWith('{')) {
+				chunks.push(JSON.parse(frame.body) as Frame)
+			}
+			if (frame.done === true) return chunks
+		}
+	}
+
 	return {
 		/** Push a Plan up the socket, the way the client applies every Plan
 		 * write. Nothing is awaited: the Agent answers with a broadcast or an
 		 * error frame. */
 		setState(state: unknown) {
 			socket.send(JSON.stringify({ type: 'cf_agent_state', state }))
+		},
+
+		/** Send one Chat turn and read its stream to the end.
+		 *
+		 * The Plan rides in `body`, which is request-only, and never in
+		 * `metadata`, which persists on the `UIMessage` and re-rides every turn
+		 * — docs/architecture.md §6. */
+		async chat(text: string, body: Record<string, unknown> = {}): Promise<Frame[]> {
+			const id = crypto.randomUUID()
+			const message = {
+				id: crypto.randomUUID(),
+				role: 'user',
+				parts: [{ type: 'text', text }],
+			}
+
+			socket.send(
+				JSON.stringify({
+					type: 'cf_agent_use_chat_request',
+					id,
+					init: {
+						method: 'POST',
+						body: JSON.stringify({
+							messages: [message],
+							trigger: 'submit-message',
+							...body,
+						}),
+					},
+				}),
+			)
+
+			return readChatStream(id)
 		},
 
 		/** Call a `@callable` method and wait for its answer. */

--- a/test/worker/chat-turn.test.ts
+++ b/test/worker/chat-turn.test.ts
@@ -1,0 +1,296 @@
+import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
+import { env, runInDurableObject } from 'cloudflare:test'
+import { describe, expect, it } from 'vitest'
+
+import type { ProposalInput } from '../../src/shared/plan'
+import { makeNode, makePlan } from '../shared/plan-fixtures'
+import { type Frame, openAgentSocket } from './agent-socket'
+
+/**
+ * The server side of a Chat turn — docs/architecture.md §6 and §7.
+ *
+ * No test calls a model: Workers AI is a remote-only binding and
+ * `vitest.config.ts` keeps remote bindings off, so a fresh clone can run
+ * `pnpm test` without an API token. What these tests drive instead is the
+ * Article Agent's `chatModel()` method, replaced with a scripted one. The
+ * boundary under test is what the turn does with a model's answer, and that is
+ * the same boundary either way.
+ */
+
+/** One part of a scripted model's stream. Read off `MockLanguageModelV3`
+ * rather than imported: the union lives in `@ai-sdk/provider`, which this repo
+ * has only as a transitive package. Stating it is what keeps a chunk list from
+ * widening to `string` and typechecking against nothing. */
+type StreamResult = Awaited<ReturnType<MockLanguageModelV3['doStream']>>
+type StreamPart = StreamResult['stream'] extends ReadableStream<infer Part> ? Part : never
+type GenerateResult = Awaited<ReturnType<MockLanguageModelV3['doGenerate']>>
+
+/** How a turn ended. A provider also reports its own raw reason, and nothing
+ * here reads that. */
+const stopped = { unified: 'stop' as const, raw: undefined }
+const calledATool = { unified: 'tool-calls' as const, raw: undefined }
+
+/** Token counts a real provider fills in. Nothing here reads them. */
+const noUsage = {
+	inputTokens: { total: 0, noCache: 0, cacheRead: 0, cacheWrite: 0 },
+	outputTokens: { total: 0, text: 0, reasoning: 0 },
+}
+
+/** One scripted turn read back as a whole answer rather than as a stream, for
+ * the calls that do not stream. `repairToolCall` is the one that matters: it
+ * retries a refused call with `generateText`, because nothing consumes a
+ * retry's stream. */
+function whole(turn: StreamPart[]): GenerateResult {
+	const finish = turn.find((part) => part.type === 'finish')
+	const content: GenerateResult['content'] = []
+
+	for (const part of turn) {
+		if (part.type === 'tool-call') content.push(part)
+		if (part.type === 'text-delta') content.push({ type: 'text', text: part.delta })
+	}
+
+	return {
+		content,
+		finishReason: finish?.type === 'finish' ? finish.finishReason : stopped,
+		usage: noUsage,
+		warnings: [],
+	}
+}
+
+/** A model that plays these turns back, one per call, streamed or whole. Both
+ * entry points share the counter, so a turn that streams and then retries
+ * takes the first two turns in order.
+ *
+ * The counter is ours rather than `MockLanguageModelV3`'s own array handling,
+ * which reads `doStream[this.doStreamCalls.length]` after pushing the call and
+ * so answers the first call with the second element. */
+function scripted(turns: StreamPart[][]) {
+	let call = 0
+
+	return new MockLanguageModelV3({
+		doStream: async () => ({
+			stream: simulateReadableStream({ chunks: turns[call++] ?? [] }),
+		}),
+		doGenerate: async () => whole(turns[call++] ?? []),
+	})
+}
+
+/** A model that answers in prose, the way a turn that discusses the Plan does. */
+function speaks(text: string) {
+	const turn: StreamPart[] = [
+		{ type: 'stream-start', warnings: [] },
+		{ type: 'text-start', id: 't1' },
+		{ type: 'text-delta', id: 't1', delta: text },
+		{ type: 'text-end', id: 't1' },
+		{ type: 'finish', finishReason: stopped, usage: noUsage },
+	]
+
+	return scripted([turn])
+}
+
+/** One turn calling the Proposal tool. The tool has no `execute`, so the call
+ * suspends rather than running, and that suspension is the Proposal. */
+function proposalTurn(input: string): StreamPart[] {
+	return [
+		{ type: 'stream-start', warnings: [] },
+		{ type: 'tool-input-start', id: 'call-1', toolName: 'proposePlanChange' },
+		{ type: 'tool-input-delta', id: 'call-1', delta: input },
+		{ type: 'tool-input-end', id: 'call-1' },
+		{
+			type: 'tool-call',
+			toolCallId: 'call-1',
+			toolName: 'proposePlanChange',
+			input,
+		},
+		{ type: 'finish', finishReason: calledATool, usage: noUsage },
+	]
+}
+
+/** A model that proposes, taking each input in turn, so a test can script a
+ * refused call and the retry that follows it. */
+function proposes(...inputs: string[]) {
+	return scripted(inputs.map(proposalTurn))
+}
+
+/** Put a scripted model behind the Article Agent's model boundary. The model
+ * records the calls made against it, so the caller keeps its own reference and
+ * reads the prompt pack off `doStreamCalls`. */
+async function scriptModel(name: string, model: MockLanguageModelV3): Promise<void> {
+	const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName(name))
+	await runInDurableObject(stub, (agent) => {
+		agent.chatModel = () => model
+	})
+}
+
+const plan = makePlan({
+	title: 'The permit queue',
+	totalTarget: 1200,
+	outline: [
+		makeNode({ id: 'n1', title: 'The opening', intent: 'Open on one refused permit.' }),
+	],
+})
+
+const proposal: ProposalInput = [
+	{ op: 'setTarget', nodeId: 'n1', expected: null, value: 400 },
+]
+
+/** The chunk types a turn streamed, which is what tells a Proposal turn from a
+ * prose one without reaching into the transcript. */
+const types = (chunks: Frame[]) => chunks.map((chunk) => chunk.type)
+
+describe('a Chat turn', () => {
+	it('returns a Proposal as a suspended tool call', async () => {
+		const writer = await openAgentSocket('chat-proposal')
+		await scriptModel('chat-proposal', proposes(JSON.stringify({ ops: proposal })))
+
+		const chunks = await writer.chat('Give the opening a word count.', { plan })
+
+		expect(types(chunks)).toContain('tool-input-available')
+		expect(types(chunks)).not.toContain('tool-output-available')
+
+		const call = chunks.find((chunk) => chunk.type === 'tool-input-available')
+		expect(call).toMatchObject({
+			toolName: 'proposePlanChange',
+			input: { ops: proposal },
+		})
+	})
+
+	it('returns prose with no tool call', async () => {
+		const writer = await openAgentSocket('chat-prose')
+		await scriptModel('chat-prose', speaks('Four hundred words fits that opening.'))
+
+		const chunks = await writer.chat('Is four hundred words right for the opening?', {
+			plan,
+		})
+
+		expect(types(chunks)).toContain('text-delta')
+		expect(types(chunks)).not.toContain('tool-input-available')
+		expect(chunks.find((chunk) => chunk.type === 'text-delta')).toMatchObject({
+			delta: 'Four hundred words fits that opening.',
+		})
+	})
+
+	// The transcript is append-only and the Plan is not, so the Plan follows the
+	// conversation — §7. It goes in front of the last message rather than after
+	// it, so the writer's own words stay the last thing the model reads.
+	it('packs the guide rules, then the conversation, then the Plan', async () => {
+		const writer = await openAgentSocket('chat-pack')
+		const model = speaks('Noted.')
+		await scriptModel('chat-pack', model)
+
+		await writer.chat('What is the opening for?', { plan })
+
+		const [call] = model.doStreamCalls
+		const system = call.prompt.find((message) => message.role === 'system')
+
+		expect(String(system?.content)).toContain('Your own taste is')
+		// The Plan is not in the prefix, which is the whole point of the ordering.
+		expect(String(system?.content)).not.toContain('The permit queue')
+
+		const [, ...conversation] = call.prompt
+		expect(conversation).toHaveLength(2)
+
+		const planBlock = JSON.stringify(conversation[0])
+		expect(planBlock).toContain('The permit queue')
+		expect(planBlock).toContain('Open on one refused permit.')
+
+		expect(JSON.stringify(conversation.at(-1))).toContain('What is the opening for?')
+	})
+
+	it('offers the Proposal tool without an execute, so the call suspends', async () => {
+		const writer = await openAgentSocket('chat-tools')
+		const model = speaks('Noted.')
+		await scriptModel('chat-tools', model)
+
+		await writer.chat('Anything to say about the outline?', { plan })
+
+		const [call] = model.doStreamCalls
+		expect(call.tools?.map((tool) => tool.name)).toEqual(['proposePlanChange'])
+	})
+
+	it('falls back to the Plan in state when the turn carries no body', async () => {
+		const writer = await openAgentSocket('chat-no-body')
+		// A second connection reads the broadcast, because the Agent does not
+		// echo a Plan back to the connection that wrote it. Waiting on it is
+		// what makes the write land before the turn reads state.
+		const reader = await openAgentSocket('chat-no-body')
+		await reader.next('cf_agent_state')
+		writer.setState(plan)
+		await reader.next('cf_agent_state')
+		const model = speaks('Noted.')
+		await scriptModel('chat-no-body', model)
+
+		await writer.chat('What is the opening for?')
+
+		const [call] = model.doStreamCalls
+
+		// Second to last, because the writer's own message stays last.
+		expect(JSON.stringify(call.prompt.at(-2))).toContain('The permit queue')
+	})
+
+	// The op payloads are strict, so a model that adds a field fails the whole
+	// call rather than having the field stripped — docs/architecture.md §6.
+	it('retries a refused tool call, carrying the validation error back', async () => {
+		const writer = await openAgentSocket('chat-retry')
+		const withExtraField = JSON.stringify({
+			ops: [
+				{ op: 'setTarget', nodeId: 'n1', expected: null, value: 400, why: 'it is short' },
+			],
+		})
+		const model = proposes(withExtraField, JSON.stringify({ ops: proposal }))
+		await scriptModel('chat-retry', model)
+
+		const chunks = await writer.chat('Give the opening a word count.', { plan })
+
+		// The retry is a `generateText` call, so it lands on doGenerate rather
+		// than beside the streamed turn.
+		const [retry] = model.doGenerateCalls
+		const reask = JSON.stringify(retry.prompt.at(-1))
+		expect(reask).toContain('was refused')
+		expect(reask).toContain('why')
+		expect(chunks.find((chunk) => chunk.type === 'tool-input-available')).toMatchObject({
+			input: { ops: proposal },
+		})
+	})
+
+	// The failure mode §6 names as the cost of strict payloads: a model that
+	// adds the same field every time thrashes the retry instead of converging.
+	// One retry is the whole budget, so the second refusal ends the turn.
+	it('gives up when the retry is refused too, and says so', async () => {
+		const writer = await openAgentSocket('chat-retry-exhausted')
+		const withExtraField = JSON.stringify({
+			ops: [
+				{ op: 'setTarget', nodeId: 'n1', expected: null, value: 400, why: 'it is short' },
+			],
+		})
+		const model = proposes(withExtraField, withExtraField)
+		await scriptModel('chat-retry-exhausted', model)
+
+		const chunks = await writer.chat('Give the opening a word count.', { plan })
+
+		// It asked twice and got nowhere, so no Proposal reaches the writer.
+		expect(model.doGenerateCalls).toHaveLength(1)
+		expect(types(chunks)).not.toContain('tool-input-available')
+		expect(types(chunks)).toContain('tool-input-error')
+
+		// And the error names the field the model kept adding, rather than the
+		// SDK's default "An error occurred."
+		const failed = chunks.find((chunk) => chunk.type === 'tool-input-error')
+		expect(String(failed?.errorText)).toContain('why')
+	})
+
+	it('keeps the transcript in the Agents SDK store, and the Plan out of it', async () => {
+		const writer = await openAgentSocket('chat-transcript')
+		await scriptModel('chat-transcript', speaks('Noted.'))
+
+		await writer.chat('What is the opening for?', { plan })
+
+		const response = await env.ArticleAgent.get(
+			env.ArticleAgent.idFromName('chat-transcript'),
+		).fetch('https://harness.test/agents/article-agent/chat-transcript/get-messages')
+		const messages = (await response.json()) as { role: string; parts: unknown[] }[]
+
+		expect(messages.map((message) => message.role)).toEqual(['user', 'assistant'])
+		expect(JSON.stringify(messages)).not.toContain('The permit queue')
+	})
+})

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -42,6 +42,13 @@
     "binding": "AI",
   },
 
+  // AI_GATEWAY_ID is deliberately not declared here. It names the account's AI
+  // Gateway, which is deployment configuration rather than repo content, and a
+  // var declared in this file overwrites the deployed value on every
+  // `wrangler deploy` — so declaring it even as an empty placeholder would wipe
+  // the one set from the CLI. Its type is in src/server/env.d.ts, and
+  // llm/model.ts is the only thing that reads it.
+
   "observability": {
     "enabled": true,
   },


### PR DESCRIPTION
Closes #25.

The server side of a Chat turn. The Article Agent extends `AIChatAgent`, so a turn runs on the socket the Plan and the RPC already share, and a Proposal arrives at the client as a suspended tool call rather than as anything the server applied.

## What to look at, in order

**`src/server/llm/model.ts` — the whole model boundary.** One function, the only place the model is named. No `complete()` / `stream()` / `structured()` wrapper: AI SDK v7 already provides those, and a wrapper would break the `execute`-less tool machinery a Proposal rides on.

**`src/shared/chat.ts` — the contracts the Chat Panel needs.** The tool name, its input schema, and the request body schema. `tsconfig.client.json` carries only `src/shared`, so anything the client must match has to live there or #26 will re-declare it.

**`src/server/llm/tools.ts` — the Proposal tool.** `execute`-less, declaring the op vocabulary from `src/shared/plan/ops.ts` rather than restating it. `chatTools` is a plain object, so #28's Offer tool joins by being added.

**`src/server/llm/prompt.ts` — the prompt pack.** Guide rules in the system prefix, the Plan appended after the conversation. See the §7 revision below.

**`src/server/llm/repair.ts` — one retry carrying the validation error.** The op payloads are strict, so a model that adds a field fails the whole call rather than having the field stripped. This is what makes that workable. It takes its tools from the callback the SDK passes, so the Review and Guide passes reuse it unchanged.

**`src/server/article-agent.ts`** now supplies only the three things it alone holds — the model, the Plan, and the transcript — and hands them to `llm/chat-turn.ts`.

## Done when

Both cases from the ticket are covered in `test/worker/chat-turn.test.ts`: a turn returning a Proposal as a suspended tool call, and a turn returning prose with no tool call. 116 tests pass; lint, format, and typecheck are clean.

`test/worker/agent-socket.ts` gained a `chat()` method rather than a second client, as #25 asked, so #26 inherits it.

## Decisions taken here that go beyond the ticket

**AI SDK v7, not v6.** The ticket and §6/§7 named v6. `ai@7` is current and `agents@0.20.1` accepts either. The four API details §6 pins all survive the major: `addToolOutput` is current with `addToolResult` deprecated, `addToolApprovalResponse` takes the approval's own `id`, and `needsApproval` / `toolApproval` still gate a server-side `execute`.

**`AIChatAgent` moved out of `agents`.** Importing `agents/ai-chat-agent` now throws and points at `@cloudflare/ai-chat`, which is what this uses.

**§7's prompt ordering is revised.** It said the stable prefix goes first and put the Plan ahead of the conversation. The rule stands; the reading was wrong. A transcript only grows, while the Plan changes on every Accepted Proposal — so the Plan in front meant the product's main loop invalidated the whole transcript behind it, every pass. The Plan now follows the conversation, slotted in front of the writer's last message so their words stay the last thing the model reads.

**The AI Gateway is named by `AI_GATEWAY_ID`, set from the CLI rather than checked in** — a var declared in `wrangler.jsonc` overwrites the deployed value on every deploy, so a placeholder there would wipe it. Unset attaches no Gateway. Leave the Gateway unauthenticated: `GatewayOptions` has nowhere to put a token, because a binding call is same-account.

**Two doc revisions ride along**, both from review rather than from this ticket: the House stops meaning "everything that spans Articles" (#40), and the article index becomes a real D1 table built as the last 1a ticket (#29).

## The model is unexercised

Nothing here has called glm-5.2. Workers AI is a remote-only binding and `vitest.config.ts` keeps remote bindings off, so `pnpm test` needs no API token. The tests drive a scripted model through the Article Agent's `chatModel()` method instead.

So the ticket's "if the model disappoints" question is still open, and the swap to `@cf/moonshotai/kimi-k2.6` remains one string. The first real call belongs to whoever runs #26 against a logged-in Worker.

---
_Generated by [Claude Code](https://claude.ai/code)_