### PR TITLE
1a-07 The Plan Panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Node 22 and pnpm 11.
 pnpm install
 pnpm dev        # the client and the Worker together, on http://localhost:5173
 pnpm storybook  # the components and screens on their own, on http://localhost:6006
-pnpm test       # builds the client, then runs the smoke tests in workerd
+pnpm test       # builds the client, then runs every project
+                # `pnpm test:shared` and `pnpm test:client` skip the build and workerd
 pnpm typecheck
 pnpm lint       # oxlint
 pnpm format     # oxfmt, in place. `pnpm format:check` reports instead
@@ -62,13 +63,16 @@ Access gate, and requiring the header would make the app unrunnable in developme
 | Path                          | What it holds                                                         |
 | ----------------------------- | --------------------------------------------------------------------- |
 | `src/client/routes/`          | TanStack Router routes, one file each                                 |
-| `src/client/components/`      | The primitives: `Frame`, `PaneRail`, `Chip`, `SourceCard`, …          |
+| `src/client/components/`      | The primitives: `Frame`, `PanelRail`, `Chip`, `ReferenceCard`, …      |
+| `src/client/plan/`            | The Plan Panel: its op builders, its writer, and its fields           |
 | `src/client/screens/`         | The wireframed screens, built against mock data                       |
 | `src/client/styles/theme.css` | The Tailwind v4 `@theme` tokens                                       |
 | `src/server/`                 | The Hono Worker entry and the `ArticleAgent` Durable Object           |
 | `src/server/llm/`             | The model boundary, the Chat turn's prompt pack, and the tools        |
-| `test/`                       | Tests running in workerd through `@cloudflare/vitest-pool-workers`    |
+| `test/`                       | Tests, in three projects: `shared`, `client`, and `worker`            |
 | `docs/`                       | The architecture document, the ADRs, and [the UI notes](./docs/ui.md) |
 
 The screens are wireframes with nothing wired to them. They are superseded one at a time as
-the routes that replace them land, so treat them as reference rather than as a library.
+the routes that replace them land, so treat them as reference rather than as a library. The
+Plan Panel is the first one wired: `src/client/plan/` holds it, and the screens now render
+the same Plan through the same components.

--- a/context.md
+++ b/context.md
@@ -128,24 +128,34 @@ _Avoid_: level, tier, inheritance chain
 ## Offers and the Ledger
 
 **Offer**:
-Something the Chat turns up and hands to the writer to rule on. Two types so far,
-References and Quotes, and Offers stay flat — two Quotes from one publication are two
-Offers, not a Quote nested in something else.
+Something the Chat turns up and hands to the writer to rule on. Two types so far, Links
+and Quotes, and Offers stay flat — two Quotes from one publication are two Offers, not a
+Quote nested in something else.
 _Avoid_: offering, result, finding, suggestion, candidate, card
 
 **Reference**:
-Something the writer is drawing on. It carries a **text** — a passage pulled from the
-source, whether a quotation, a clip, or a key pullout — or a **source** — the attribution,
-with a title, an author or publication, a year, and a url, each of them optional. At
-least one of the two is present; an entry with neither is nothing.
-_Avoid_: source (a source is the attribution _inside_ a Reference), citation, cite
+The umbrella, and never a type of its own: **every Reference is a Link or a Quote.** It
+carries a **text** — a passage pulled from the source, whether a quotation, a clip, or a
+key pullout — or a **source** — the attribution, with a title, an author or publication, a
+year, and a url, each of them optional. At least one of the two is present; an entry with
+neither is nothing.
+_Avoid_: Reference for a Link (that is what made "a Reference of type reference" a
+tautology), source (a source is the attribution _inside_ a Reference), citation, cite
+
+**Link**:
+A Reference of type Link — something the writer is drawing on, named rather than quoted.
+Most carry a url and some do not: a print citation with an author, a publication, and a
+year is a Link, and so is a broadcast nobody has put online. Naming them for the common
+case is deliberate, and the field that holds the address is the **url**, so the two never
+share a word.
+_Avoid_: reference (see above), source, citation, cite, bookmark
 
 **Quote**:
 A Reference of type Quote — a passage pulled from the source rather than the attribution
-alone. Not a separate entity: one structure carries both, and the type says which. A Quote
-carries a text, and a Reference may carry one without being a Quote, because the type is
-stored on the record rather than read off the text. That is what stops the Offer ledger
-and the Plan Panel naming one item two ways.
+alone. Not a separate entity from a Link: one structure carries both, and the type says
+which. A Quote carries a text, and a Link may carry one without being a Quote, because
+the type is stored on the record rather than read off the text. That is what stops the
+Offer ledger and the Plan Panel naming one item two ways.
 _Avoid_: excerpt, passage, snippet, pull quote
 
 **Ledger**:
@@ -219,8 +229,8 @@ What sort of thing a record is, named after the record it belongs to — an Offe
 note type, a refusal type. For a Guidance note: structure, tone drift, citations,
 repetition, budget, pacing, plan divergence — illustrative rather than a fixed taxonomy,
 and the Notes Panel groups by it. A note about the Voice and a note about an Adjective are
-both tone drift, because the writer reads them the same way. For an Offer: Reference,
-Quote, and whatever comes later. The field is `type` throughout, and it reads the way the
+both tone drift, because the writer reads them the same way. For a Reference and for an
+Offer: Link, Quote, and whatever comes later. The field is `type` throughout, and it reads the way the
 phrase does: `offer.type`, not "the kind of an Offer".
 _Avoid_: kind, category, tag, label
 

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -111,6 +111,12 @@ The cost is that the type can now be wrong in a way it could not be when it was 
 so `referenceSchema` refines that a Quote carries a text, and `offerContentSchema` refines
 the same for an Offer. `context.md` carries the vocabulary.
 
+**Amended again:** the two type values are now `'link'` and `'quote'`, where the first was
+`'reference'`. Reference is the umbrella and never a type of its own, so "a Reference of
+type reference" was a tautology and the Panel printed it — a list headed References with
+its rows labelled reference. Most Links carry a url and some do not, which is why the
+field that holds the address keeps the name `url` and the type does not take it.
+
 **Consequence:** three quotes from one publication carry three copies of the attribution,
 so correcting a year is three edits. This is the same denormalisation #11 accepted when it
 chose copy-with-Provenance.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,12 +116,12 @@ plan: {
   a stable ID that never changes.
 - **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
   Section or nowhere yet.
-- **A Quote is a Reference of that `type`.** One structure: a pulled passage, an
-  attribution, or both, with at least one present. The type is **stored, not derived from
-  the text**, so an Offer and the Reference it was Accepted into carry one answer and the
-  Offer ledger and the Plan Panel cannot label an item differently. A Quote carries a text;
-  a Reference may carry one without being a Quote. Amended in
-  [ADR 0002](./adr/0002-the-plan-data-model.md).
+- **Every Reference is a Link or a Quote**, and Reference is the umbrella rather than a
+  type of its own. One structure: a pulled passage, an attribution, or both, with at least
+  one present. The type is **stored, not derived from the text**, so an Offer and the
+  Reference it was Accepted into carry one answer and the Offer ledger and the Plan Panel
+  cannot label an item differently. A Quote carries a text; a Link may carry one without
+  being a Quote. Amended in [ADR 0002](./adr/0002-the-plan-data-model.md).
 - **Voice replaces; Adjectives compose.** One Voice applies at a time and the nearest Scope
   wins outright. Adjectives accumulate. Resolution runs House, then Article, then
   Section, **at read time**. A Section's ancestors take part in that same order, so a Subsection
@@ -156,7 +156,7 @@ relief valve is moving References into SQLite rows, which is the phase 2 move an
 
 ## 5. Offers and the Ledger
 
-The Chat turns up **Offers** — References and Quotes — as SQLite rows in the Article Agent.
+The Chat turns up **Offers** — Links and Quotes — as SQLite rows in the Article Agent.
 Each carries a disposition: **Undecided**, **Accepted**, or **Declined**, and Declining is
 restorable. The **Ledger** is a View over Offers, not a store.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -224,10 +224,15 @@ proposal: [
 
 **Thirteen ops**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
 `deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
-`placeReference`, `createReference`, `deleteReference`, `setReference`. The last three are
-how the writer pastes a Reference in themselves, and the applier understanding an op does
-not mean the Chat may propose it: what the model is offered is the tool schema, and
-research reaches the Plan through the Ledger — §5. A content op reads `nodeId: null` as the Article Scope, so setting the
+`placeReference`, `createReference`, `deleteReference`, `setReference`.
+
+**The Chat is offered ten of them.** The three Reference ops are how the writer pastes a
+Reference in themselves, and `chatProposalSchema` leaves them out of the tool the model
+sees — research reaches the Plan by being Accepted from an Offer, and handing a model
+`createReference` would be a way round the Ledger (§5). The applier takes all thirteen,
+because the writer's own paste goes through it too.
+
+A content op reads `nodeId: null` as the Article Scope, so setting the
 Article's Voice and setting one node's Voice are one op rather than two. Two ops carry a
 consequence worth stating: **`deleteNode` unplaces every Reference placed at the node it
 removes or at any node below it**, because the Plan is written whole and a Reference naming a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,11 @@ Offers are flat. Two Quotes from one publication are two Offers.
 Accepting copies the Offer into the Plan as a new editable record carrying its Provenance —
 rule 5. Deduplicate a re-offered Reference on the Provenance, not on the content.
 
+**The writer pastes their own References straight into the Plan**, and those carry
+`provenance: { type: 'writer' }` rather than an Offer id. They never enter the Ledger: an
+Offer is something the Chat turned up and handed over to rule on, and there is nothing to
+rule on in a passage the writer typed.
+
 **A Proposal is not an Offer.** The writer rules on both the same way, but a Proposal lives
 in the Chat turn that made it, goes Stale, and leaves no record, where an Offer is a row that
 keeps its disposition.
@@ -217,9 +222,12 @@ proposal: [
   than greying it out — whole-field comparison is conservative and will refuse a Proposal
   against a field the writer has since touched.
 
-**Ten ops**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
+**Thirteen ops**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
 `deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
-`placeReference`. A content op reads `nodeId: null` as the Article Scope, so setting the
+`placeReference`, `createReference`, `deleteReference`, `setReference`. The last three are
+how the writer pastes a Reference in themselves, and the applier understanding an op does
+not mean the Chat may propose it: what the model is offered is the tool schema, and
+research reaches the Plan through the Ledger — §5. A content op reads `nodeId: null` as the Article Scope, so setting the
 Article's Voice and setting one node's Voice are one op rather than two. Two ops carry a
 consequence worth stating: **`deleteNode` unplaces every Reference placed at the node it
 removes or at any node below it**, because the Plan is written whole and a Reference naming a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -329,6 +329,20 @@ already reactive through Article Agent state and, at 1b, party-db's TanStack DB 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen. The **Areas** are Articles (with Board and Archive Views), House, and Team.
 
+**The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
+in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
+`expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to
+`setState`. One write path means the Panel cannot make a change the applier would refuse,
+and a structural edit gets the consequences the ops already state — deleting a Section
+unplaces its References. The writer's own edits never go Stale: staleness is the gap
+between generating a Proposal and applying it, and there is no gap here.
+
+**One writer holds the Plan and the debounce**, in `src/client/plan/writer.ts`. It applies
+each edit locally, sends after a pause for the four ops a keystroke produces, and sends at
+once for everything else. An update arriving from the Article Agent over an unsent edit is
+the echo of an older write and is dropped — the client is the Plan's only writer, so there
+is nothing else it can be.
+
 **The Article Agent's WebSocket is multiplexed.** It carries `cf_agent_*` control frames for
 state, RPC, and scheduling on one socket. In phase 1 this is free, because the SDK's own
 client handles them. It becomes work if a party-db transport ever shares that socket.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "deploy": "vite build && wrangler deploy",
     "test": "vite build && vitest run",
     "test:shared": "vitest run --project shared",
+    "test:client": "vitest run --project client",
     "test:watch": "vitest",
     "typecheck": "wrangler types --check && tsc --build",
     "lint": "oxlint .",

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -43,7 +43,7 @@ export function Button({
 		<button
 			type={type}
 			className={cx(
-				'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter]',
+				'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter] disabled:pointer-events-none disabled:opacity-40',
 				variant === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
 				variantClass[variant],
 				className,

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -21,6 +21,12 @@ export interface ButtonProps extends Omit<
 	children?: ReactNode
 }
 
+// `pressed` replaces the variant rather than layering over it. Two utilities
+// setting the same property resolve by their order in the stylesheet, not by
+// the order they are written in, so `bg-ink` next to `bg-surface` is a coin
+// toss — and it landed on ink fill with ink text.
+const pressedClass = 'border border-ink bg-ink text-paper hover:brightness-125'
+
 const variantClass: Record<ButtonVariant, string> = {
 	default: 'border border-edge bg-surface text-ink hover:border-ink/40 hover:bg-hush',
 	accent: 'border border-accent-edge bg-accent text-accent-ink hover:brightness-[0.97]',
@@ -50,8 +56,7 @@ export function Button({
 			className={cx(
 				'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter] disabled:pointer-events-none disabled:opacity-40',
 				variant === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
-				variantClass[variant],
-				pressed && 'border-ink bg-ink text-paper hover:bg-ink',
+				pressed ? pressedClass : variantClass[variant],
 				className,
 			)}
 			{...rest}

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -15,6 +15,9 @@ export interface ButtonProps extends Omit<
 	 */
 	variant?: ButtonVariant
 	size?: ButtonSize
+	/** "You are here" — the chosen one of a set. State rather than a call to
+	 * action, so it takes ink rather than the accent, the way a solid Chip does. */
+	pressed?: boolean
 	children?: ReactNode
 }
 
@@ -34,6 +37,7 @@ const sizeClass: Record<ButtonSize, string> = {
 export function Button({
 	variant = 'default',
 	size = 'md',
+	pressed,
 	className,
 	children,
 	type = 'button',
@@ -42,15 +46,43 @@ export function Button({
 	return (
 		<button
 			type={type}
+			aria-pressed={pressed}
 			className={cx(
 				'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter] disabled:pointer-events-none disabled:opacity-40',
 				variant === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
 				variantClass[variant],
+				pressed && 'border-ink bg-ink text-paper hover:bg-ink',
 				className,
 			)}
 			{...rest}
 		>
 			{children}
 		</button>
+	)
+}
+
+export interface ButtonGroupProps {
+	/** Names the set for a screen reader: "Where the Section goes". */
+	label: string
+	children: ReactNode
+	className?: string
+}
+
+/**
+ * Buttons that belong together, joined into one control. Two related choices
+ * read as one decision this way, where two loose pills read as two.
+ */
+export function ButtonGroup({ label, children, className }: ButtonGroupProps) {
+	return (
+		<div
+			aria-label={label}
+			className={cx(
+				'inline-flex [&>*]:rounded-none [&>*+*]:-ml-px [&>*:first-child]:rounded-l-full [&>*:last-child]:rounded-r-full',
+				className,
+			)}
+			role="group"
+		>
+			{children}
+		</div>
 	)
 }

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -65,6 +65,8 @@ export interface TextFieldProps {
 	hiddenLabel?: string
 	value: string
 	onChange: (value: string) => void
+	/** Where Enter means something — closing the Section being edited, say. */
+	onKeyDown?: (event: KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => void
 	placeholder?: string
 	suffix?: ReactNode
 	size?: 'sm' | 'md'
@@ -79,6 +81,7 @@ export function TextField({
 	hiddenLabel,
 	value,
 	onChange,
+	onKeyDown,
 	placeholder,
 	suffix,
 	size = 'md',
@@ -106,6 +109,7 @@ export function TextField({
 						aria-label={hiddenLabel}
 						className={cx(inputClass, 'resize-none leading-snug')}
 						onChange={handle}
+						onKeyDown={onKeyDown}
 						placeholder={placeholder}
 						rows={rows}
 						value={value}
@@ -115,6 +119,7 @@ export function TextField({
 						aria-label={hiddenLabel}
 						className={inputClass}
 						onChange={handle}
+						onKeyDown={onKeyDown}
 						placeholder={placeholder}
 						type="text"
 						value={value}

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -1,6 +1,16 @@
-import type { ReactNode } from 'react'
+import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react'
 
 import { cx } from '../lib/cx'
+
+/** The frame both the read-only Field and the editable TextField sit in, so a
+ * field the writer types in looks like the one they cannot. */
+const frameClass =
+	'flex flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5'
+
+const sizeClass = {
+	sm: 'h-7 text-[0.75rem]',
+	md: 'h-8 text-[0.8125rem]',
+}
 
 export interface FieldProps {
 	label?: ReactNode
@@ -12,7 +22,7 @@ export interface FieldProps {
 	className?: string
 }
 
-/** A read-only input frame — the showcase does not wire up editing. */
+/** A field that displays a value. `TextField` is the one the writer types in. */
 export function Field({
 	label,
 	value,
@@ -27,12 +37,7 @@ export function Field({
 			{label ? (
 				<span className="shrink-0 text-[0.8125rem] font-medium text-muted">{label}</span>
 			) : null}
-			<div
-				className={cx(
-					'flex flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5',
-					size === 'sm' ? 'h-7 text-[0.75rem]' : 'h-8 text-[0.8125rem]',
-				)}
-			>
+			<div className={cx(frameClass, sizeClass[size])}>
 				<span
 					className={cx('min-w-0 flex-1 truncate', empty ? 'text-faint' : 'text-ink')}
 				>
@@ -41,6 +46,117 @@ export function Field({
 				{suffix}
 			</div>
 		</div>
+	)
+}
+
+export interface TextFieldProps {
+	/** Shown beside the field, and clicking it focuses the field. Where a row of
+	 * fields carries no visible label, pass `hiddenLabel` instead. */
+	label?: ReactNode
+	/** Names the field for a screen reader when no label is shown. */
+	hiddenLabel?: string
+	value: string
+	onChange: (value: string) => void
+	placeholder?: string
+	suffix?: ReactNode
+	size?: 'sm' | 'md'
+	/** More than one row renders a textarea, which is what an intent note wants. */
+	rows?: number
+	className?: string
+}
+
+/** The same frame, with the writer typing into it. */
+export function TextField({
+	label,
+	hiddenLabel,
+	value,
+	onChange,
+	placeholder,
+	suffix,
+	size = 'md',
+	rows = 1,
+	className,
+}: TextFieldProps) {
+	const handle = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+		onChange(event.target.value)
+
+	const inputClass =
+		'min-w-0 flex-1 bg-transparent text-ink outline-none placeholder:text-faint'
+
+	return (
+		<label
+			className={cx('flex gap-2.5', rows > 1 ? 'items-start' : 'items-center', className)}
+		>
+			{label ? (
+				<span className="shrink-0 pt-1.5 text-[0.8125rem] font-medium text-muted">
+					{label}
+				</span>
+			) : null}
+			<div
+				className={cx(frameClass, rows > 1 ? 'py-1.5 text-[0.75rem]' : sizeClass[size])}
+			>
+				{rows > 1 ? (
+					<textarea
+						aria-label={hiddenLabel}
+						className={cx(inputClass, 'resize-none leading-snug')}
+						onChange={handle}
+						placeholder={placeholder}
+						rows={rows}
+						value={value}
+					/>
+				) : (
+					<input
+						aria-label={hiddenLabel}
+						className={inputClass}
+						onChange={handle}
+						placeholder={placeholder}
+						type="text"
+						value={value}
+					/>
+				)}
+				{suffix}
+			</div>
+		</label>
+	)
+}
+
+export interface InlineInputProps {
+	/** Names the field for a screen reader. A row of these carries no visible
+	 * label, so it is required rather than optional. */
+	label: string
+	value: string
+	onChange: (value: string) => void
+	onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
+	placeholder?: string
+	className?: string
+}
+
+/**
+ * A field with no frame around it, for text that is already the thing on the
+ * row — a Section title, an Adjective being added. It shows its edge on hover
+ * and on focus, so a row of them reads as text until the writer reaches for it.
+ */
+export function InlineInput({
+	label,
+	value,
+	onChange,
+	onKeyDown,
+	placeholder,
+	className,
+}: InlineInputProps) {
+	return (
+		<input
+			aria-label={label}
+			className={cx(
+				'min-w-0 rounded-sm border-b border-transparent bg-transparent text-ink outline-none placeholder:text-faint hover:border-edge focus:border-edge',
+				className,
+			)}
+			onChange={(event) => onChange(event.target.value)}
+			onKeyDown={onKeyDown}
+			placeholder={placeholder}
+			type="text"
+			value={value}
+		/>
 	)
 }
 

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -1,16 +1,26 @@
-import type { ChangeEvent, KeyboardEvent, ReactNode } from 'react'
+import type { ChangeEvent, KeyboardEvent, ReactNode, Ref } from 'react'
 
 import { cx } from '../lib/cx'
 
 /** The frame both the read-only Field and the editable TextField sit in, so a
- * field the writer types in looks like the one they cannot. */
+ * field the writer types in looks like the one they cannot.
+ *
+ * `min-w-0` is load-bearing: an input carries an intrinsic width of about 20
+ * characters, and a flex item's automatic minimum size takes it: the frame
+ * would refuse to shrink inside a narrow field and spill over whatever sits
+ * beside it. */
 const frameClass =
-	'flex flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5'
+	'flex min-w-0 flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5'
 
 const sizeClass = {
 	sm: 'h-7 text-[0.75rem]',
 	md: 'h-8 text-[0.8125rem]',
 }
+
+/** One label style for every field, and it is the same mono label a list gets.
+ * `text-muted` over the class's own faint, because a label the writer is
+ * reading to fill a field in is not a count they skim past. */
+const labelClass = 'label-meta shrink-0 text-muted'
 
 export interface FieldProps {
 	label?: ReactNode
@@ -34,9 +44,7 @@ export function Field({
 	const empty = value === undefined || value === null || value === ''
 	return (
 		<div className={cx('flex items-center gap-2.5', className)}>
-			{label ? (
-				<span className="shrink-0 text-[0.8125rem] font-medium text-muted">{label}</span>
-			) : null}
+			{label ? <span className={labelClass}>{label}</span> : null}
 			<div className={cx(frameClass, sizeClass[size])}>
 				<span
 					className={cx('min-w-0 flex-1 truncate', empty ? 'text-faint' : 'text-ink')}
@@ -88,9 +96,7 @@ export function TextField({
 			className={cx('flex gap-2.5', rows > 1 ? 'items-start' : 'items-center', className)}
 		>
 			{label ? (
-				<span className="shrink-0 pt-1.5 text-[0.8125rem] font-medium text-muted">
-					{label}
-				</span>
+				<span className={cx(labelClass, rows > 1 && 'pt-1.5')}>{label}</span>
 			) : null}
 			<div
 				className={cx(frameClass, rows > 1 ? 'py-1.5 text-[0.75rem]' : sizeClass[size])}
@@ -128,6 +134,8 @@ export interface InlineInputProps {
 	onChange: (value: string) => void
 	onKeyDown?: (event: KeyboardEvent<HTMLInputElement>) => void
 	placeholder?: string
+	/** Held so a Section the writer has just made can take the caret. */
+	ref?: Ref<HTMLInputElement>
 	className?: string
 }
 
@@ -142,11 +150,13 @@ export function InlineInput({
 	onChange,
 	onKeyDown,
 	placeholder,
+	ref,
 	className,
 }: InlineInputProps) {
 	return (
 		<input
 			aria-label={label}
+			ref={ref}
 			className={cx(
 				'min-w-0 rounded-sm border-b border-transparent bg-transparent text-ink outline-none placeholder:text-faint hover:border-edge focus:border-edge',
 				className,

--- a/src/client/components/MetaLabel.tsx
+++ b/src/client/components/MetaLabel.tsx
@@ -9,7 +9,7 @@ export interface MetaLabelProps {
 	className?: string
 }
 
-/** The small uppercase mono label that heads a list or a group. */
+/** The small mono label that heads a list or a group. */
 export function MetaLabel({ children, count, className }: MetaLabelProps) {
 	return (
 		<div className={cx('label-meta', className)}>

--- a/src/client/components/OutlineRow.tsx
+++ b/src/client/components/OutlineRow.tsx
@@ -1,30 +1,38 @@
+import type { OutlineNode } from '../../shared/plan'
 import { cx } from '../lib/cx'
-import type { Section } from '../mock/content'
 import { Chip } from './Chip'
 
 export interface OutlineRowProps {
-	section: Section
-	/** Marks the section being written; renders a quiet "now" flag. */
+	node: OutlineNode
+	/** What the row is numbered: "2" for a Section, "2.1" for a Subsection. */
+	ordinal: string
+	/** Marks the Section being written; renders a quiet "now" flag. */
 	current?: boolean
-	/** Accent the word count — used when a review has just changed it. */
+	/** Accent the word count — used when a Review has just changed it. */
 	changed?: boolean
 	/** Drop the chips and run as a single line. */
 	dense?: boolean
 	className?: string
 }
 
-/** One row of the Outline: number, title, target, and any Tone instructions. */
+/**
+ * One row of the Outline, read-only: its number, its title, its target, and its
+ * Tone. The editable row is `plan/SectionRow.tsx`.
+ */
 export function OutlineRow({
-	section,
+	node,
+	ordinal,
 	current = false,
 	changed = false,
 	dense = false,
 	className,
 }: OutlineRowProps) {
+	const target = node.target === undefined ? null : `${node.target}w`
+
 	return (
 		<div className={cx('flex items-start gap-2.5', className)}>
 			<span className="mt-px w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
-				{section.n}
+				{ordinal}
 			</span>
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<div className="flex items-baseline gap-2">
@@ -35,26 +43,28 @@ export function OutlineRow({
 							dense && 'truncate',
 						)}
 					>
-						{section.title}
+						{node.title}
 					</span>
 					{current ? (
 						<span className="shrink-0 text-[0.6875rem] text-faint">now</span>
 					) : null}
-					{dense ? (
+					{dense && target !== null ? (
 						<Chip variant={changed ? 'accent' : 'default'} className="ml-auto">
-							{section.words}w
+							{target}
 						</Chip>
 					) : null}
 				</div>
 				{!dense ? (
 					<div className="flex flex-wrap gap-1.5">
-						<Chip variant={changed ? 'accent' : 'default'}>{section.words}w</Chip>
-						{section.adjectives?.map((adjective) => (
+						{target !== null ? (
+							<Chip variant={changed ? 'accent' : 'default'}>{target}</Chip>
+						) : null}
+						{node.adjectives?.map((adjective) => (
 							<Chip key={adjective} variant="outline">
 								{adjective}
 							</Chip>
 						))}
-						{section.voice ? <Chip variant="outline">voice: {section.voice}</Chip> : null}
+						{node.voice ? <Chip variant="outline">voice: {node.voice}</Chip> : null}
 					</div>
 				) : null}
 			</div>

--- a/src/client/components/OutlineRow.tsx
+++ b/src/client/components/OutlineRow.tsx
@@ -38,7 +38,7 @@ export function OutlineRow({
 				<div className="flex items-baseline gap-2">
 					<span
 						className={cx(
-							'min-w-0 text-[0.8125rem] leading-snug',
+							'min-w-0 flex-1 text-[0.8125rem] leading-snug',
 							current ? 'font-medium text-ink' : 'text-ink',
 							dense && 'truncate',
 						)}
@@ -48,17 +48,14 @@ export function OutlineRow({
 					{current ? (
 						<span className="shrink-0 text-[0.6875rem] text-faint">now</span>
 					) : null}
-					{dense && target !== null ? (
-						<Chip variant={changed ? 'accent' : 'default'} className="ml-auto">
-							{target}
-						</Chip>
+					{/* The count sits on the title line, where the eye can run down a
+					    column of them rather than hunting each row for it. */}
+					{target !== null ? (
+						<Chip variant={changed ? 'accent' : 'default'}>{target}</Chip>
 					) : null}
 				</div>
 				{!dense ? (
-					<div className="flex flex-wrap gap-1.5">
-						{target !== null ? (
-							<Chip variant={changed ? 'accent' : 'default'}>{target}</Chip>
-						) : null}
+					<div className="flex flex-wrap gap-1.5 empty:hidden">
 						{node.adjectives?.map((adjective) => (
 							<Chip key={adjective} variant="outline">
 								{adjective}

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
 
-import { outline, quotes, references } from '../mock/content'
+import { plan, quotes, references, sectionState } from '../mock/content'
 import { Button } from './Button'
 import { Check } from './Check'
 import { Chip } from './Chip'
@@ -98,10 +98,10 @@ export const Progress: Story = {
 			</Row>
 			<Row label="Length bar — the shape of the piece">
 				<LengthBar
-					segments={outline.map((s) => ({
-						label: s.title,
-						words: s.words,
-						state: s.state,
+					segments={plan.outline.map((node) => ({
+						label: node.title,
+						words: node.target ?? 0,
+						state: sectionState[node.id],
 					}))}
 					height={160}
 					accentCurrent
@@ -158,9 +158,9 @@ export const Notes: Story = {
 export const PlanPieces: Story = {
 	render: () => (
 		<div className="flex w-[26rem] flex-col gap-4">
-			<OutlineRow section={outline[1]} />
-			<OutlineRow section={outline[2]} current />
-			<OutlineRow section={outline[3]} dense />
+			<OutlineRow node={plan.outline[1]} ordinal="2" />
+			<OutlineRow node={plan.outline[2]} ordinal="3" current />
+			<OutlineRow node={plan.outline[3]} ordinal="4" dense />
 			<div className="flex flex-col gap-2 pt-2">
 				<PolarityHeading polarity="yes" count={3}>
 					Sounds like this

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -105,5 +105,8 @@ one of the two is not really asking for a decision.
 </div>
 
 Type is three families: `--font-sans` for the interface, `--font-serif` for the
-writing surface and anything quoted from it, `--font-mono` for the small
-uppercase labels and counts.
+writing surface and anything quoted from it, `--font-mono` for the small labels
+and counts — field labels included, so a label reads the same everywhere.
+
+Those labels are set in **sentence case**. Uppercasing them reads as shouting,
+and the monospace face already separates a label from the writing around it.

--- a/src/client/mock/content.ts
+++ b/src/client/mock/content.ts
@@ -1,9 +1,13 @@
+import type { OutlineNode, Plan } from '../../shared/plan'
+
 /**
  * Sample content for the showcase.
  *
  * None of this is wired to anything — it exists so the components can be read
- * as a real product rather than as grey boxes. Swap it for API data when the
- * back end lands; the shapes here are a reasonable first sketch of it.
+ * as a real product rather than as grey boxes. The Plan below is the exception
+ * and carries the real schema, because the Plan Panel is wired: the showcase
+ * and the app render one Plan through one set of components. Everything still
+ * typed here is a sketch, and each one is replaced as its ticket lands.
  */
 
 export interface Article {
@@ -111,49 +115,115 @@ export const portfolioBacklist = [
 
 export const ARTICLE_TITLE = 'Why Cities Stopped Building'
 
-export interface Section {
-	n: number
-	title: string
-	words: number
-	adjectives?: string[]
-	voice?: string
-	state?: 'done' | 'current' | 'planned'
+/**
+ * The Plan, in the shape the Article Agent actually holds — `src/shared/plan`.
+ * The screens read it through the same components the live Plan Panel uses, so
+ * a change to the schema breaks the showcase rather than letting it drift.
+ */
+export const plan: Plan = {
+	title: ARTICLE_TITLE,
+	totalTarget: 2400,
+	voice: 'Reported feature',
+	adjectives: [],
+	outline: [
+		{
+			id: 'sec-cranes',
+			title: 'The year the cranes stopped',
+			intent: 'Open on the count, and make the drop concrete before any argument.',
+			target: 300,
+			adjectives: ['high energy'],
+			children: [],
+		},
+		{
+			id: 'sec-review',
+			title: 'How review became the process',
+			intent: 'The mechanism: eleven points at which one objection resets the clock.',
+			target: 700,
+			voice: 'Explainer',
+			adjectives: ['well researched'],
+			children: [],
+		},
+		{
+			id: 'sec-cost',
+			title: 'Who actually pays for the delay',
+			intent: 'The human cost, carried by the developers who would not go on record.',
+			target: 900,
+			children: [],
+		},
+		{
+			id: 'sec-faster',
+			title: 'What a faster city would look like',
+			target: 500,
+			adjectives: ['unhurried'],
+			children: [],
+		},
+	],
+	references: [
+		{
+			id: 'ref-throughput',
+			type: 'reference',
+			provenance: { type: 'offer', offerId: 'offer-throughput' },
+			source: {
+				title: 'Permit throughput in six mid-sized cities',
+				author: 'R. Okonkwo',
+				publication: 'the Quarterly',
+				year: 2023,
+			},
+			nodeId: 'sec-review',
+			note: 'Median approval time tripled while application volume stayed flat.',
+		},
+		{
+			id: 'ref-middle',
+			type: 'reference',
+			provenance: { type: 'offer', offerId: 'offer-middle' },
+			source: {
+				title: 'Zoning and the missing middle',
+				author: 'A. Weill',
+				publication: 'Field Notes',
+				year: 2019,
+			},
+			nodeId: 'sec-cost',
+		},
+		{
+			id: 'ref-forty-times',
+			type: 'quote',
+			provenance: { type: 'offer', offerId: 'offer-throughput' },
+			text: 'We did not decide to stop building. We decided, forty separate times, that this particular building could wait.',
+			source: { title: 'Permit throughput in six mid-sized cities' },
+			nodeId: 'sec-review',
+		},
+		{
+			id: 'ref-meter',
+			type: 'quote',
+			provenance: { type: 'writer' },
+			text: 'The meter runs on an empty lot exactly as fast as it runs on a finished one.',
+			source: { title: 'The cost of discretionary review' },
+			nodeId: null,
+		},
+	],
 }
 
-export const outline: Section[] = [
-	{
-		n: 1,
-		title: 'The year the cranes stopped',
-		words: 300,
-		adjectives: ['high energy'],
-		state: 'done',
-	},
-	{
-		n: 2,
-		title: 'How review became the process',
-		words: 700,
-		adjectives: ['well researched'],
-		voice: 'Explainer',
-		state: 'done',
-	},
-	{ n: 3, title: 'Who actually pays for the delay', words: 900, state: 'current' },
-	{
-		n: 4,
-		title: 'What a faster city would look like',
-		words: 500,
-		adjectives: ['unhurried'],
-		state: 'planned',
-	},
-]
+export const outline: OutlineNode[] = plan.outline
 
-export const outlineRevised: Section[] = [
-	{ n: 1, title: 'The year the cranes stopped', words: 300 },
-	{ n: 2, title: 'How review became the process', words: 700 },
-	{ n: 3, title: 'Who actually pays for the delay', words: 700 },
+/** Which Section the writer is in, and which are drafted. Not the Plan's to
+ * carry: the Draft is a flat run of Blocks and a Boundary is inferred. */
+export const sectionState: Record<string, 'done' | 'current' | 'planned'> = {
+	'sec-cranes': 'done',
+	'sec-review': 'done',
+	'sec-cost': 'current',
+	'sec-faster': 'planned',
+}
+
+/** The same Outline after a Review, for the screen that shows what changed. */
+export const outlineRevised: OutlineNode[] = [
+	{ id: 'sec-cranes', title: 'The year the cranes stopped', target: 300, children: [] },
+	{ id: 'sec-review', title: 'How review became the process', target: 700, children: [] },
+	{ id: 'sec-cost', title: 'Who actually pays for the delay', target: 700, children: [] },
 	{
-		n: 4,
+		id: 'sec-faster',
 		title: 'What a faster city would look like — and the argument for it',
-		words: 700,
+		target: 700,
+		children: [],
 	},
 ]
 

--- a/src/client/mock/content.ts
+++ b/src/client/mock/content.ts
@@ -161,7 +161,7 @@ export const plan: Plan = {
 	references: [
 		{
 			id: 'ref-throughput',
-			type: 'reference',
+			type: 'link',
 			provenance: { type: 'offer', offerId: 'offer-throughput' },
 			source: {
 				title: 'Permit throughput in six mid-sized cities',
@@ -174,7 +174,7 @@ export const plan: Plan = {
 		},
 		{
 			id: 'ref-middle',
-			type: 'reference',
+			type: 'link',
 			provenance: { type: 'offer', offerId: 'offer-middle' },
 			source: {
 				title: 'Zoning and the missing middle',

--- a/src/client/plan/AddSection.tsx
+++ b/src/client/plan/AddSection.tsx
@@ -1,14 +1,13 @@
 import { useState } from 'react'
 
 import type { OutlineNode } from '../../shared/plan'
-import { Button } from '../components/Button'
+import { Button, ButtonGroup } from '../components/Button'
 import type { SectionAnchor } from './edits'
 
 /**
- * Making a Section, and saying where it goes. The button that opens this sits
- * at the top of the Outline while a new Section usually belongs somewhere else,
- * so it asks rather than appending and leaving the writer to hunt for what it
- * did.
+ * Making a Section, and saying where it goes. It asks rather than appending,
+ * because a new Section usually belongs somewhere other than wherever the
+ * button happens to sit.
  *
  * Subsections are TBD, so every choice here anchors at the top level.
  */
@@ -37,7 +36,7 @@ export function AddSection({ outline, onAdd }: AddSectionProps) {
 
 	if (!asking) {
 		return (
-			<Button onClick={() => setAsking(true)} size="sm" variant="quiet">
+			<Button onClick={() => setAsking(true)} size="sm">
 				+ section
 			</Button>
 		)
@@ -45,25 +44,38 @@ export function AddSection({ outline, onAdd }: AddSectionProps) {
 
 	return (
 		<div
-			className="flex flex-col items-stretch gap-1 rounded-md border border-edge bg-surface p-1.5"
+			className="flex flex-col items-start gap-2 rounded-md border border-edge bg-surface p-2.5"
 			onKeyDown={(event) => {
 				if (event.key === 'Escape') setAsking(false)
 			}}
 		>
-			<p className="label-meta px-1 pb-0.5">Where does it go?</p>
-			<Choice onChoose={() => add({ parentId: null, afterId: null })}>
-				At the beginning
-			</Choice>
-			{/* The last Section is left out: "after" it and "at the end" are the
-			    same place, and one of them is the shorter thing to read. */}
+			<p className="label-meta text-muted">New section: where?</p>
+
+			<ButtonGroup label="Where the Section goes">
+				<Button onClick={() => add({ parentId: null, afterId: null })} size="sm">
+					Top
+				</Button>
+				<Button onClick={() => add({ parentId: null, beforeId: null })} size="sm">
+					Bottom
+				</Button>
+			</ButtonGroup>
+
+			{/* The last Section is left out: "after" it and "bottom" are the same
+			    place, and one of them is the shorter thing to read. */}
 			{outline.slice(0, -1).map((node, index) => (
-				<Choice key={node.id} onChoose={() => add({ parentId: null, afterId: node.id })}>
-					After {index + 1}. {node.title === '' ? 'Untitled section' : node.title}
-				</Choice>
+				<button
+					key={node.id}
+					className="w-full truncate rounded-md border border-edge bg-surface px-2.5 py-1.5 text-left text-[0.75rem] text-ink hover:border-ink/40 hover:bg-hush"
+					onClick={() => add({ parentId: null, afterId: node.id })}
+					type="button"
+				>
+					<span className="text-faint">after {index + 1} · </span>
+					{node.title === '' ? 'Untitled section' : node.title}
+				</button>
 			))}
-			<Choice onChoose={() => add({ parentId: null, beforeId: null })}>At the end</Choice>
+
 			<Button
-				className="mt-0.5 self-end"
+				className="self-end"
 				onClick={() => setAsking(false)}
 				size="sm"
 				variant="quiet"
@@ -71,22 +83,5 @@ export function AddSection({ outline, onAdd }: AddSectionProps) {
 				cancel
 			</Button>
 		</div>
-	)
-}
-
-interface ChoiceProps {
-	onChoose: () => void
-	children: React.ReactNode
-}
-
-function Choice({ onChoose, children }: ChoiceProps) {
-	return (
-		<button
-			className="truncate rounded-sm px-1 py-1 text-left text-[0.75rem] text-ink hover:bg-hush"
-			onClick={onChoose}
-			type="button"
-		>
-			{children}
-		</button>
 	)
 }

--- a/src/client/plan/AddSection.tsx
+++ b/src/client/plan/AddSection.tsx
@@ -1,0 +1,92 @@
+import { useState } from 'react'
+
+import type { OutlineNode } from '../../shared/plan'
+import { Button } from '../components/Button'
+import type { SectionAnchor } from './edits'
+
+/**
+ * Making a Section, and saying where it goes. The button that opens this sits
+ * at the top of the Outline while a new Section usually belongs somewhere else,
+ * so it asks rather than appending and leaving the writer to hunt for what it
+ * did.
+ *
+ * Subsections are TBD, so every choice here anchors at the top level.
+ */
+
+export interface AddSectionProps {
+	outline: readonly OutlineNode[]
+	onAdd: (anchor: SectionAnchor) => void
+}
+
+export function AddSection({ outline, onAdd }: AddSectionProps) {
+	const [asking, setAsking] = useState(false)
+
+	const add = (anchor: SectionAnchor) => {
+		setAsking(false)
+		onAdd(anchor)
+	}
+
+	// With nothing in the Outline there is nowhere else to put it.
+	if (outline.length === 0) {
+		return (
+			<Button onClick={() => add({ parentId: null, beforeId: null })} size="sm">
+				+ section
+			</Button>
+		)
+	}
+
+	if (!asking) {
+		return (
+			<Button onClick={() => setAsking(true)} size="sm" variant="quiet">
+				+ section
+			</Button>
+		)
+	}
+
+	return (
+		<div
+			className="flex flex-col items-stretch gap-1 rounded-md border border-edge bg-surface p-1.5"
+			onKeyDown={(event) => {
+				if (event.key === 'Escape') setAsking(false)
+			}}
+		>
+			<p className="label-meta px-1 pb-0.5">Where does it go?</p>
+			<Choice onChoose={() => add({ parentId: null, afterId: null })}>
+				At the beginning
+			</Choice>
+			{/* The last Section is left out: "after" it and "at the end" are the
+			    same place, and one of them is the shorter thing to read. */}
+			{outline.slice(0, -1).map((node, index) => (
+				<Choice key={node.id} onChoose={() => add({ parentId: null, afterId: node.id })}>
+					After {index + 1}. {node.title === '' ? 'Untitled section' : node.title}
+				</Choice>
+			))}
+			<Choice onChoose={() => add({ parentId: null, beforeId: null })}>At the end</Choice>
+			<Button
+				className="mt-0.5 self-end"
+				onClick={() => setAsking(false)}
+				size="sm"
+				variant="quiet"
+			>
+				cancel
+			</Button>
+		</div>
+	)
+}
+
+interface ChoiceProps {
+	onChoose: () => void
+	children: React.ReactNode
+}
+
+function Choice({ onChoose, children }: ChoiceProps) {
+	return (
+		<button
+			className="truncate rounded-sm px-1 py-1 text-left text-[0.75rem] text-ink hover:bg-hush"
+			onClick={onChoose}
+			type="button"
+		>
+			{children}
+		</button>
+	)
+}

--- a/src/client/plan/ArticlePlanPanel.tsx
+++ b/src/client/plan/ArticlePlanPanel.tsx
@@ -1,0 +1,37 @@
+import { PlanPanel } from './PlanPanel'
+import { usePlan } from './usePlan'
+
+/**
+ * The Plan Panel, wired to one Article Agent. Mounting it inside the Article
+ * screen is issue #29; everything it needs from the socket is `usePlan`.
+ */
+
+export interface ArticlePlanPanelProps {
+	/** The Article Agent's name, which is the Article's id. */
+	articleId: string
+	className?: string
+}
+
+export function ArticlePlanPanel({ articleId, className }: ArticlePlanPanelProps) {
+	const { plan, edit, refusal, rejected } = usePlan(articleId)
+
+	// The socket usually settles in well under a second, so this says what it is
+	// waiting for rather than drawing a skeleton of the Panel.
+	if (plan === null) {
+		return (
+			<div className={className}>
+				<p className="p-3.5 text-[0.75rem] text-faint">Opening the Plan…</p>
+			</div>
+		)
+	}
+
+	return (
+		<PlanPanel
+			className={className}
+			edit={edit}
+			plan={plan}
+			refusal={refusal}
+			rejected={rejected}
+		/>
+	)
+}

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -39,9 +39,11 @@ export function PlanPanel({
 	className,
 }: PlanPanelProps) {
 	// One Section is open at a time. `made` is the one the writer has just
-	// added, which takes the caret as it opens.
+	// added, which takes the caret as it opens, and `shown` is the Reference a
+	// Section row has just sent them down to.
 	const [openId, setOpenId] = useState<string | null>(null)
 	const [made, setMade] = useState<string | null>(null)
+	const [shown, setShown] = useState<string | null>(null)
 
 	const entries = outlineEntries(plan.outline)
 	const allocation = planAllocation(plan)
@@ -117,6 +119,7 @@ export function PlanPanel({
 								edit={edit}
 								entry={entry}
 								onOpen={setOpenId}
+								onShowReference={setShown}
 								open={entry.node.id === openId}
 								plan={plan}
 								takeCaret={entry.node.id === made}
@@ -138,7 +141,9 @@ export function PlanPanel({
 				className="flex flex-col items-stretch gap-1.5"
 				edit={edit}
 				entries={entries}
+				onShown={() => setShown(null)}
 				plan={plan}
+				shown={shown}
 			/>
 		</Panel>
 	)

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -1,10 +1,13 @@
+import { useState } from 'react'
+
 import type { Plan, ProposalInput, Refusal } from '../../shared/plan'
 import { planAllocation, resolveArticleScope } from '../../shared/plan'
-import { Button } from '../components/Button'
 import { GroupHeading } from '../components/Divider'
 import { EmptySlot, TextField } from '../components/Field'
 import { LengthBar } from '../components/LengthBar'
 import { Panel } from '../components/Panel'
+import { AddSection } from './AddSection'
+import type { SectionAnchor } from './edits'
 import { addSection, setAdjectives, setTarget, setTitle, setVoice } from './edits'
 import { outlineEntries } from './outline'
 import { ReferenceList } from './ReferenceList'
@@ -35,13 +38,28 @@ export function PlanPanel({
 	rejected = null,
 	className,
 }: PlanPanelProps) {
+	// One Section is open at a time. `made` is the one the writer has just
+	// added, which takes the caret as it opens.
+	const [openId, setOpenId] = useState<string | null>(null)
+	const [made, setMade] = useState<string | null>(null)
+
 	const entries = outlineEntries(plan.outline)
 	const allocation = planAllocation(plan)
 	const resolved = resolveArticleScope(plan)
 
-	// The bar is the shape of the piece, so it only draws once every Section
-	// carries a share of it. Until then the gap is the thing to read.
-	const targeted = plan.outline.every((node) => node.target !== undefined)
+	// The bar is the shape of the piece, drawn from the Sections that carry a
+	// share of it. A Section with no target is left out rather than taking the
+	// bar away: what is placed is still worth seeing.
+	const segments = plan.outline
+		.filter((node) => node.target !== undefined)
+		.map((node) => ({ label: node.title, words: node.target ?? 0 }))
+
+	const add = (anchor: SectionAnchor) => {
+		const id = crypto.randomUUID()
+		edit(addSection(anchor, id))
+		setOpenId(id)
+		setMade(id)
+	}
 
 	return (
 		<Panel className={className} variant="sunk">
@@ -64,14 +82,14 @@ export function PlanPanel({
 				value={plan.title}
 			/>
 
-			<div className="flex flex-wrap items-center gap-2.5">
+			<div className="flex flex-wrap items-center gap-x-2.5 gap-y-1">
 				<TargetField
-					className="w-44"
+					className="w-48 shrink-0"
 					label="Length"
 					onTarget={(target) => edit(setTarget(plan, null, target))}
 					target={plan.totalTarget}
 				/>
-				<AllocationNote allocation={allocation} className="text-[0.6875rem] text-faint" />
+				<AllocationNote allocation={allocation} className="label-meta" />
 			</div>
 
 			<ToneFields
@@ -83,20 +101,7 @@ export function PlanPanel({
 				voice={plan.voice ?? null}
 			/>
 
-			<GroupHeading
-				action={
-					<Button
-						onClick={() => edit(addSection({ parentId: null, beforeId: null }))}
-						size="sm"
-						variant="quiet"
-					>
-						+ section
-					</Button>
-				}
-				count={plan.outline.length}
-			>
-				Outline
-			</GroupHeading>
+			<GroupHeading count={plan.outline.length}>Outline</GroupHeading>
 
 			{entries.length === 0 ? (
 				<EmptySlot className="min-h-[3.5rem]">
@@ -105,22 +110,28 @@ export function PlanPanel({
 				</EmptySlot>
 			) : (
 				<div className="flex items-start gap-3.5">
-					<div className="flex min-w-0 flex-1 flex-col gap-3.5">
+					<div className="flex min-w-0 flex-1 flex-col gap-1.5">
 						{entries.map((entry) => (
-							<SectionRow key={entry.node.id} edit={edit} entry={entry} plan={plan} />
+							<SectionRow
+								key={entry.node.id}
+								edit={edit}
+								entry={entry}
+								onOpen={setOpenId}
+								open={entry.node.id === openId}
+								plan={plan}
+								takeCaret={entry.node.id === made}
+							/>
 						))}
 					</div>
-					{targeted ? (
-						<LengthBar
-							segments={plan.outline.map((node) => ({
-								label: node.title,
-								words: node.target ?? 0,
-							}))}
-							height={Math.max(120, entries.length * 96)}
-						/>
+					{segments.length > 0 ? (
+						<LengthBar segments={segments} height={Math.max(120, entries.length * 44)} />
 					) : null}
 				</div>
 			)}
+
+			<div className="flex">
+				<AddSection onAdd={add} outline={plan.outline} />
+			</div>
 
 			<GroupHeading count={plan.references.length}>References</GroupHeading>
 			<ReferenceList

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -135,7 +135,7 @@ export function PlanPanel({
 
 			<GroupHeading count={plan.references.length}>References</GroupHeading>
 			<ReferenceList
-				className="flex flex-col gap-1.5"
+				className="flex flex-col items-stretch gap-1.5"
 				edit={edit}
 				entries={entries}
 				plan={plan}

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -1,0 +1,134 @@
+import type { Plan, ProposalInput, Refusal } from '../../shared/plan'
+import { planAllocation, resolveArticleScope } from '../../shared/plan'
+import { Button } from '../components/Button'
+import { GroupHeading } from '../components/Divider'
+import { EmptySlot, TextField } from '../components/Field'
+import { LengthBar } from '../components/LengthBar'
+import { Panel } from '../components/Panel'
+import { addSection, setAdjectives, setTarget, setTitle, setVoice } from './edits'
+import { outlineEntries } from './outline'
+import { ReferenceList } from './ReferenceList'
+import { SectionRow } from './SectionRow'
+import { ToneFields } from './ToneFields'
+import { AllocationNote, TargetField } from './WordCount'
+
+/**
+ * The Plan Panel — the surface the writer edits directly. It takes the Plan and
+ * one `edit` function, so a story can drive it from local state and the app can
+ * drive it from the Article Agent, which is the only writer of either.
+ */
+
+export interface PlanPanelProps {
+	plan: Plan
+	edit: (ops: ProposalInput | null) => void
+	/** Why the last edit did not land. */
+	refusal?: Refusal | null
+	/** What the Article Agent said when a write did not parse. */
+	rejected?: string | null
+	className?: string
+}
+
+export function PlanPanel({
+	plan,
+	edit,
+	refusal = null,
+	rejected = null,
+	className,
+}: PlanPanelProps) {
+	const entries = outlineEntries(plan.outline)
+	const allocation = planAllocation(plan)
+	const resolved = resolveArticleScope(plan)
+
+	// The bar is the shape of the piece, so it only draws once every Section
+	// carries a share of it. Until then the gap is the thing to read.
+	const targeted = plan.outline.every((node) => node.target !== undefined)
+
+	return (
+		<Panel className={className} variant="sunk">
+			{refusal === null ? null : (
+				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
+					{refusal.message}
+				</p>
+			)}
+			{rejected === null ? null : (
+				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
+					The Article Agent refused the write. {rejected}
+				</p>
+			)}
+
+			<TextField
+				hiddenLabel="Article title"
+				label="Title"
+				onChange={(title) => edit(setTitle(plan, null, title))}
+				placeholder="Untitled article"
+				value={plan.title}
+			/>
+
+			<div className="flex flex-wrap items-center gap-2.5">
+				<TargetField
+					className="w-44"
+					label="Length"
+					onTarget={(target) => edit(setTarget(plan, null, target))}
+					target={plan.totalTarget}
+				/>
+				<AllocationNote allocation={allocation} className="text-[0.6875rem] text-faint" />
+			</div>
+
+			<ToneFields
+				adjectives={plan.adjectives}
+				onAdjectives={(adjectives) => edit(setAdjectives(plan, null, adjectives))}
+				onVoice={(voice) => edit(setVoice(plan, null, voice))}
+				resolved={resolved}
+				scopeName="the Article"
+				voice={plan.voice ?? null}
+			/>
+
+			<GroupHeading
+				action={
+					<Button
+						onClick={() => edit(addSection({ parentId: null, beforeId: null }))}
+						size="sm"
+						variant="quiet"
+					>
+						+ section
+					</Button>
+				}
+				count={plan.outline.length}
+			>
+				Outline
+			</GroupHeading>
+
+			{entries.length === 0 ? (
+				<EmptySlot className="min-h-[3.5rem]">
+					Sections appear as you agree on them in the Chat — and you can write your own
+					straight in here
+				</EmptySlot>
+			) : (
+				<div className="flex items-start gap-3.5">
+					<div className="flex min-w-0 flex-1 flex-col gap-3.5">
+						{entries.map((entry) => (
+							<SectionRow key={entry.node.id} edit={edit} entry={entry} plan={plan} />
+						))}
+					</div>
+					{targeted ? (
+						<LengthBar
+							segments={plan.outline.map((node) => ({
+								label: node.title,
+								words: node.target ?? 0,
+							}))}
+							height={Math.max(120, entries.length * 96)}
+						/>
+					) : null}
+				</div>
+			)}
+
+			<GroupHeading count={plan.references.length}>References</GroupHeading>
+			<ReferenceList
+				className="flex flex-col gap-1.5"
+				edit={edit}
+				entries={entries}
+				plan={plan}
+			/>
+		</Panel>
+	)
+}

--- a/src/client/plan/ReferenceForm.tsx
+++ b/src/client/plan/ReferenceForm.tsx
@@ -1,0 +1,187 @@
+import { useState } from 'react'
+
+import type {
+	Reference,
+	ReferenceContent,
+	ReferenceType,
+	Source,
+} from '../../shared/plan'
+import { referenceContentSchema } from '../../shared/plan'
+import { Button, ButtonGroup } from '../components/Button'
+import { TextField } from '../components/Field'
+
+/**
+ * What a Reference says, in fields the writer types or pastes into.
+ *
+ * It holds a draft and commits on save, where the rest of the Panel writes
+ * every keystroke. A Reference has to carry a text or a source, so a
+ * half-filled one is not a Reference yet and the Plan has nowhere to put it.
+ */
+
+export interface ReferenceFormProps {
+	/** The Reference being rewritten, and nothing when one is being pasted in. */
+	reference?: Reference
+	onSave: (content: ReferenceContent) => void
+	onCancel: () => void
+	onDelete?: () => void
+}
+
+export function ReferenceForm({
+	reference,
+	onSave,
+	onCancel,
+	onDelete,
+}: ReferenceFormProps) {
+	const [type, setType] = useState<ReferenceType>(reference?.type ?? 'reference')
+	const [text, setText] = useState(reference?.text ?? '')
+	const [note, setNote] = useState(reference?.note ?? '')
+	const [source, setSource] = useState<SourceDraft>({
+		title: reference?.source?.title ?? '',
+		author: reference?.source?.author ?? '',
+		publication: reference?.source?.publication ?? '',
+		year: reference?.source?.year === undefined ? '' : String(reference.source.year),
+		url: reference?.source?.url ?? '',
+	})
+	const [refused, setRefused] = useState<string | null>(null)
+
+	const field = (key: keyof SourceDraft) => (typed: string) =>
+		setSource({ ...source, [key]: typed })
+
+	const save = () => {
+		const content = { type, ...stated('text', text), ...stated('note', note) }
+		const attribution = sourceOf(source)
+		const draft = attribution === null ? content : { ...content, source: attribution }
+
+		// The schema is what says whether this is a Reference yet, so the form
+		// asks it rather than keeping a second copy of the rule.
+		const parsed = referenceContentSchema.safeParse(draft)
+		if (!parsed.success) return setRefused(parsed.error.issues[0].message)
+
+		onSave(parsed.data)
+	}
+
+	return (
+		<div
+			className="flex flex-col gap-2 rounded-md border border-edge bg-surface p-2.5"
+			onKeyDown={(event) => {
+				if (event.key === 'Escape') onCancel()
+			}}
+		>
+			<ButtonGroup label="What sort of Reference this is">
+				<Button
+					onClick={() => setType('reference')}
+					pressed={type === 'reference'}
+					size="sm"
+				>
+					reference
+				</Button>
+				<Button onClick={() => setType('quote')} pressed={type === 'quote'} size="sm">
+					quote
+				</Button>
+			</ButtonGroup>
+
+			<div className="flex flex-col gap-1">
+				<span className="label-meta text-muted">Passage</span>
+				<TextField
+					hiddenLabel="The passage"
+					onChange={setText}
+					placeholder={
+						type === 'quote'
+							? 'Paste the passage'
+							: 'Paste a passage, or leave it and give the source alone'
+					}
+					rows={3}
+					value={text}
+				/>
+			</div>
+
+			<div className="grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-x-2 gap-y-1.5">
+				<span className="label-meta text-muted">Title</span>
+				<TextField
+					hiddenLabel="Source title"
+					onChange={field('title')}
+					size="sm"
+					value={source.title}
+				/>
+				<span className="label-meta text-muted">Author</span>
+				<TextField
+					hiddenLabel="Author"
+					onChange={field('author')}
+					size="sm"
+					value={source.author}
+				/>
+				<span className="label-meta text-muted">Where</span>
+				<TextField
+					hiddenLabel="Publication"
+					onChange={field('publication')}
+					placeholder="publication"
+					size="sm"
+					value={source.publication}
+				/>
+				<span className="label-meta text-muted">Year</span>
+				<TextField
+					hiddenLabel="Year"
+					onChange={(typed) => field('year')(typed.replace(/\D/g, ''))}
+					size="sm"
+					value={source.year}
+				/>
+				<span className="label-meta text-muted">Link</span>
+				<TextField
+					hiddenLabel="Link"
+					onChange={field('url')}
+					placeholder="https://"
+					size="sm"
+					value={source.url}
+				/>
+				<span className="label-meta text-muted">Note</span>
+				<TextField
+					hiddenLabel="Your note"
+					onChange={setNote}
+					placeholder="why it matters"
+					size="sm"
+					value={note}
+				/>
+			</div>
+
+			{refused === null ? null : (
+				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
+					{refused}
+				</p>
+			)}
+
+			<div className="flex items-center gap-1.5">
+				<Button onClick={save} size="sm">
+					{reference === undefined ? 'add' : 'save'}
+				</Button>
+				<Button onClick={onCancel} size="sm" variant="quiet">
+					cancel
+				</Button>
+				{onDelete ? (
+					<Button className="ml-auto" onClick={onDelete} size="sm" variant="quiet">
+						delete
+					</Button>
+				) : null}
+			</div>
+		</div>
+	)
+}
+
+type SourceDraft = Record<'title' | 'author' | 'publication' | 'year' | 'url', string>
+
+/** A field the writer left empty is a field the Reference does not carry — §4's
+ * one spelling per state. */
+function stated(key: 'text' | 'note', value: string) {
+	return value.trim() === '' ? {} : { [key]: value.trim() }
+}
+
+/** The attribution, or null where the writer stated none of it. */
+function sourceOf(draft: SourceDraft): Source | null {
+	const source: Source = {}
+	if (draft.title.trim() !== '') source.title = draft.title.trim()
+	if (draft.author.trim() !== '') source.author = draft.author.trim()
+	if (draft.publication.trim() !== '') source.publication = draft.publication.trim()
+	if (draft.year !== '') source.year = Number(draft.year)
+	if (draft.url.trim() !== '') source.url = draft.url.trim()
+
+	return Object.keys(source).length === 0 ? null : source
+}

--- a/src/client/plan/ReferenceForm.tsx
+++ b/src/client/plan/ReferenceForm.tsx
@@ -32,7 +32,7 @@ export function ReferenceForm({
 	onCancel,
 	onDelete,
 }: ReferenceFormProps) {
-	const [type, setType] = useState<ReferenceType>(reference?.type ?? 'reference')
+	const [type, setType] = useState<ReferenceType>(reference?.type ?? 'link')
 	const [text, setText] = useState(reference?.text ?? '')
 	const [note, setNote] = useState(reference?.note ?? '')
 	const [source, setSource] = useState<SourceDraft>({
@@ -68,12 +68,8 @@ export function ReferenceForm({
 			}}
 		>
 			<ButtonGroup label="What sort of Reference this is">
-				<Button
-					onClick={() => setType('reference')}
-					pressed={type === 'reference'}
-					size="sm"
-				>
-					reference
+				<Button onClick={() => setType('link')} pressed={type === 'link'} size="sm">
+					link
 				</Button>
 				<Button onClick={() => setType('quote')} pressed={type === 'quote'} size="sm">
 					quote
@@ -125,9 +121,9 @@ export function ReferenceForm({
 					size="sm"
 					value={source.year}
 				/>
-				<span className="label-meta text-muted">Link</span>
+				<span className="label-meta text-muted">URL</span>
 				<TextField
-					hiddenLabel="Link"
+					hiddenLabel="URL"
 					onChange={field('url')}
 					placeholder="https://"
 					size="sm"

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -1,13 +1,18 @@
+import { useState } from 'react'
+
 import type { Plan, ProposalInput, Reference } from '../../shared/plan'
+import { Button } from '../components/Button'
 import { Chip } from '../components/Chip'
 import { EmptySlot } from '../components/Field'
-import { placeReference } from './edits'
+import { addReference, deleteReference, placeReference, setReference } from './edits'
 import type { OutlineEntry } from './outline'
+import { ReferenceForm } from './ReferenceForm'
 
 /**
- * The Plan's References, each placed at a Section or nowhere yet. References
- * are flat and carry an optional `nodeId`, so placing one is a field on the
- * Reference rather than a move in the Outline — docs/architecture.md §4.
+ * The Plan's References: what the Chat turned up and the writer Accepted, and
+ * what the writer pasted in themselves. Each is placed at a Section or nowhere
+ * yet — References are flat and carry an optional `nodeId`, so placing one is a
+ * field on the Reference rather than a move in the Outline — architecture §4.
  *
  * The type is read off the record and never derived from whether a text is
  * present: a Reference may carry a passage without being a Quote, and the two
@@ -22,85 +27,128 @@ export interface ReferenceListProps {
 }
 
 export function ReferenceList({ plan, entries, edit, className }: ReferenceListProps) {
-	if (plan.references.length === 0) {
-		return (
-			<EmptySlot className={className}>
-				References arrive from the Chat, and land here once you Accept them
-			</EmptySlot>
-		)
-	}
+	// One Reference is open at a time, and `adding` is the blank form.
+	const [openId, setOpenId] = useState<string | null>(null)
+	const [adding, setAdding] = useState(false)
 
 	return (
 		<div className={className}>
-			{plan.references.map((reference) => (
-				<div
-					key={reference.id}
-					className="flex flex-col gap-1.5 rounded-md border border-edge bg-surface p-2"
-				>
-					<div className="flex items-baseline gap-2">
-						<Chip variant="outline">{reference.type}</Chip>
-						{reference.source?.title ? (
-							<p className="min-w-0 flex-1 text-[0.75rem] leading-snug font-medium text-ink">
-								{reference.source.title}
-							</p>
-						) : null}
-					</div>
+			{plan.references.length === 0 && !adding ? (
+				<EmptySlot>
+					References arrive from the Chat, and land here once you Accept them — or paste
+					your own
+				</EmptySlot>
+			) : null}
 
-					{reference.text ? (
-						<blockquote className="border-l-2 border-rule pl-2.5 text-[0.8125rem] leading-relaxed text-ink">
-							“{reference.text}”
-						</blockquote>
-					) : null}
-
-					{attribution(reference) === '' ? null : (
-						<p className="text-[0.6875rem] text-faint">{attribution(reference)}</p>
-					)}
-					{reference.note ? (
-						<p className="text-[0.75rem] text-muted">{reference.note}</p>
-					) : null}
-
-					<PlacementSelect
+			{plan.references.map((reference) =>
+				reference.id === openId ? (
+					<ReferenceForm
+						key={reference.id}
+						onCancel={() => setOpenId(null)}
+						onDelete={() => {
+							setOpenId(null)
+							edit(deleteReference(reference.id))
+						}}
+						onSave={(content) => {
+							setOpenId(null)
+							edit(setReference(plan, reference.id, content))
+						}}
+						reference={reference}
+					/>
+				) : (
+					<ReferenceRow
+						key={reference.id}
 						entries={entries}
-						nodeId={reference.nodeId}
+						onOpen={() => setOpenId(reference.id)}
 						onPlace={(nodeId) => edit(placeReference(plan, reference.id, nodeId))}
 						reference={reference}
 					/>
-				</div>
-			))}
+				),
+			)}
+
+			{adding ? (
+				<ReferenceForm
+					onCancel={() => setAdding(false)}
+					onSave={(content) => {
+						setAdding(false)
+						edit(addReference(content))
+					}}
+				/>
+			) : (
+				<Button className="self-start" onClick={() => setAdding(true)} size="sm">
+					+ reference
+				</Button>
+			)}
 		</div>
 	)
 }
 
-/** Everything in the attribution except the title, which heads the entry. */
-function attribution(reference: Reference): string {
-	const { author, publication, year, url } = reference.source ?? {}
-
-	return [author, publication, year, url].filter(Boolean).join(' · ')
-}
-
-interface PlacementSelectProps {
+interface ReferenceRowProps {
 	reference: Reference
 	entries: OutlineEntry[]
-	nodeId: string | null
+	onOpen: () => void
 	onPlace: (nodeId: string | null) => void
 }
 
-function PlacementSelect({ reference, entries, nodeId, onPlace }: PlacementSelectProps) {
-	const label = reference.source?.title ?? reference.text ?? reference.id
+function ReferenceRow({ reference, entries, onOpen, onPlace }: ReferenceRowProps) {
+	const attribution = [
+		reference.source?.author,
+		reference.source?.publication,
+		reference.source?.year,
+		reference.source?.url,
+	]
+		.filter(Boolean)
+		.join(' · ')
 
 	return (
-		<select
-			aria-label={`Where ${label} sits`}
-			className="h-7 rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-ink"
-			onChange={(event) => onPlace(event.target.value === '' ? null : event.target.value)}
-			value={nodeId ?? ''}
-		>
-			<option value="">not placed</option>
-			{entries.map((entry) => (
-				<option key={entry.node.id} value={entry.node.id}>
-					{entry.ordinal} {entry.node.title === '' ? 'Untitled' : entry.node.title}
-				</option>
-			))}
-		</select>
+		<div className="flex flex-col gap-1.5 rounded-md border border-edge bg-surface p-2">
+			<div className="flex items-baseline gap-2">
+				<Chip variant="outline">{reference.type}</Chip>
+				{reference.source?.title ? (
+					<p className="min-w-0 flex-1 text-[0.75rem] leading-snug font-medium text-ink">
+						{reference.source.title}
+					</p>
+				) : (
+					<span className="flex-1" />
+				)}
+				<Button onClick={onOpen} size="sm" variant="quiet">
+					edit
+				</Button>
+			</div>
+
+			{reference.text ? (
+				<blockquote className="border-l-2 border-rule pl-2.5 text-[0.8125rem] leading-relaxed text-ink">
+					“{reference.text}”
+				</blockquote>
+			) : null}
+
+			{attribution === '' ? null : (
+				<p className="text-[0.6875rem] text-faint">{attribution}</p>
+			)}
+			{reference.note ? (
+				<p className="text-[0.75rem] text-muted">{reference.note}</p>
+			) : null}
+
+			<select
+				aria-label={`Where ${label(reference)} sits`}
+				className="h-7 rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-ink"
+				onChange={(event) =>
+					onPlace(event.target.value === '' ? null : event.target.value)
+				}
+				value={reference.nodeId ?? ''}
+			>
+				<option value="">not placed</option>
+				{entries.map((entry) => (
+					<option key={entry.node.id} value={entry.node.id}>
+						{entry.ordinal} {entry.node.title === '' ? 'Untitled' : entry.node.title}
+					</option>
+				))}
+			</select>
+		</div>
 	)
+}
+
+/** What to call one in a label a screen reader reads out. */
+function label(reference: Reference): string {
+	return reference.source?.title ?? reference.text ?? reference.id
 }

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -1,0 +1,106 @@
+import type { Plan, ProposalInput, Reference } from '../../shared/plan'
+import { Chip } from '../components/Chip'
+import { EmptySlot } from '../components/Field'
+import { placeReference } from './edits'
+import type { OutlineEntry } from './outline'
+
+/**
+ * The Plan's References, each placed at a Section or nowhere yet. References
+ * are flat and carry an optional `nodeId`, so placing one is a field on the
+ * Reference rather than a move in the Outline — docs/architecture.md §4.
+ *
+ * The type is read off the record and never derived from whether a text is
+ * present: a Reference may carry a passage without being a Quote, and the two
+ * Panels have to label one entry the same way.
+ */
+
+export interface ReferenceListProps {
+	plan: Plan
+	entries: OutlineEntry[]
+	edit: (ops: ProposalInput | null) => void
+	className?: string
+}
+
+export function ReferenceList({ plan, entries, edit, className }: ReferenceListProps) {
+	if (plan.references.length === 0) {
+		return (
+			<EmptySlot className={className}>
+				References arrive from the Chat, and land here once you Accept them
+			</EmptySlot>
+		)
+	}
+
+	return (
+		<div className={className}>
+			{plan.references.map((reference) => (
+				<div
+					key={reference.id}
+					className="flex flex-col gap-1.5 rounded-md border border-edge bg-surface p-2"
+				>
+					<div className="flex items-baseline gap-2">
+						<Chip variant="outline">{reference.type}</Chip>
+						{reference.source?.title ? (
+							<p className="min-w-0 flex-1 text-[0.75rem] leading-snug font-medium text-ink">
+								{reference.source.title}
+							</p>
+						) : null}
+					</div>
+
+					{reference.text ? (
+						<blockquote className="border-l-2 border-rule pl-2.5 text-[0.8125rem] leading-relaxed text-ink">
+							“{reference.text}”
+						</blockquote>
+					) : null}
+
+					{attribution(reference) === '' ? null : (
+						<p className="text-[0.6875rem] text-faint">{attribution(reference)}</p>
+					)}
+					{reference.note ? (
+						<p className="text-[0.75rem] text-muted">{reference.note}</p>
+					) : null}
+
+					<PlacementSelect
+						entries={entries}
+						nodeId={reference.nodeId}
+						onPlace={(nodeId) => edit(placeReference(plan, reference.id, nodeId))}
+						reference={reference}
+					/>
+				</div>
+			))}
+		</div>
+	)
+}
+
+/** Everything in the attribution except the title, which heads the entry. */
+function attribution(reference: Reference): string {
+	const { author, publication, year, url } = reference.source ?? {}
+
+	return [author, publication, year, url].filter(Boolean).join(' · ')
+}
+
+interface PlacementSelectProps {
+	reference: Reference
+	entries: OutlineEntry[]
+	nodeId: string | null
+	onPlace: (nodeId: string | null) => void
+}
+
+function PlacementSelect({ reference, entries, nodeId, onPlace }: PlacementSelectProps) {
+	const label = reference.source?.title ?? reference.text ?? reference.id
+
+	return (
+		<select
+			aria-label={`Where ${label} sits`}
+			className="h-7 rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-ink"
+			onChange={(event) => onPlace(event.target.value === '' ? null : event.target.value)}
+			value={nodeId ?? ''}
+		>
+			<option value="">not placed</option>
+			{entries.map((entry) => (
+				<option key={entry.node.id} value={entry.node.id}>
+					{entry.ordinal} {entry.node.title === '' ? 'Untitled' : entry.node.title}
+				</option>
+			))}
+		</select>
+	)
+}

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import type { Plan, ProposalInput, Reference } from '../../shared/plan'
+import type { Plan, ProposalInput } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { Chip } from '../components/Chip'
 import { EmptySlot } from '../components/Field'
@@ -8,6 +8,8 @@ import { cx } from '../lib/cx'
 import { addReference, deleteReference, placeReference, setReference } from './edits'
 import type { OutlineEntry } from './outline'
 import { ReferenceForm } from './ReferenceForm'
+import type { ReferenceEntry } from './references'
+import { referenceEntries, referenceMark, referenceName } from './references'
 
 /**
  * The Plan's References: what the Chat turned up and the writer Accepted, and
@@ -55,7 +57,7 @@ export function ReferenceList({
 				</EmptySlot>
 			) : null}
 
-			{plan.references.map((reference) =>
+			{referenceEntries(plan).map(({ reference, number }) =>
 				reference.id === openId ? (
 					<ReferenceForm
 						key={reference.id}
@@ -73,11 +75,11 @@ export function ReferenceList({
 				) : (
 					<ReferenceRow
 						key={reference.id}
+						entry={{ reference, number }}
 						entries={entries}
 						onOpen={() => setOpenId(reference.id)}
 						onPlace={(nodeId) => edit(placeReference(plan, reference.id, nodeId))}
 						onShown={onShown}
-						reference={reference}
 						shown={reference.id === shown}
 					/>
 				),
@@ -101,7 +103,7 @@ export function ReferenceList({
 }
 
 interface ReferenceRowProps {
-	reference: Reference
+	entry: ReferenceEntry
 	entries: OutlineEntry[]
 	onOpen: () => void
 	onPlace: (nodeId: string | null) => void
@@ -110,13 +112,14 @@ interface ReferenceRowProps {
 }
 
 function ReferenceRow({
-	reference,
+	entry,
 	entries,
 	onOpen,
 	onPlace,
 	shown,
 	onShown,
 }: ReferenceRowProps) {
+	const { reference } = entry
 	const row = useRef<HTMLDivElement>(null)
 
 	useEffect(() => {
@@ -148,7 +151,9 @@ function ReferenceRow({
 			)}
 		>
 			<div className="flex items-baseline gap-2">
-				<Chip variant="outline">{reference.type}</Chip>
+				<Chip className="font-mono" variant="outline">
+					{referenceMark(entry)}
+				</Chip>
 				{reference.source?.title ? (
 					<p className="min-w-0 flex-1 text-[0.75rem] leading-snug font-medium text-ink">
 						{reference.source.title}
@@ -175,7 +180,7 @@ function ReferenceRow({
 			) : null}
 
 			<select
-				aria-label={`Where ${label(reference)} sits`}
+				aria-label={`Where ${referenceMark(entry)}, ${referenceName(reference)}, sits`}
 				className="h-7 rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-ink"
 				onChange={(event) =>
 					onPlace(event.target.value === '' ? null : event.target.value)
@@ -191,9 +196,4 @@ function ReferenceRow({
 			</select>
 		</div>
 	)
-}
-
-/** What to call one in a label a screen reader reads out. */
-function label(reference: Reference): string {
-	return reference.source?.title ?? reference.text ?? reference.id
 }

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { Plan, ProposalInput, Reference } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { Chip } from '../components/Chip'
 import { EmptySlot } from '../components/Field'
+import { cx } from '../lib/cx'
 import { addReference, deleteReference, placeReference, setReference } from './edits'
 import type { OutlineEntry } from './outline'
 import { ReferenceForm } from './ReferenceForm'
@@ -23,10 +24,24 @@ export interface ReferenceListProps {
 	plan: Plan
 	entries: OutlineEntry[]
 	edit: (ops: ProposalInput | null) => void
+	/** A Reference a Section row has sent the writer down to. It scrolls into
+	 * view and takes the accent for a moment, which is the whole of the answer
+	 * to "which one did I mean?" */
+	shown?: string | null
+	/** Said once the Reference has been shown, so the next click on the same one
+	 * shows it again. */
+	onShown?: () => void
 	className?: string
 }
 
-export function ReferenceList({ plan, entries, edit, className }: ReferenceListProps) {
+export function ReferenceList({
+	plan,
+	entries,
+	edit,
+	shown = null,
+	onShown,
+	className,
+}: ReferenceListProps) {
 	// One Reference is open at a time, and `adding` is the blank form.
 	const [openId, setOpenId] = useState<string | null>(null)
 	const [adding, setAdding] = useState(false)
@@ -61,7 +76,9 @@ export function ReferenceList({ plan, entries, edit, className }: ReferenceListP
 						entries={entries}
 						onOpen={() => setOpenId(reference.id)}
 						onPlace={(nodeId) => edit(placeReference(plan, reference.id, nodeId))}
+						onShown={onShown}
 						reference={reference}
+						shown={reference.id === shown}
 					/>
 				),
 			)}
@@ -88,9 +105,31 @@ interface ReferenceRowProps {
 	entries: OutlineEntry[]
 	onOpen: () => void
 	onPlace: (nodeId: string | null) => void
+	shown: boolean
+	onShown?: () => void
 }
 
-function ReferenceRow({ reference, entries, onOpen, onPlace }: ReferenceRowProps) {
+function ReferenceRow({
+	reference,
+	entries,
+	onOpen,
+	onPlace,
+	shown,
+	onShown,
+}: ReferenceRowProps) {
+	const row = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		if (!shown) return
+
+		row.current?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+		// The wash is a pointer, not a state the row is in, so it lets go by
+		// itself rather than waiting for the writer to dismiss it.
+		const held = setTimeout(() => onShown?.(), 1600)
+
+		return () => clearTimeout(held)
+	}, [shown, onShown])
+
 	const attribution = [
 		reference.source?.author,
 		reference.source?.publication,
@@ -101,7 +140,13 @@ function ReferenceRow({ reference, entries, onOpen, onPlace }: ReferenceRowProps
 		.join(' · ')
 
 	return (
-		<div className="flex flex-col gap-1.5 rounded-md border border-edge bg-surface p-2">
+		<div
+			ref={row}
+			className={cx(
+				'flex flex-col gap-1.5 rounded-md border p-2 transition-colors',
+				shown ? 'border-accent-edge bg-accent-soft' : 'border-edge bg-surface',
+			)}
+		>
 			<div className="flex items-baseline gap-2">
 				<Chip variant="outline">{reference.type}</Chip>
 				{reference.source?.title ? (

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -64,11 +64,14 @@ export function SectionRow({
 	const title = useRef<HTMLInputElement>(null)
 	const row = useRef<HTMLDivElement>(null)
 
+	// Opening a Section puts the caret in its title. Without it the focus stays
+	// on the closed row's button, which this row has just replaced — so it falls
+	// to the page, and Escape has nothing to close.
 	useEffect(() => {
-		if (!open || !takeCaret) return
+		if (!open) return
 
-		row.current?.scrollIntoView({ block: 'nearest' })
 		title.current?.focus()
+		if (takeCaret) row.current?.scrollIntoView({ block: 'nearest' })
 	}, [open, takeCaret])
 
 	if (!open) {
@@ -102,6 +105,18 @@ export function SectionRow({
 				'flex items-start gap-2.5 rounded-md border border-edge bg-surface p-2.5',
 				className,
 			)}
+			onBlur={(event) => {
+				// Reaching for another field closes this Section. A blur with nowhere
+				// to go — clicking the page, or the row being moved in the list — is
+				// not the writer leaving, so it does not close anything.
+				const to = event.relatedTarget
+				if (to !== null && !event.currentTarget.contains(to)) onOpen(null)
+			}}
+			onKeyDown={(event) => {
+				if (event.key !== 'Escape') return
+				event.stopPropagation()
+				onOpen(null)
+			}}
 			style={{ marginLeft: depth * 20 }}
 		>
 			<span className="mt-1.5 w-3 shrink-0 font-mono text-[0.6875rem] text-faint">

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import type { Plan, ProposalInput, Reference } from '../../shared/plan'
+import type { Plan, ProposalInput } from '../../shared/plan'
 import { nodeAllocation, resolveNodeScope } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { InlineInput, TextField } from '../components/Field'
@@ -17,6 +17,7 @@ import {
 } from './edits'
 import type { OutlineEntry } from './outline'
 import { depthName } from './outline'
+import { referenceMark, referenceName, referencesAt } from './references'
 import { ToneFields } from './ToneFields'
 import { AllocationNote, TargetField } from './WordCount'
 
@@ -67,7 +68,7 @@ export function SectionRow({
 	const title = useRef<HTMLInputElement>(null)
 	const row = useRef<HTMLDivElement>(null)
 
-	const placed = plan.references.filter((reference) => reference.nodeId === node.id)
+	const placed = referencesAt(plan, node.id)
 
 	// Opening a Section puts the caret in its title. Without it the focus stays
 	// on the closed row's button, which this row has just replaced — so it falls
@@ -90,15 +91,15 @@ export function SectionRow({
 	const references =
 		placed.length === 0 ? null : (
 			<div className="flex flex-col gap-0.5 pl-[1.375rem]">
-				{placed.map((reference) => (
+				{placed.map((held) => (
 					<button
-						key={reference.id}
+						key={held.reference.id}
 						className="flex items-baseline gap-1.5 truncate text-left text-[0.6875rem] text-muted hover:text-ink"
-						onClick={() => onShowReference(reference.id)}
+						onClick={() => onShowReference(held.reference.id)}
 						type="button"
 					>
-						<span className="label-meta shrink-0">{reference.type}</span>
-						<span className="truncate">{nameOfReference(reference)}</span>
+						<span className="label-meta shrink-0">{referenceMark(held)}</span>
+						<span className="truncate">{referenceName(held.reference)}</span>
 					</button>
 				))}
 			</div>
@@ -256,11 +257,4 @@ export function SectionRow({
 			</div>
 		</div>
 	)
-}
-
-/** What a Reference reads as on one line: its passage, or its title. */
-function nameOfReference(reference: Reference): string {
-	if (reference.text !== undefined) return `“${reference.text}”`
-
-	return reference.source?.title ?? reference.source?.url ?? 'Untitled reference'
 }

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -1,0 +1,171 @@
+import { useState } from 'react'
+
+import type { Plan, ProposalInput } from '../../shared/plan'
+import { nodeAllocation, resolveNodeScope } from '../../shared/plan'
+import { Button } from '../components/Button'
+import { InlineInput, TextField } from '../components/Field'
+import {
+	addSection,
+	deleteSection,
+	liftSection,
+	moveSection,
+	nestSection,
+	setAdjectives,
+	setIntent,
+	setTarget,
+	setTitle,
+	setVoice,
+} from './edits'
+import type { OutlineEntry } from './outline'
+import { depthName } from './outline'
+import { ToneFields } from './ToneFields'
+import { AllocationNote, TargetField } from './WordCount'
+
+/**
+ * One Section of the Outline, with every field the writer edits directly. The
+ * row keeps its id through every operation here — a reorder anchors on the
+ * neighbour it swaps with, and nothing regenerates an id.
+ */
+
+export interface SectionRowProps {
+	entry: OutlineEntry
+	plan: Plan
+	edit: (ops: ProposalInput | null) => void
+	className?: string
+}
+
+export function SectionRow({ entry, plan, edit, className }: SectionRowProps) {
+	const [armed, setArmed] = useState(false)
+	const { node, depth, index, ordinal, siblings } = entry
+
+	const name = depthName(depth)
+	const scopeName = `${name} ${ordinal}`
+	const resolved = resolveNodeScope(plan, node.id) ?? { voice: null, adjectives: [] }
+	const allocation = nodeAllocation(node)
+
+	const nest = nestSection(plan, node.id)
+	const lift = liftSection(plan, node.id)
+
+	return (
+		<div
+			className={className}
+			style={{ paddingLeft: depth * 20 }}
+			data-section-id={node.id}
+		>
+			<div className="flex items-start gap-2.5">
+				<span className="mt-1 w-6 shrink-0 font-mono text-[0.6875rem] text-faint">
+					{ordinal}
+				</span>
+
+				<div className="flex min-w-0 flex-1 flex-col gap-1.5">
+					<InlineInput
+						className="w-full text-[0.8125rem] leading-snug font-medium"
+						label={`Title of ${scopeName}`}
+						onChange={(title) => edit(setTitle(plan, node.id, title))}
+						placeholder={`Untitled ${name.toLowerCase()}`}
+						value={node.title}
+					/>
+
+					<TextField
+						hiddenLabel={`Intent note for ${scopeName}`}
+						onChange={(intent) =>
+							edit(setIntent(plan, node.id, intent === '' ? null : intent))
+						}
+						placeholder="What this Section does"
+						rows={2}
+						value={node.intent ?? ''}
+					/>
+
+					<div className="flex flex-wrap items-center gap-2.5">
+						<TargetField
+							className="w-36"
+							hiddenLabel={`Word-count target for ${scopeName}`}
+							onTarget={(target) => edit(setTarget(plan, node.id, target))}
+							target={node.target ?? null}
+						/>
+						{node.children.length > 0 ? (
+							<AllocationNote
+								allocation={allocation}
+								className="text-[0.6875rem] text-faint"
+								parts="the Subsections"
+							/>
+						) : null}
+					</div>
+
+					<ToneFields
+						adjectives={node.adjectives ?? []}
+						onAdjectives={(adjectives) => edit(setAdjectives(plan, node.id, adjectives))}
+						onVoice={(voice) => edit(setVoice(plan, node.id, voice))}
+						resolved={resolved}
+						scopeName={scopeName}
+						voice={node.voice ?? null}
+					/>
+
+					<div className="flex flex-wrap items-center gap-1.5 pt-0.5">
+						<Button
+							aria-label={`Move ${scopeName} up`}
+							disabled={index === 0}
+							onClick={() => edit(moveSection(plan, node.id, 'up'))}
+							size="sm"
+							variant="quiet"
+						>
+							↑
+						</Button>
+						<Button
+							aria-label={`Move ${scopeName} down`}
+							disabled={index === siblings.length - 1}
+							onClick={() => edit(moveSection(plan, node.id, 'down'))}
+							size="sm"
+							variant="quiet"
+						>
+							↓
+						</Button>
+						{nest !== null ? (
+							<Button
+								onClick={() => edit(nest)}
+								size="sm"
+								title={`Make ${scopeName} a Subsection of the Section above it`}
+								variant="quiet"
+							>
+								→ subsection
+							</Button>
+						) : null}
+						{lift !== null ? (
+							<Button
+								onClick={() => edit(lift)}
+								size="sm"
+								title={`Make ${scopeName} a Section of its own`}
+								variant="quiet"
+							>
+								← section
+							</Button>
+						) : null}
+						{depth === 0 ? (
+							<Button
+								onClick={() => edit(addSection({ parentId: node.id, beforeId: null }))}
+								size="sm"
+								variant="quiet"
+							>
+								+ subsection
+							</Button>
+						) : null}
+						<Button
+							className="ml-auto"
+							onBlur={() => setArmed(false)}
+							onClick={() => {
+								// Two clicks, because there is no undo and a delete takes the
+								// Subsections with it. Leaving the button disarms it.
+								if (armed) edit(deleteSection(node.id))
+								else setArmed(true)
+							}}
+							size="sm"
+							variant="quiet"
+						>
+							{armed ? `delete ${name.toLowerCase()}?` : 'delete'}
+						</Button>
+					</div>
+				</div>
+			</div>
+		</div>
+	)
+}

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -1,15 +1,14 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import type { Plan, ProposalInput } from '../../shared/plan'
 import { nodeAllocation, resolveNodeScope } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { InlineInput, TextField } from '../components/Field'
+import { OutlineRow } from '../components/OutlineRow'
+import { cx } from '../lib/cx'
 import {
-	addSection,
 	deleteSection,
-	liftSection,
 	moveSection,
-	nestSection,
 	setAdjectives,
 	setIntent,
 	setTarget,
@@ -22,148 +21,179 @@ import { ToneFields } from './ToneFields'
 import { AllocationNote, TargetField } from './WordCount'
 
 /**
- * One Section of the Outline, with every field the writer edits directly. The
- * row keeps its id through every operation here — a reorder anchors on the
+ * One Section of the Outline, closed until the writer opens it. Closed, it is
+ * the row they read: the number, the title, the target, and the Tone. Open, it
+ * is every field they edit. One Section is open at a time, so the Panel stays a
+ * list rather than a wall of inputs.
+ *
+ * The row keeps its id through every operation here — a reorder anchors on the
  * neighbour it swaps with, and nothing regenerates an id.
+ *
+ * **Subsections are TBD.** The Plan carries them and this row renders one, but
+ * the Panel offers no control that makes, nests, or lifts one. The Outline is
+ * flat until the flat one is smooth.
  */
 
 export interface SectionRowProps {
 	entry: OutlineEntry
 	plan: Plan
 	edit: (ops: ProposalInput | null) => void
+	/** True when this is the Section the writer has open. */
+	open: boolean
+	/** Open this Section, or close it with null. */
+	onOpen: (nodeId: string | null) => void
+	/** Take the caret, because the writer just made this Section. */
+	takeCaret?: boolean
 	className?: string
 }
 
-export function SectionRow({ entry, plan, edit, className }: SectionRowProps) {
+export function SectionRow({
+	entry,
+	plan,
+	edit,
+	open,
+	onOpen,
+	takeCaret = false,
+	className,
+}: SectionRowProps) {
 	const [armed, setArmed] = useState(false)
 	const { node, depth, index, ordinal, siblings } = entry
 
 	const name = depthName(depth)
 	const scopeName = `${name} ${ordinal}`
+	const title = useRef<HTMLInputElement>(null)
+	const row = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		if (!open || !takeCaret) return
+
+		row.current?.scrollIntoView({ block: 'nearest' })
+		title.current?.focus()
+	}, [open, takeCaret])
+
+	if (!open) {
+		return (
+			<button
+				className={cx(
+					'-mx-1.5 rounded-md px-1.5 py-1 text-left hover:bg-hush',
+					className,
+				)}
+				onClick={() => onOpen(node.id)}
+				style={{ marginLeft: depth * 20 }}
+				type="button"
+			>
+				<OutlineRow node={node} ordinal={ordinal} />
+				{node.intent ? (
+					<p className="mt-1 truncate pl-[1.375rem] text-[0.75rem] text-muted">
+						{node.intent}
+					</p>
+				) : null}
+			</button>
+		)
+	}
+
 	const resolved = resolveNodeScope(plan, node.id) ?? { voice: null, adjectives: [] }
 	const allocation = nodeAllocation(node)
 
-	const nest = nestSection(plan, node.id)
-	const lift = liftSection(plan, node.id)
-
 	return (
 		<div
-			className={className}
-			style={{ paddingLeft: depth * 20 }}
-			data-section-id={node.id}
+			ref={row}
+			className={cx(
+				'flex items-start gap-2.5 rounded-md border border-edge bg-surface p-2.5',
+				className,
+			)}
+			style={{ marginLeft: depth * 20 }}
 		>
-			<div className="flex items-start gap-2.5">
-				<span className="mt-1 w-6 shrink-0 font-mono text-[0.6875rem] text-faint">
-					{ordinal}
-				</span>
+			<span className="mt-1.5 w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
+				{ordinal}
+			</span>
 
-				<div className="flex min-w-0 flex-1 flex-col gap-1.5">
+			<div className="flex min-w-0 flex-1 flex-col gap-2">
+				<div className="flex items-center gap-2.5">
 					<InlineInput
-						className="w-full text-[0.8125rem] leading-snug font-medium"
+						ref={title}
+						className="min-w-0 flex-1 text-[0.8125rem] leading-snug font-medium"
 						label={`Title of ${scopeName}`}
-						onChange={(title) => edit(setTitle(plan, node.id, title))}
+						onChange={(typed) => edit(setTitle(plan, node.id, typed))}
 						placeholder={`Untitled ${name.toLowerCase()}`}
 						value={node.title}
 					/>
-
-					<TextField
-						hiddenLabel={`Intent note for ${scopeName}`}
-						onChange={(intent) =>
-							edit(setIntent(plan, node.id, intent === '' ? null : intent))
-						}
-						placeholder="What this Section does"
-						rows={2}
-						value={node.intent ?? ''}
+					<TargetField
+						className="w-28 shrink-0"
+						hiddenLabel={`Word-count target for ${scopeName}`}
+						onTarget={(target) => edit(setTarget(plan, node.id, target))}
+						placeholder="—"
+						target={node.target ?? null}
 					/>
+				</div>
 
-					<div className="flex flex-wrap items-center gap-2.5">
-						<TargetField
-							className="w-36"
-							hiddenLabel={`Word-count target for ${scopeName}`}
-							onTarget={(target) => edit(setTarget(plan, node.id, target))}
-							target={node.target ?? null}
-						/>
-						{node.children.length > 0 ? (
-							<AllocationNote
-								allocation={allocation}
-								className="text-[0.6875rem] text-faint"
-								parts="the Subsections"
-							/>
-						) : null}
-					</div>
-
-					<ToneFields
-						adjectives={node.adjectives ?? []}
-						onAdjectives={(adjectives) => edit(setAdjectives(plan, node.id, adjectives))}
-						onVoice={(voice) => edit(setVoice(plan, node.id, voice))}
-						resolved={resolved}
-						scopeName={scopeName}
-						voice={node.voice ?? null}
+				{node.children.length > 0 ? (
+					<AllocationNote
+						allocation={allocation}
+						className="text-[0.6875rem] text-faint"
+						parts="the Subsections"
 					/>
+				) : null}
 
-					<div className="flex flex-wrap items-center gap-1.5 pt-0.5">
-						<Button
-							aria-label={`Move ${scopeName} up`}
-							disabled={index === 0}
-							onClick={() => edit(moveSection(plan, node.id, 'up'))}
-							size="sm"
-							variant="quiet"
-						>
-							↑
-						</Button>
-						<Button
-							aria-label={`Move ${scopeName} down`}
-							disabled={index === siblings.length - 1}
-							onClick={() => edit(moveSection(plan, node.id, 'down'))}
-							size="sm"
-							variant="quiet"
-						>
-							↓
-						</Button>
-						{nest !== null ? (
-							<Button
-								onClick={() => edit(nest)}
-								size="sm"
-								title={`Make ${scopeName} a Subsection of the Section above it`}
-								variant="quiet"
-							>
-								→ subsection
-							</Button>
-						) : null}
-						{lift !== null ? (
-							<Button
-								onClick={() => edit(lift)}
-								size="sm"
-								title={`Make ${scopeName} a Section of its own`}
-								variant="quiet"
-							>
-								← section
-							</Button>
-						) : null}
-						{depth === 0 ? (
-							<Button
-								onClick={() => edit(addSection({ parentId: node.id, beforeId: null }))}
-								size="sm"
-								variant="quiet"
-							>
-								+ subsection
-							</Button>
-						) : null}
-						<Button
-							className="ml-auto"
-							onBlur={() => setArmed(false)}
-							onClick={() => {
-								// Two clicks, because there is no undo and a delete takes the
-								// Subsections with it. Leaving the button disarms it.
-								if (armed) edit(deleteSection(node.id))
-								else setArmed(true)
-							}}
-							size="sm"
-							variant="quiet"
-						>
-							{armed ? `delete ${name.toLowerCase()}?` : 'delete'}
-						</Button>
-					</div>
+				<TextField
+					hiddenLabel={`Intent note for ${scopeName}`}
+					onChange={(intent) =>
+						edit(setIntent(plan, node.id, intent === '' ? null : intent))
+					}
+					placeholder="What this Section does"
+					rows={2}
+					value={node.intent ?? ''}
+				/>
+
+				<ToneFields
+					adjectives={node.adjectives ?? []}
+					onAdjectives={(adjectives) => edit(setAdjectives(plan, node.id, adjectives))}
+					onVoice={(voice) => edit(setVoice(plan, node.id, voice))}
+					resolved={resolved}
+					scopeName={scopeName}
+					voice={node.voice ?? null}
+				/>
+
+				<div className="flex items-center gap-1.5 pt-0.5">
+					<Button
+						aria-label={`Move ${scopeName} up`}
+						disabled={index === 0}
+						onClick={() => edit(moveSection(plan, node.id, 'up'))}
+						size="sm"
+						variant="quiet"
+					>
+						↑
+					</Button>
+					<Button
+						aria-label={`Move ${scopeName} down`}
+						disabled={index === siblings.length - 1}
+						onClick={() => edit(moveSection(plan, node.id, 'down'))}
+						size="sm"
+						variant="quiet"
+					>
+						↓
+					</Button>
+					<Button
+						onBlur={() => setArmed(false)}
+						onClick={() => {
+							// Two clicks, because there is no undo. Leaving the button disarms
+							// it.
+							if (armed) edit(deleteSection(node.id))
+							else setArmed(true)
+						}}
+						size="sm"
+						variant="quiet"
+					>
+						{armed ? `delete ${name.toLowerCase()}?` : 'delete'}
+					</Button>
+					<Button
+						className="ml-auto"
+						onClick={() => onOpen(null)}
+						size="sm"
+						variant="quiet"
+					>
+						done
+					</Button>
 				</div>
 			</div>
 		</div>

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-import type { Plan, ProposalInput } from '../../shared/plan'
+import type { Plan, ProposalInput, Reference } from '../../shared/plan'
 import { nodeAllocation, resolveNodeScope } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { InlineInput, TextField } from '../components/Field'
@@ -44,6 +44,8 @@ export interface SectionRowProps {
 	onOpen: (nodeId: string | null) => void
 	/** Take the caret, because the writer just made this Section. */
 	takeCaret?: boolean
+	/** Show a Reference placed here, down in the References list. */
+	onShowReference: (referenceId: string) => void
 	className?: string
 }
 
@@ -54,6 +56,7 @@ export function SectionRow({
 	open,
 	onOpen,
 	takeCaret = false,
+	onShowReference,
 	className,
 }: SectionRowProps) {
 	const [armed, setArmed] = useState(false)
@@ -63,6 +66,8 @@ export function SectionRow({
 	const scopeName = `${name} ${ordinal}`
 	const title = useRef<HTMLInputElement>(null)
 	const row = useRef<HTMLDivElement>(null)
+
+	const placed = plan.references.filter((reference) => reference.nodeId === node.id)
 
 	// Opening a Section puts the caret in its title. Without it the focus stays
 	// on the closed row's button, which this row has just replaced — so it falls
@@ -74,24 +79,58 @@ export function SectionRow({
 		if (takeCaret) row.current?.scrollIntoView({ block: 'nearest' })
 	}, [open, takeCaret])
 
+	/** Enter is done. Nothing is lost by leaving — the Section reopens on a
+	 * click, and the write has already gone. */
+	const doneOnEnter = (event: { key: string; preventDefault: () => void }) => {
+		if (event.key !== 'Enter') return
+		event.preventDefault()
+		onOpen(null)
+	}
+
+	const references =
+		placed.length === 0 ? null : (
+			<div className="flex flex-col gap-0.5 pl-[1.375rem]">
+				{placed.map((reference) => (
+					<button
+						key={reference.id}
+						className="flex items-baseline gap-1.5 truncate text-left text-[0.6875rem] text-muted hover:text-ink"
+						onClick={() => onShowReference(reference.id)}
+						type="button"
+					>
+						<span className="label-meta shrink-0">{reference.type}</span>
+						<span className="truncate">{nameOfReference(reference)}</span>
+					</button>
+				))}
+			</div>
+		)
+
 	if (!open) {
 		return (
-			<button
-				className={cx(
-					'-mx-1.5 rounded-md px-1.5 py-1 text-left hover:bg-hush',
-					className,
-				)}
-				onClick={() => onOpen(node.id)}
+			<div
+				className={cx('flex flex-col gap-1', className)}
 				style={{ marginLeft: depth * 20 }}
-				type="button"
 			>
-				<OutlineRow node={node} ordinal={ordinal} />
-				{node.intent ? (
-					<p className="mt-1 truncate pl-[1.375rem] text-[0.75rem] text-muted">
-						{node.intent}
-					</p>
-				) : null}
-			</button>
+				<button
+					className="-mx-1.5 rounded-md px-1.5 py-1 text-left hover:bg-hush"
+					onClick={() => onOpen(node.id)}
+					// Opening on mousedown, because the Section that is open closes on
+					// the focus leaving it — which relays out the list and moves this
+					// row out from under the pointer before the click lands.
+					onMouseDown={(event) => {
+						event.preventDefault()
+						onOpen(node.id)
+					}}
+					type="button"
+				>
+					<OutlineRow node={node} ordinal={ordinal} />
+					{node.intent ? (
+						<p className="mt-1 truncate pl-[1.375rem] text-[0.75rem] text-muted">
+							{node.intent}
+						</p>
+					) : null}
+				</button>
+				{references}
+			</div>
 		)
 	}
 
@@ -130,12 +169,14 @@ export function SectionRow({
 						className="min-w-0 flex-1 text-[0.8125rem] leading-snug font-medium"
 						label={`Title of ${scopeName}`}
 						onChange={(typed) => edit(setTitle(plan, node.id, typed))}
+						onKeyDown={doneOnEnter}
 						placeholder={`Untitled ${name.toLowerCase()}`}
 						value={node.title}
 					/>
 					<TargetField
 						className="w-28 shrink-0"
 						hiddenLabel={`Word-count target for ${scopeName}`}
+						onKeyDown={doneOnEnter}
 						onTarget={(target) => edit(setTarget(plan, node.id, target))}
 						placeholder="—"
 						target={node.target ?? null}
@@ -168,6 +209,8 @@ export function SectionRow({
 					scopeName={scopeName}
 					voice={node.voice ?? null}
 				/>
+
+				{references}
 
 				<div className="flex items-center gap-1.5 pt-0.5">
 					<Button
@@ -213,4 +256,11 @@ export function SectionRow({
 			</div>
 		</div>
 	)
+}
+
+/** What a Reference reads as on one line: its passage, or its title. */
+function nameOfReference(reference: Reference): string {
+	if (reference.text !== undefined) return `“${reference.text}”`
+
+	return reference.source?.title ?? reference.source?.url ?? 'Untitled reference'
 }

--- a/src/client/plan/ToneFields.tsx
+++ b/src/client/plan/ToneFields.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react'
+
+import type { ResolvedScope } from '../../shared/plan'
+import { Chip } from '../components/Chip'
+import { InlineInput, TextField } from '../components/Field'
+
+/**
+ * The Tone at one Scope: its Voice and its Adjectives. One Voice applies at a
+ * time and the nearest Scope wins outright, while Adjectives accumulate — so
+ * what this Scope states is editable here, and what it inherits is shown
+ * beside it and edited where it was said. Resolution runs at read time, and
+ * nothing here stores a resolved value — docs/architecture.md §4.
+ */
+
+export interface ToneFieldsProps {
+	/** Names the Scope for a screen reader: "the Article", "Section 2". */
+	scopeName: string
+	/** What this Scope states, against `resolved`, which is what applies. */
+	voice: string | null
+	adjectives: string[]
+	resolved: ResolvedScope
+	onVoice: (voice: string | null) => void
+	onAdjectives: (adjectives: string[]) => void
+	className?: string
+}
+
+export function ToneFields({
+	scopeName,
+	voice,
+	adjectives,
+	resolved,
+	onVoice,
+	onAdjectives,
+	className,
+}: ToneFieldsProps) {
+	const [adding, setAdding] = useState('')
+
+	const inherited = voice === null ? resolved.voice : null
+	const inheritedAdjectives = resolved.adjectives.filter(
+		(adjective) => !adjectives.includes(adjective),
+	)
+
+	const add = () => {
+		const adjective = adding.trim()
+		setAdding('')
+		if (adjective === '' || adjectives.includes(adjective)) return
+
+		onAdjectives([...adjectives, adjective])
+	}
+
+	return (
+		<div className={className}>
+			<TextField
+				hiddenLabel={`Voice for ${scopeName}`}
+				label="Voice"
+				onChange={(typed) => onVoice(typed.trim() === '' ? null : typed)}
+				placeholder={inherited === null ? 'no Voice set' : `${inherited}, inherited`}
+				size="sm"
+				value={voice ?? ''}
+			/>
+
+			<div className="mt-2 flex flex-wrap items-center gap-1.5">
+				<span className="label-meta shrink-0">Adjectives</span>
+				{inheritedAdjectives.map((adjective) => (
+					<Chip key={adjective} dimmed title="inherited" variant="outline">
+						{adjective}
+					</Chip>
+				))}
+				{adjectives.map((adjective) => (
+					<Chip key={adjective}>
+						{adjective}
+						<button
+							aria-label={`Remove ${adjective} from ${scopeName}`}
+							className="text-faint hover:text-ink"
+							onClick={() =>
+								onAdjectives(adjectives.filter((held) => held !== adjective))
+							}
+							type="button"
+						>
+							×
+						</button>
+					</Chip>
+				))}
+				<InlineInput
+					className="w-24 text-[0.6875rem]"
+					label={`Add an Adjective to ${scopeName}`}
+					onChange={setAdding}
+					onKeyDown={(event) => {
+						if (event.key !== 'Enter') return
+						event.preventDefault()
+						add()
+					}}
+					placeholder="+ adjective"
+					value={adding}
+				/>
+			</div>
+		</div>
+	)
+}

--- a/src/client/plan/ToneFields.tsx
+++ b/src/client/plan/ToneFields.tsx
@@ -3,13 +3,14 @@ import { useState } from 'react'
 import type { ResolvedScope } from '../../shared/plan'
 import { Chip } from '../components/Chip'
 import { InlineInput, TextField } from '../components/Field'
+import { cx } from '../lib/cx'
 
 /**
  * The Tone at one Scope: its Voice and its Adjectives. One Voice applies at a
  * time and the nearest Scope wins outright, while Adjectives accumulate — so
  * what this Scope states is editable here, and what it inherits is shown
- * beside it and edited where it was said. Resolution runs at read time, and
- * nothing here stores a resolved value — docs/architecture.md §4.
+ * beside it, dimmed, and edited where it was said. Resolution runs at read
+ * time, and nothing here stores a resolved value — docs/architecture.md §4.
  */
 
 export interface ToneFieldsProps {
@@ -48,19 +49,26 @@ export function ToneFields({
 		onAdjectives([...adjectives, adjective])
 	}
 
+	// Both labels in one column, so Voice and Adjectives read as the pair they
+	// are rather than as two unrelated fields.
 	return (
-		<div className={className}>
+		<div
+			className={cx(
+				'grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-x-2 gap-y-1.5',
+				className,
+			)}
+		>
+			<span className="label-meta text-muted">Voice</span>
 			<TextField
 				hiddenLabel={`Voice for ${scopeName}`}
-				label="Voice"
 				onChange={(typed) => onVoice(typed.trim() === '' ? null : typed)}
 				placeholder={inherited === null ? 'no Voice set' : `${inherited}, inherited`}
 				size="sm"
 				value={voice ?? ''}
 			/>
 
-			<div className="mt-2 flex flex-wrap items-center gap-1.5">
-				<span className="label-meta shrink-0">Adjectives</span>
+			<span className="label-meta text-muted">Adjectives</span>
+			<div className="flex flex-wrap items-center gap-1.5">
 				{inheritedAdjectives.map((adjective) => (
 					<Chip key={adjective} dimmed title="inherited" variant="outline">
 						{adjective}

--- a/src/client/plan/WordCount.tsx
+++ b/src/client/plan/WordCount.tsx
@@ -1,0 +1,79 @@
+import type { Allocation } from '../../shared/plan'
+import { TextField } from '../components/Field'
+
+/**
+ * The word-count target on screen. The total is stored and nothing derives it,
+ * so the parts are allowed to disagree with the whole and the gap is
+ * information rather than an error — docs/architecture.md §4.
+ */
+
+export interface TargetFieldProps {
+	label?: string
+	hiddenLabel?: string
+	/** The stored target, and null where none is stated. */
+	target: number | null
+	onTarget: (target: number | null) => void
+	placeholder?: string
+	size?: 'sm' | 'md'
+	className?: string
+}
+
+export function TargetField({
+	label,
+	hiddenLabel,
+	target,
+	onTarget,
+	placeholder = 'no target',
+	size = 'sm',
+	className,
+}: TargetFieldProps) {
+	// Only digits reach the Plan. A target is a positive whole number of words,
+	// so an empty field and a zero both say "no target" rather than one of them
+	// failing the schema on the way out.
+	const read = (typed: string) => {
+		const digits = typed.replace(/\D/g, '')
+		onTarget(digits === '' || Number(digits) === 0 ? null : Number(digits))
+	}
+
+	return (
+		<TextField
+			className={className}
+			hiddenLabel={hiddenLabel}
+			label={label}
+			onChange={read}
+			placeholder={placeholder}
+			size={size}
+			suffix={<span className="shrink-0 text-[0.6875rem] text-faint">words</span>}
+			value={target === null ? '' : String(target)}
+		/>
+	)
+}
+
+export interface AllocationNoteProps {
+	allocation: Allocation
+	/** What the parts are called here: Sections under the Article, Subsections
+	 * under a Section. */
+	parts?: string
+	className?: string
+}
+
+/** What the targets below add up to against the target above them. */
+export function AllocationNote({
+	allocation,
+	parts = 'the Sections',
+	className,
+}: AllocationNoteProps) {
+	const { gap, status } = allocation
+	if (status === 'unstated') return null
+
+	const words = (count: number) => `${count.toLocaleString()} words`
+
+	const said = {
+		balanced: `${parts} meet the total`,
+		unallocated: `${words(gap ?? 0)} unallocated`,
+		under: `${parts} fall ${words(gap ?? 0)} short`,
+		over: `${words(-(gap ?? 0))} over the total`,
+	}[status]
+
+	return <span className={className}>{said}</span>
+}

--- a/src/client/plan/WordCount.tsx
+++ b/src/client/plan/WordCount.tsx
@@ -1,4 +1,5 @@
 import type { Allocation } from '../../shared/plan'
+import type { TextFieldProps } from '../components/Field'
 import { TextField } from '../components/Field'
 
 /**
@@ -10,6 +11,7 @@ import { TextField } from '../components/Field'
 export interface TargetFieldProps {
 	label?: string
 	hiddenLabel?: string
+	onKeyDown?: TextFieldProps['onKeyDown']
 	/** The stored target, and null where none is stated. */
 	target: number | null
 	onTarget: (target: number | null) => void
@@ -21,6 +23,7 @@ export interface TargetFieldProps {
 export function TargetField({
 	label,
 	hiddenLabel,
+	onKeyDown,
 	target,
 	onTarget,
 	placeholder = 'no target',
@@ -41,6 +44,7 @@ export function TargetField({
 			hiddenLabel={hiddenLabel}
 			label={label}
 			onChange={read}
+			onKeyDown={onKeyDown}
 			placeholder={placeholder}
 			size={size}
 			suffix={<span className="shrink-0 text-[0.6875rem] text-faint">words</span>}

--- a/src/client/plan/edits.ts
+++ b/src/client/plan/edits.ts
@@ -1,0 +1,148 @@
+import type { Anchor, OutlineNode, Plan, ProposalInput } from '../../shared/plan'
+import { findNodePath } from '../../shared/plan'
+import { placementOf } from './outline'
+
+/**
+ * The writer's edits, written in the op vocabulary the Chat proposes in and
+ * applied by the same applier — docs/architecture.md §6. One path into the Plan
+ * means the Panel cannot make a change the applier would refuse, and a
+ * structural edit carries the consequences the ops already state: deleting a
+ * Section unplaces the References placed at it.
+ *
+ * Every builder reads `expected` out of the Plan it is handed, so the writer's
+ * own edits never go Stale. Staleness is the Chat's problem — it comes from the
+ * gap between generating a Proposal and applying it, and there is no such gap
+ * here.
+ *
+ * A builder returns null where the edit has nowhere to go: the first Section
+ * cannot move up, and a Subsection cannot nest again. The Panel disables the
+ * control rather than sending an op the applier would refuse.
+ */
+
+/** Which Scope a content op acts on. null is the Article — §6. */
+export type Scope = string | null
+
+/** Where a new Section goes: whose child it is, and which neighbour it anchors
+ * to. `beforeId: null` is last child, and `afterId: null` is first. */
+export type SectionAnchor = { parentId: string | null } & Anchor
+
+export function setTitle(plan: Plan, scope: Scope, value: string): ProposalInput {
+	const expected = scope === null ? plan.title : (nodeAt(plan, scope)?.title ?? '')
+
+	return [{ op: 'setTitle', nodeId: scope, expected, value }]
+}
+
+/** The Article carries no intent note, so this one takes a Section. */
+export function setIntent(
+	plan: Plan,
+	nodeId: string,
+	value: string | null,
+): ProposalInput {
+	return [
+		{ op: 'setIntent', nodeId, expected: nodeAt(plan, nodeId)?.intent ?? null, value },
+	]
+}
+
+export function setTarget(plan: Plan, scope: Scope, value: number | null): ProposalInput {
+	const expected =
+		scope === null ? plan.totalTarget : (nodeAt(plan, scope)?.target ?? null)
+
+	return [{ op: 'setTarget', nodeId: scope, expected, value }]
+}
+
+export function setVoice(plan: Plan, scope: Scope, value: string | null): ProposalInput {
+	const expected =
+		scope === null ? (plan.voice ?? null) : (nodeAt(plan, scope)?.voice ?? null)
+
+	return [{ op: 'setVoice', nodeId: scope, expected, value }]
+}
+
+export function setAdjectives(plan: Plan, scope: Scope, value: string[]): ProposalInput {
+	const expected =
+		scope === null ? plan.adjectives : (nodeAt(plan, scope)?.adjectives ?? [])
+
+	return [{ op: 'setAdjectives', nodeId: scope, expected, value }]
+}
+
+/** A new Section, empty and untitled. The id is made here because the Plan is
+ * the only place ids live, and it never changes again. */
+export function addSection(
+	anchor: SectionAnchor,
+	id: string = crypto.randomUUID(),
+): ProposalInput {
+	return [{ op: 'createNode', ...anchor, node: { id, title: '', children: [] } }]
+}
+
+export function deleteSection(nodeId: string): ProposalInput {
+	return [{ op: 'deleteNode', nodeId }]
+}
+
+/**
+ * Move a Section one place among its siblings. It anchors to the neighbour it
+ * swaps with rather than to a position, which is the same anchoring the Chat's
+ * Proposals use.
+ */
+export function moveSection(
+	plan: Plan,
+	nodeId: string,
+	direction: 'up' | 'down',
+): ProposalInput | null {
+	const at = placementOf(plan, nodeId)
+	if (at === null) return null
+
+	const swapWith = direction === 'up' ? at.index - 1 : at.index + 1
+	if (swapWith < 0 || swapWith >= at.siblings.length) return null
+
+	const neighbour = at.siblings[swapWith].id
+	const anchor: Anchor =
+		direction === 'up' ? { beforeId: neighbour } : { afterId: neighbour }
+
+	return [{ op: 'moveNode', nodeId, parentId: at.parentId, ...anchor }]
+}
+
+/**
+ * Make a Section the last Subsection of the Section above it. Null where that
+ * would go a level too deep: the interface offers two levels, and anything
+ * deeper wants a word the writer already holds rather than a more recursive
+ * one — context.md, **Subsection**.
+ */
+export function nestSection(plan: Plan, nodeId: string): ProposalInput | null {
+	const at = placementOf(plan, nodeId)
+	if (at === null || at.depth > 0 || at.index === 0) return null
+	if (at.node.children.length > 0) return null
+
+	return [
+		{ op: 'moveNode', nodeId, parentId: at.siblings[at.index - 1].id, beforeId: null },
+	]
+}
+
+/** Make a Subsection a Section again, directly after the one it sat in. */
+export function liftSection(plan: Plan, nodeId: string): ProposalInput | null {
+	const at = placementOf(plan, nodeId)
+	if (at === null || at.parentId === null) return null
+
+	const parent = placementOf(plan, at.parentId)
+	if (parent === null) return null
+
+	return [{ op: 'moveNode', nodeId, parentId: parent.parentId, afterId: at.parentId }]
+}
+
+/** Place a Reference at a Section, or nowhere with null. */
+export function placeReference(
+	plan: Plan,
+	referenceId: string,
+	nodeId: string | null,
+): ProposalInput | null {
+	const reference = plan.references.find((held) => held.id === referenceId)
+	if (reference === undefined) return null
+
+	return [
+		{ op: 'placeReference', referenceId, expected: reference.nodeId, value: nodeId },
+	]
+}
+
+function nodeAt(plan: Plan, nodeId: string): OutlineNode | null {
+	const path = findNodePath(plan.outline, nodeId)
+
+	return path === null ? null : path[path.length - 1]
+}

--- a/src/client/plan/edits.ts
+++ b/src/client/plan/edits.ts
@@ -101,8 +101,11 @@ export function moveSection(
 }
 
 /**
- * Make a Section the last Subsection of the Section above it. Null where that
- * would go a level too deep: the interface offers two levels, and anything
+ * Make a Section the last Subsection of the Section above it. **No control in
+ * the Panel calls this yet** — Subsections are TBD, and SectionRow says why.
+ * The Chat can still propose one, so the applier and this builder stay.
+ *
+ * Null where the move would go a level too deep: the interface offers two levels, and anything
  * deeper wants a word the writer already holds rather than a more recursive
  * one — context.md, **Subsection**.
  */
@@ -116,7 +119,8 @@ export function nestSection(plan: Plan, nodeId: string): ProposalInput | null {
 	]
 }
 
-/** Make a Subsection a Section again, directly after the one it sat in. */
+/** Make a Subsection a Section again, directly after the one it sat in. TBD
+ * alongside `nestSection`. */
 export function liftSection(plan: Plan, nodeId: string): ProposalInput | null {
 	const at = placementOf(plan, nodeId)
 	if (at === null || at.parentId === null) return null

--- a/src/client/plan/edits.ts
+++ b/src/client/plan/edits.ts
@@ -1,5 +1,11 @@
-import type { Anchor, OutlineNode, Plan, ProposalInput } from '../../shared/plan'
-import { findNodePath } from '../../shared/plan'
+import type {
+	Anchor,
+	OutlineNode,
+	Plan,
+	ProposalInput,
+	ReferenceContent,
+} from '../../shared/plan'
+import { findNodePath, referenceContent } from '../../shared/plan'
 import { placementOf } from './outline'
 
 /**
@@ -129,6 +135,48 @@ export function liftSection(plan: Plan, nodeId: string): ProposalInput | null {
 	if (parent === null) return null
 
 	return [{ op: 'moveNode', nodeId, parentId: parent.parentId, afterId: at.parentId }]
+}
+
+/**
+ * A Reference the writer pasted in themselves, which is what its Provenance
+ * says. The ones that arrive from the Chat are Accepted from an Offer and carry
+ * that Offer's id instead — architecture §5.
+ */
+export function addReference(
+	content: ReferenceContent,
+	nodeId: string | null = null,
+	id: string = crypto.randomUUID(),
+): ProposalInput {
+	return [
+		{
+			op: 'createReference',
+			reference: { id, provenance: { type: 'writer' }, nodeId, ...content },
+		},
+	]
+}
+
+/** Replace what a Reference says, keeping its id, its Provenance, and where it
+ * sits. */
+export function setReference(
+	plan: Plan,
+	referenceId: string,
+	content: ReferenceContent,
+): ProposalInput | null {
+	const reference = plan.references.find((held) => held.id === referenceId)
+	if (reference === undefined) return null
+
+	return [
+		{
+			op: 'setReference',
+			referenceId,
+			expected: referenceContent(reference),
+			value: content,
+		},
+	]
+}
+
+export function deleteReference(referenceId: string): ProposalInput {
+	return [{ op: 'deleteReference', referenceId }]
 }
 
 /** Place a Reference at a Section, or nowhere with null. */

--- a/src/client/plan/outline.ts
+++ b/src/client/plan/outline.ts
@@ -1,0 +1,72 @@
+import { findNodePath, type OutlineNode, type Plan } from '../../shared/plan'
+
+/**
+ * Reading the Outline for the Panel. Depth picks the word the writer reads — 0
+ * is a Section and 1 is a Subsection — so nothing here says "node" anywhere the
+ * writer can see it.
+ */
+
+/** Where one Section sits in the Outline. */
+export type Placement = {
+	node: OutlineNode
+	/** The Section holding this one, and null when it sits at the top level. */
+	parentId: string | null
+	/** The array holding it, which is what its order is. */
+	siblings: readonly OutlineNode[]
+	index: number
+	/** 0 is a Section and 1 is a Subsection. */
+	depth: number
+}
+
+export type OutlineEntry = Placement & {
+	/** What the row is numbered: "2" for a Section, "2.1" for a Subsection. */
+	ordinal: string
+}
+
+/** Where one Section sits, or null when the Plan carries none with that id. */
+export function placementOf(plan: Plan, nodeId: string): Placement | null {
+	const path = findNodePath(plan.outline, nodeId)
+	if (path === null) return null
+
+	const node = path[path.length - 1]
+	const parent = path.length > 1 ? path[path.length - 2] : null
+	const siblings = parent === null ? plan.outline : parent.children
+
+	return {
+		node,
+		parentId: parent === null ? null : parent.id,
+		siblings,
+		index: siblings.indexOf(node),
+		depth: path.length - 1,
+	}
+}
+
+/**
+ * Every Section and Subsection in reading order. The Panel renders one flat
+ * list rather than a recursive one, so a row is one component and the depth is
+ * a number it indents by.
+ */
+export function outlineEntries(outline: readonly OutlineNode[]): OutlineEntry[] {
+	const entries: OutlineEntry[] = []
+
+	const walk = (
+		siblings: readonly OutlineNode[],
+		parentId: string | null,
+		depth: number,
+		prefix: string,
+	) => {
+		siblings.forEach((node, index) => {
+			const ordinal = `${prefix}${index + 1}`
+			entries.push({ node, parentId, siblings, index, depth, ordinal })
+			walk(node.children, node.id, depth + 1, `${ordinal}.`)
+		})
+	}
+	walk(outline, null, 0, '')
+
+	return entries
+}
+
+/** What the writer calls a row at this depth. */
+export function depthName(depth: number): string {
+	return depth === 0 ? 'Section' : 'Subsection'
+}

--- a/src/client/plan/references.ts
+++ b/src/client/plan/references.ts
@@ -1,0 +1,38 @@
+import type { Plan, Reference } from '../../shared/plan'
+
+/** Reading the References list for the Panel. */
+
+export type ReferenceEntry = {
+	reference: Reference
+	/** Where it sits in the list, counting from 1. */
+	number: number
+}
+
+/**
+ * What a Reference is called where there is one line to say it in: its type,
+ * then its number in the References list — `ref [2]`, `quote [3]`.
+ *
+ * The number is the position in the list rather than anything stored, the way a
+ * footnote number is. Deleting one renumbers the rest, and nothing refers to a
+ * Reference by it.
+ */
+export function referenceMark(entry: ReferenceEntry): string {
+	return `${entry.reference.type === 'quote' ? 'quote' : 'ref'} [${entry.number}]`
+}
+
+/** What a Reference reads as on one line: its passage, or its title. */
+export function referenceName(reference: Reference): string {
+	if (reference.text !== undefined) return `“${reference.text}”`
+
+	return reference.source?.title ?? reference.source?.url ?? 'Untitled reference'
+}
+
+/** Every Reference, numbered. */
+export function referenceEntries(plan: Plan): ReferenceEntry[] {
+	return plan.references.map((reference, index) => ({ reference, number: index + 1 }))
+}
+
+/** The References placed at one Section, keeping their numbers in the list. */
+export function referencesAt(plan: Plan, nodeId: string): ReferenceEntry[] {
+	return referenceEntries(plan).filter((entry) => entry.reference.nodeId === nodeId)
+}

--- a/src/client/plan/references.ts
+++ b/src/client/plan/references.ts
@@ -10,21 +10,21 @@ export type ReferenceEntry = {
 
 /**
  * What a Reference is called where there is one line to say it in: its type,
- * then its number in the References list — `ref [2]`, `quote [3]`.
+ * then its number in the References list — `link [2]`, `quote [3]`.
  *
  * The number is the position in the list rather than anything stored, the way a
  * footnote number is. Deleting one renumbers the rest, and nothing refers to a
  * Reference by it.
  */
 export function referenceMark(entry: ReferenceEntry): string {
-	return `${entry.reference.type === 'quote' ? 'quote' : 'ref'} [${entry.number}]`
+	return `${entry.reference.type} [${entry.number}]`
 }
 
 /** What a Reference reads as on one line: its passage, or its title. */
 export function referenceName(reference: Reference): string {
 	if (reference.text !== undefined) return `“${reference.text}”`
 
-	return reference.source?.title ?? reference.source?.url ?? 'Untitled reference'
+	return reference.source?.title ?? reference.source?.url ?? 'Untitled link'
 }
 
 /** Every Reference, numbered. */

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -1,0 +1,87 @@
+import { useAgent } from 'agents/react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import type { Plan, ProposalInput, Refusal } from '../../shared/plan'
+import { isPlanRefused } from '../../shared/plan'
+import { createPlanWriter } from './writer'
+
+/**
+ * The Plan Panel's connection to one Article Agent: its state blob in, and
+ * every edit back out through `setState` — docs/architecture.md §3, rule 1.
+ *
+ * The socket is multiplexed, so the Chat Panel shares this one and does not
+ * open its own — §8.
+ */
+
+export type PlanConnection = {
+	/** The Plan the writer sees, and null until the first state update arrives. */
+	plan: Plan | null
+	/** Apply an edit. Takes what the builders in edits.ts return, including the
+	 * null they return for an edit with nowhere to go. */
+	edit: (ops: ProposalInput | null) => void
+	/** Why the last edit did not land, cleared by the next one. */
+	refusal: Refusal | null
+	/** What the Article Agent said when a write did not parse. Reaching this is
+	 * a bug in the applier, and it is shown rather than swallowed. */
+	rejected: string | null
+}
+
+export function usePlan(articleId: string): PlanConnection {
+	const [plan, setPlan] = useState<Plan | null>(null)
+	const [refusal, setRefusal] = useState<Refusal | null>(null)
+	const [rejected, setRejected] = useState<string | null>(null)
+
+	// The socket is not built yet when the writer is, and it is replaced on every
+	// reconnect, so the writer sends through a ref rather than holding one.
+	const socket = useRef<{ setState: (plan: Plan) => void } | null>(null)
+	const held = useRef<ReturnType<typeof createPlanWriter> | null>(null)
+	held.current ??= createPlanWriter({
+		send: (next) => socket.current?.setState(next),
+		onPlan: setPlan,
+		onRefusal: setRefusal,
+	})
+	const writer = held.current
+
+	const agent = useAgent<Plan>({
+		agent: 'article-agent',
+		name: articleId,
+		onStateUpdate: (state, source) => {
+			// A client update is the echo of a write the writer already holds.
+			if (source === 'server') writer.receive(state)
+		},
+		onMessage: (event: MessageEvent) => {
+			const frame = parse(event.data)
+			if (isPlanRefused(frame)) setRejected(frame.error)
+		},
+	})
+
+	useEffect(() => {
+		socket.current = agent
+	})
+
+	// Flushing on the way out is what keeps the last keystroke of a burst.
+	useEffect(() => () => writer.dispose(), [writer])
+
+	const edit = useCallback(
+		(ops: ProposalInput | null) => {
+			setRefusal(null)
+			setRejected(null)
+			writer.edit(ops)
+		},
+		[writer],
+	)
+
+	return { plan, edit, refusal, rejected }
+}
+
+/** The socket carries frames this Panel does not read, and a binary one is not
+ * JSON at all. */
+function parse(data: unknown): unknown {
+	if (typeof data !== 'string') return null
+
+	try {
+		return JSON.parse(data)
+	} catch {
+		return null
+	}
+}

--- a/src/client/plan/writer.ts
+++ b/src/client/plan/writer.ts
@@ -1,0 +1,131 @@
+import type { OpName, Plan, ProposalInput, Refusal } from '../../shared/plan'
+import { applyProposal } from '../../shared/plan'
+
+/**
+ * The Plan's one writer. It holds the Plan the writer sees, applies each edit
+ * locally, and hands the result to the Article Agent — docs/architecture.md §3,
+ * rule 1.
+ *
+ * **It debounces while the writer types.** The Plan is one blob re-serialised
+ * and broadcast on every write, so an un-debounced intent-note field sends
+ * about 40 KB per keystroke — §4.
+ *
+ * There is no React in here, which is what lets the debounce be tested against
+ * a clock rather than against a rendered field.
+ */
+
+/** How long a pause ends a burst of typing. */
+export const WRITE_DELAY = 400
+
+/** The ops a keystroke produces. A burst of these is one write, and every other
+ * op goes at once: an Adjective is committed with a key rather than typed into
+ * the Plan, and nothing structural comes from a held-down key at all. */
+const typedOps = new Set<OpName>(['setTitle', 'setIntent', 'setTarget', 'setVoice'])
+
+export type PlanWriterOptions = {
+	/** Hand the Plan to the Article Agent. Every write goes through this. */
+	send: (plan: Plan) => void
+	/** The Plan the writer sees, after each edit and each Article Agent update. */
+	onPlan: (plan: Plan) => void
+	/** Why an edit did not land. The applier writes the sentence. */
+	onRefusal?: (refusal: Refusal) => void
+	delay?: number
+}
+
+export type PlanWriter = {
+	/** The Plan as the writer sees it, and null until the first one arrives. */
+	readonly plan: Plan | null
+	/** True while a typed edit is waiting for the pause that sends it. */
+	readonly pending: boolean
+	/** Apply an edit and schedule the write. Returns the refusal, or null when
+	 * it landed. An edit built as null — a Section that cannot move up — is not
+	 * an edit, and does nothing. */
+	edit: (ops: ProposalInput | null) => Refusal | null
+	/** Take an update from the Article Agent. */
+	receive: (plan: Plan) => void
+	/** Send what is waiting, now. */
+	flush: () => void
+	/** Flush and stop. Called when the Panel goes away, so the last keystroke of
+	 * a burst is not the one that gets lost. */
+	dispose: () => void
+}
+
+export function createPlanWriter(options: PlanWriterOptions): PlanWriter {
+	const delay = options.delay ?? WRITE_DELAY
+
+	let plan: Plan | null = null
+	let timer: ReturnType<typeof setTimeout> | null = null
+	let unsent = false
+
+	const clear = () => {
+		if (timer === null) return
+		clearTimeout(timer)
+		timer = null
+	}
+
+	const flush = () => {
+		clear()
+		if (!unsent || plan === null) return
+
+		unsent = false
+		options.send(plan)
+	}
+
+	return {
+		get plan() {
+			return plan
+		},
+		get pending() {
+			return timer !== null
+		},
+
+		edit(ops) {
+			if (ops === null) return null
+			if (plan === null) return notYet
+
+			const result = applyProposal(plan, ops)
+			if (!result.ok) {
+				options.onRefusal?.(result.refusal)
+				return result.refusal
+			}
+
+			plan = result.plan
+			unsent = true
+			options.onPlan(result.plan)
+
+			if (ops.every((op) => typedOps.has(op.op))) {
+				clear()
+				timer = setTimeout(flush, delay)
+			} else {
+				flush()
+			}
+
+			return null
+		},
+
+		receive(next) {
+			// The client is the Plan's only writer, so an update arriving over an
+			// edit of ours is the echo of an older one — §3, rule 1. Taking it would
+			// undo what the writer can see on screen.
+			if (unsent || timer !== null) return
+
+			plan = next
+			options.onPlan(next)
+		},
+
+		flush,
+		dispose() {
+			flush()
+			clear()
+		},
+	}
+}
+
+/** An edit made before the first Plan arrives. The Panel renders nothing to
+ * edit until then, so this is a guard rather than a state the writer meets. */
+const notYet: Refusal = {
+	type: 'missing',
+	index: null,
+	op: null,
+	message: 'The Plan has not arrived from the Article Agent yet.',
+}

--- a/src/client/screens/article/BlankPlanScreen.tsx
+++ b/src/client/screens/article/BlankPlanScreen.tsx
@@ -37,10 +37,7 @@ export function BlankPlanScreen() {
 						</EmptySlot>
 					</PlanBlock>
 					<PlanBlock title="References" meta="0">
-						<EmptySlot>Tick a reference in the chat</EmptySlot>
-					</PlanBlock>
-					<PlanBlock title="Quotes" meta="0">
-						<EmptySlot>Or paste your own</EmptySlot>
+						<EmptySlot>Tick a reference in the chat, or paste your own</EmptySlot>
 					</PlanBlock>
 					<p className="mt-auto text-[0.6875rem] text-faint">
 						Scrolls. Nothing here is locked, and nothing has to be finished before you

--- a/src/client/screens/article/MidChatScreen.tsx
+++ b/src/client/screens/article/MidChatScreen.tsx
@@ -3,14 +3,8 @@ import { ChatComposer, ChatMessage } from '../../components/Chat'
 import { Frame, FrameBody } from '../../components/Frame'
 import { Panel } from '../../components/Panel'
 import { ReferenceCard } from '../../components/ReferenceCard'
-import { ARTICLE_TITLE, outline, quotes, references } from '../../mock/content'
-import {
-	PlanBlock,
-	PlanLength,
-	PlanOutline,
-	PlanQuotes,
-	PlanReferences,
-} from './PlanBlocks'
+import { ARTICLE_TITLE, plan, references } from '../../mock/content'
+import { PlanBlock, PlanLength, PlanOutline, PlanReferences } from './PlanBlocks'
 
 /**
  * 2(b) — Mid-chat. Ticking a reference in the chat sends it straight into
@@ -42,22 +36,19 @@ export function MidChatScreen() {
 				</Panel>
 
 				<Panel variant="sunk">
-					<PlanLength words={2400} voice="Reported feature" />
+					<PlanLength total={plan.totalTarget} voice={plan.voice} />
 					<PlanBlock title="Outline" meta="3 of ~4">
 						<PlanOutline
-							sections={outline.slice(0, 2)}
+							outline={plan.outline.slice(0, 2)}
 							typing="Who actually pays for the delay"
 							showAdd
 						/>
 					</PlanBlock>
-					<PlanBlock title="References" meta="5">
+					<PlanBlock title="References" meta="4">
 						<PlanReferences
-							references={[references[0], references[1]]}
-							justAddedId={references[0].id}
+							references={plan.references.slice(0, 3)}
+							justAddedId={plan.references[0].id}
 						/>
-					</PlanBlock>
-					<PlanBlock title="Quotes" meta="3">
-						<PlanQuotes quotes={[quotes[0], quotes[2]]} />
 					</PlanBlock>
 				</Panel>
 			</FrameBody>

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { useState } from 'react'
 
+import type { Plan, ProposalInput, Refusal } from '../../../shared/plan'
+import { applyProposal, emptyPlan } from '../../../shared/plan'
 import { Annotation } from '../../components/Annotation'
+import { Frame, FrameBody } from '../../components/Frame'
+import { plan as plannedArticle } from '../../mock/content'
+import { PlanPanel } from '../../plan/PlanPanel'
 import { BlankPlanScreen } from './BlankPlanScreen'
 import { ChatWithReferencesScreen } from './ChatWithReferencesScreen'
 import { LedgerDrawerScreen } from './LedgerDrawerScreen'
@@ -16,6 +22,33 @@ const meta = {
 
 export default meta
 type Story = StoryObj<typeof meta>
+
+/**
+ * The Plan Panel, with the applier behind it and local state standing in for
+ * the Article Agent. Every edit runs the ops the app runs, so a refusal shows
+ * up here the way the writer would meet it.
+ */
+function EditablePlan({ start }: { start: Plan }) {
+	const [plan, setPlan] = useState(start)
+	const [refusal, setRefusal] = useState<Refusal | null>(null)
+
+	const edit = (ops: ProposalInput | null) => {
+		if (ops === null) return
+
+		setRefusal(null)
+		const result = applyProposal(plan, ops)
+		if (result.ok) setPlan(result.plan)
+		else setRefusal(result.refusal)
+	}
+
+	return (
+		<Frame width={520}>
+			<FrameBody>
+				<PlanPanel edit={edit} plan={plan} refusal={refusal} />
+			</FrameBody>
+		</Frame>
+	)
+}
 
 export const A_BlankPlan: Story = {
 	name: '2(a) Blank page',
@@ -69,9 +102,10 @@ export const E_PlanSheet: Story = {
 		<div className="flex flex-col">
 			<PlanSheetScreen />
 			<Annotation>
-				Outline, references and quotes are stacked, never columned: inside a status the
-				eye should only have to travel one way. The bar beside the outline is the shape of
-				the piece — 300 / 700 / 900 / 500 of 2,400.
+				The Outline and the References are stacked, never columned: inside a status the
+				eye should only have to travel one way. One list holds both Quotes and References,
+				because the type is a field on the record. The bar beside the Outline is the shape
+				of the piece — 300 / 700 / 900 / 500 of 2,400.
 			</Annotation>
 		</div>
 	),
@@ -98,6 +132,33 @@ export const G_LedgerPopover: Story = {
 			<Annotation>
 				The groups are the lifecycle and their order is fixed, so the undecided pile at
 				the bottom visibly shrinks as you work.
+			</Annotation>
+		</div>
+	),
+}
+
+export const H_PlanPanelBlank: Story = {
+	name: '2(h) The Plan Panel, new Article',
+	render: () => (
+		<div className="flex flex-col">
+			<EditablePlan start={emptyPlan()} />
+			<Annotation>
+				The wired Panel, not a wireframe. A new Article opens into this: a title, no
+				length, no Tone, and one button that makes the first Section.
+			</Annotation>
+		</div>
+	),
+}
+
+export const I_PlanPanelWired: Story = {
+	name: '2(i) The Plan Panel, under way',
+	render: () => (
+		<div className="flex flex-col">
+			<EditablePlan start={plannedArticle} />
+			<Annotation>
+				Every field here writes through the same ops the Chat proposes in, so the Panel
+				cannot make a change the applier would refuse. Typing debounces: the Plan is one
+				blob re-broadcast on every write, and a keystroke is not a write.
 			</Annotation>
 		</div>
 	),

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -103,7 +103,7 @@ export const E_PlanSheet: Story = {
 			<PlanSheetScreen />
 			<Annotation>
 				The Outline and the References are stacked, never columned: inside a status the
-				eye should only have to travel one way. One list holds both Quotes and References,
+				eye should only have to travel one way. One list holds both Links and Quotes,
 				because the type is a field on the record. The bar beside the Outline is the shape
 				of the piece — 300 / 700 / 900 / 500 of 2,400.
 			</Annotation>

--- a/src/client/screens/article/PlanAndDraftScreen.tsx
+++ b/src/client/screens/article/PlanAndDraftScreen.tsx
@@ -1,7 +1,7 @@
 import { ArticleBar } from '../../components/ArticleBar'
 import { DraftSurface } from '../../components/DraftSurface'
 import { Frame, FrameBody } from '../../components/Frame'
-import { ARTICLE_TITLE, draftParagraphs, outline } from '../../mock/content'
+import { ARTICLE_TITLE, draftParagraphs, plan } from '../../mock/content'
 import { PlanRail } from './PlanRail'
 
 /**
@@ -14,8 +14,9 @@ export function PlanAndDraftScreen() {
 			<ArticleBar title={ARTICLE_TITLE} open={['plan', 'draft']} status="draft 1" />
 			<FrameBody row className="min-h-[19rem]">
 				<PlanRail
-					sections={outline}
+					outline={plan.outline}
 					written={[300, 700, 520, 0]}
+					currentId="sec-cost"
 					counts={['refs 2/12', 'quotes 4/6', 'notes 1/3']}
 				/>
 				<DraftSurface paragraphs={draftParagraphs} measure="narrow" caret />

--- a/src/client/screens/article/PlanBlocks.tsx
+++ b/src/client/screens/article/PlanBlocks.tsx
@@ -1,26 +1,27 @@
 import type { ReactNode } from 'react'
 
+import type { OutlineNode, Reference } from '../../../shared/plan'
 import { Chip } from '../../components/Chip'
 import { EmptySlot, Field } from '../../components/Field'
 import { OutlineRow } from '../../components/OutlineRow'
 import { PanelHeader } from '../../components/Panel'
-import { QuoteRow } from '../../components/QuoteRow'
 import { cx } from '../../lib/cx'
-import type { Section, Quote, Reference } from '../../mock/content'
+import { outlineEntries } from '../../plan/outline'
 
 export interface PlanLengthProps {
-	words?: number
+	/** The Article's stored total, and null where none is stated. */
+	total?: number | null
 	voice?: string
 }
 
-/** The target. Empty until you or the Chat puts a number in it. */
-export function PlanLength({ words, voice }: PlanLengthProps) {
+/** The Article's target. Empty until the writer or the Chat puts a number in it. */
+export function PlanLength({ total, voice }: PlanLengthProps) {
 	return (
 		<div className="flex items-center gap-2.5">
 			<Field
 				label="Length"
 				size="sm"
-				value={words ? `${words.toLocaleString()} words` : undefined}
+				value={total ? `${total.toLocaleString()} words` : undefined}
 				placeholder="words —"
 			/>
 			{voice ? <Chip variant="outline">voice: {voice}</Chip> : null}
@@ -45,38 +46,49 @@ export function PlanBlock({ title, meta, children, className }: PlanBlockProps) 
 }
 
 export interface PlanOutlineProps {
-	sections: Section[]
-	/** A section still being typed in by hand. */
+	outline: readonly OutlineNode[]
+	/** The Section being written. */
+	currentId?: string
+	/** A Section still being typed in by hand. */
 	typing?: string
 	dense?: boolean
+	/** Accent the targets from this position in the Outline onward. */
 	changedFrom?: number
 	showAdd?: boolean
 	className?: string
 }
 
 export function PlanOutline({
-	sections,
+	outline,
+	currentId,
 	typing,
 	dense = false,
 	changedFrom,
 	showAdd = false,
 	className,
 }: PlanOutlineProps) {
+	const entries = outlineEntries(outline)
+
 	return (
 		<div className={cx('flex flex-col gap-2.5', className)}>
-			{sections.map((section) => (
+			{entries.map((entry) => (
 				<OutlineRow
-					key={section.n}
-					section={section}
+					key={entry.node.id}
+					node={entry.node}
+					ordinal={entry.ordinal}
 					dense={dense}
-					current={section.state === 'current'}
-					changed={changedFrom !== undefined && section.n >= changedFrom}
+					current={entry.node.id === currentId}
+					changed={
+						changedFrom !== undefined &&
+						entry.depth === 0 &&
+						entry.index + 1 >= changedFrom
+					}
 				/>
 			))}
 			{typing ? (
 				<div className="flex items-start gap-2.5">
 					<span className="mt-px w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
-						{sections.length + 1}
+						{entries.length + 1}
 					</span>
 					<div className="flex min-w-0 flex-1 flex-col gap-1">
 						<div className="rounded-md border border-edge bg-surface px-2 py-1 text-[0.8125rem] text-ink">
@@ -96,12 +108,23 @@ export function PlanOutline({
 }
 
 export interface PlanReferencesProps {
-	references: Reference[]
-	/** Marks the reference that has just crossed over from the chat. */
+	references: readonly Reference[]
+	/** Marks the Reference that has just crossed over from the Chat. */
 	justAddedId?: string
+	/** What each entry is placed at, by Section id. */
+	placedAt?: Record<string, string>
 }
 
-export function PlanReferences({ references, justAddedId }: PlanReferencesProps) {
+/**
+ * The Plan's References. One list, and the type on the record says which kind
+ * of entry a row is — a Quote carries a passage, and a Reference may carry one
+ * without being a Quote.
+ */
+export function PlanReferences({
+	references,
+	justAddedId,
+	placedAt,
+}: PlanReferencesProps) {
 	return (
 		<div className="flex flex-col gap-1.5">
 			{references.map((reference) => (
@@ -117,33 +140,30 @@ export function PlanReferences({ references, justAddedId }: PlanReferencesProps)
 					{reference.id === justAddedId ? (
 						<p className="label-meta">★ just added</p>
 					) : null}
-					<p className="text-[0.75rem] leading-snug font-medium text-ink">
-						{reference.title}
-					</p>
+					{reference.source?.title ? (
+						<p className="text-[0.75rem] leading-snug font-medium text-ink">
+							{reference.source.title}
+						</p>
+					) : null}
+					{reference.text ? (
+						<blockquote className="border-l-2 border-rule pl-2 text-[0.8125rem] leading-relaxed text-ink">
+							“{reference.text}”
+						</blockquote>
+					) : null}
 					<p className="text-[0.6875rem] text-faint">
-						{[reference.outlet, reference.year, reference.section]
+						{[
+							reference.type,
+							reference.source?.publication,
+							reference.source?.year,
+							reference.nodeId === null
+								? 'not placed'
+								: (placedAt?.[reference.nodeId] ?? 'placed'),
+						]
 							.filter(Boolean)
 							.join(' · ')}
 					</p>
 				</div>
 			))}
-		</div>
-	)
-}
-
-export interface PlanQuotesProps {
-	quotes: Quote[]
-	showUsage?: boolean
-	footer?: ReactNode
-}
-
-export function PlanQuotes({ quotes, showUsage = false, footer }: PlanQuotesProps) {
-	return (
-		<div className="flex flex-col gap-2.5">
-			{quotes.map((quote) => (
-				<QuoteRow key={quote.id} quote={quote} showUsage={showUsage} />
-			))}
-			{footer ? <p className="text-[0.6875rem] text-faint">{footer}</p> : null}
 		</div>
 	)
 }

--- a/src/client/screens/article/PlanRail.tsx
+++ b/src/client/screens/article/PlanRail.tsx
@@ -1,25 +1,38 @@
+import type { OutlineNode } from '../../../shared/plan'
 import { Chip } from '../../components/Chip'
 import { ProgressBar } from '../../components/ProgressBar'
 import { cx } from '../../lib/cx'
-import type { Section } from '../../mock/content'
 
 export interface PlanRailProps {
-	sections: Section[]
-	/** Written words per section, in the same order. */
+	outline: readonly OutlineNode[]
+	/** Written words per Section, in the same order. */
 	written: number[]
-	/** Chips at the foot of the rail: refs, quotes, notes. */
+	/** The Section being written. */
+	currentId?: string
+	/** Chips at the foot of the rail: references, quotes, notes. */
 	counts?: string[]
 	className?: string
 }
 
 /**
- * The plan collapsed to a rail beside the draft. Section titles, one quiet bar
+ * The Plan collapsed to a rail beside the Draft. Section titles, one quiet bar
  * each, and a whole-piece bar at the bottom — the secondary user wants a sense
  * of completion without a number that twitches on every keystroke.
  */
-export function PlanRail({ sections, written, counts, className }: PlanRailProps) {
-	const target = sections.reduce((sum, section) => sum + section.words, 0)
-	const done = written.reduce((sum, n) => sum + n, 0)
+export function PlanRail({
+	outline,
+	written,
+	currentId,
+	counts,
+	className,
+}: PlanRailProps) {
+	const target = outline.reduce((sum, node) => sum + (node.target ?? 0), 0)
+	const done = written.reduce((sum, count) => sum + count, 0)
+
+	// A Section with no target has no share of the piece to be part-way through,
+	// so its bar sits empty rather than dividing by nothing.
+	const share = (words: number, of: number | undefined) =>
+		of === undefined || of === 0 ? 0 : words / of
 
 	return (
 		<aside
@@ -28,10 +41,11 @@ export function PlanRail({ sections, written, counts, className }: PlanRailProps
 				className,
 			)}
 		>
-			{sections.map((section, i) => {
-				const current = section.state === 'current'
+			{outline.map((node, i) => {
+				const current = node.id === currentId
+				const part = share(written[i], node.target)
 				return (
-					<div key={section.n} className="flex flex-col gap-1.5">
+					<div key={node.id} className="flex flex-col gap-1.5">
 						<div className="flex items-baseline gap-1.5">
 							<p
 								className={cx(
@@ -39,21 +53,21 @@ export function PlanRail({ sections, written, counts, className }: PlanRailProps
 									current ? 'font-medium text-ink' : 'text-muted',
 								)}
 							>
-								{section.title}
+								{node.title}
 							</p>
 							{current ? <span className="text-[0.625rem] text-faint">now</span> : null}
 						</div>
 						<ProgressBar
-							value={written[i] / section.words}
-							label={`${section.title} progress`}
-							variant={written[i] / section.words > 1 ? 'attention' : 'quiet'}
+							value={part}
+							label={`${node.title} progress`}
+							variant={part > 1 ? 'attention' : 'quiet'}
 						/>
 					</div>
 				)
 			})}
 
 			<div className="mt-auto flex flex-col gap-1.5">
-				<ProgressBar value={done / target} thickness={5} label="Whole piece" />
+				<ProgressBar value={share(done, target)} thickness={5} label="Whole piece" />
 				<p className="text-[0.6875rem] text-faint">whole piece</p>
 			</div>
 

--- a/src/client/screens/article/PlanSheetScreen.tsx
+++ b/src/client/screens/article/PlanSheetScreen.tsx
@@ -5,35 +5,39 @@ import { Divider } from '../../components/Divider'
 import { Frame, FrameBody } from '../../components/Frame'
 import { LengthBar } from '../../components/LengthBar'
 import { Panel, PanelHeader } from '../../components/Panel'
-import { QuoteRow } from '../../components/QuoteRow'
-import { ARTICLE_TITLE, outline, quotes, references } from '../../mock/content'
-import { PlanOutline } from './PlanBlocks'
+import { plan, sectionState } from '../../mock/content'
+import { PlanOutline, PlanReferences } from './PlanBlocks'
+
+/** What each Section is called on the References list. */
+const placedAt = Object.fromEntries(
+	plan.outline.map((node, index) => [node.id, `§${index + 1}`]),
+)
 
 /**
- * 2(e) — The plan on its own, full width. Outline, references and quotes are
+ * 2(e) — The Plan on its own, full width. The Outline and the References are
  * stacked rather than columned: within a status the eye should only travel
- * down. The bar beside the outline is the shape of the piece — each section's
+ * down. The bar beside the Outline is the shape of the piece — each Section's
  * height is its share of the 2,400 words.
  */
 export function PlanSheetScreen() {
 	return (
 		<Frame width={680}>
-			<ArticleBar title={ARTICLE_TITLE} open={['plan']} status="draft 1" />
+			<ArticleBar title={plan.title} open={['plan']} status="draft 1" />
 			<FrameBody>
 				<Panel className="gap-5 p-5">
 					<section className="flex flex-col gap-3">
 						<PanelHeader
 							title="Outline"
 							meta="2,400 words target"
-							actions={<Chip variant="outline">voice: Reported feature</Chip>}
+							actions={<Chip variant="outline">voice: {plan.voice}</Chip>}
 						/>
 						<div className="flex items-start gap-5">
-							<PlanOutline sections={outline} className="flex-1" />
+							<PlanOutline outline={plan.outline} className="flex-1" />
 							<LengthBar
-								segments={outline.map((section) => ({
-									label: section.title,
-									words: section.words,
-									state: section.state,
+								segments={plan.outline.map((node) => ({
+									label: node.title,
+									words: node.target ?? 0,
+									state: sectionState[node.id],
 								}))}
 								height={188}
 							/>
@@ -47,39 +51,12 @@ export function PlanSheetScreen() {
 					<Divider weight="strong" />
 
 					<section className="flex flex-col gap-3">
-						<PanelHeader title="References" meta="12 · 9 kept" />
-						<div className="grid grid-cols-3 gap-2.5">
-							{[references[0], references[1], references[3]].map((reference) => (
-								<div
-									key={reference.id}
-									className="flex flex-col gap-1 rounded-md border border-edge bg-sunk p-2.5"
-								>
-									<p className="text-[0.75rem] leading-snug font-medium text-ink">
-										{reference.title}
-									</p>
-									<p className="text-[0.6875rem] text-faint">
-										{[reference.outlet, reference.year].filter(Boolean).join(' · ')}
-									</p>
-									<p className="mt-auto pt-1 text-[0.6875rem] text-muted">
-										{reference.section ?? 'unassigned'}
-									</p>
-								</div>
-							))}
-						</div>
-					</section>
-
-					<Divider weight="strong" />
-
-					<section className="flex flex-col gap-3">
-						<PanelHeader title="Quotes" meta="8 saved" />
-						<div className="flex flex-col gap-3">
-							{quotes.map((quote) => (
-								<QuoteRow key={quote.id} quote={quote} />
-							))}
-							<p className="text-[0.6875rem] text-faint">
-								+ 5 more · drag a quote onto a section to place it
-							</p>
-						</div>
+						<PanelHeader title="References" meta="4 · 3 placed" />
+						<PlanReferences references={plan.references} placedAt={placedAt} />
+						<p className="text-[0.6875rem] text-faint">
+							A Quote is a Reference of that type, so one list holds both — drag one onto
+							a Section to place it.
+						</p>
 					</section>
 
 					<div className="flex items-center gap-3 pt-1">

--- a/src/client/screens/article/PlanSheetScreen.tsx
+++ b/src/client/screens/article/PlanSheetScreen.tsx
@@ -54,7 +54,7 @@ export function PlanSheetScreen() {
 						<PanelHeader title="References" meta="4 · 3 placed" />
 						<PlanReferences references={plan.references} placedAt={placedAt} />
 						<p className="text-[0.6875rem] text-faint">
-							A Quote is a Reference of that type, so one list holds both — drag one onto
+							Every Reference is a Link or a Quote, so one list holds both — drag one onto
 							a Section to place it.
 						</p>
 					</section>

--- a/src/client/screens/article/ReadyToDraftScreen.tsx
+++ b/src/client/screens/article/ReadyToDraftScreen.tsx
@@ -3,7 +3,7 @@ import { Button } from '../../components/Button'
 import { ChatComposer, ChatMessage } from '../../components/Chat'
 import { Frame, FrameBody } from '../../components/Frame'
 import { Panel } from '../../components/Panel'
-import { ARTICLE_TITLE, outline } from '../../mock/content'
+import { ARTICLE_TITLE, plan } from '../../mock/content'
 import { PlanBlock, PlanLength, PlanOutline } from './PlanBlocks'
 
 /**
@@ -35,9 +35,9 @@ export function ReadyToDraftScreen() {
 
 				<Panel variant="sunk" padded={false}>
 					<div className="flex flex-1 flex-col gap-3.5 p-3.5">
-						<PlanLength words={2400} />
+						<PlanLength total={plan.totalTarget} />
 						<PlanBlock title="Outline" meta="4 sections">
-							<PlanOutline sections={outline} dense />
+							<PlanOutline outline={plan.outline} dense />
 						</PlanBlock>
 						<p className="text-[0.75rem] text-muted">13 references · 8 quotes</p>
 					</div>

--- a/src/client/screens/review/NotesToChatScreen.tsx
+++ b/src/client/screens/review/NotesToChatScreen.tsx
@@ -51,7 +51,7 @@ export function NotesToChatScreen() {
 				<Panel variant="sunk" padded={false}>
 					<div className="flex flex-1 flex-col gap-3.5 p-3.5">
 						<PanelHeader title="Plan" meta="revised just now" />
-						<PlanOutline sections={outlineRevised} dense changedFrom={3} />
+						<PlanOutline outline={outlineRevised} dense changedFrom={3} />
 
 						<div className="flex flex-col gap-2">
 							<MetaLabel>Quotes</MetaLabel>

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -37,10 +37,10 @@
 		'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif;
 	--font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
-	/* Meta label: the small uppercase mono labels used all over the design */
+	/* Meta label: the small mono labels used all over the design */
 	--text-meta: 0.6875rem;
 	--text-meta--line-height: 1.4;
-	--text-meta--letter-spacing: 0.06em;
+	--text-meta--letter-spacing: 0.02em;
 
 	--radius-frame: 0.625rem;
 
@@ -70,13 +70,16 @@
 }
 
 @layer components {
-	/* The small uppercase mono label. Used often enough to earn a class. */
+	/* The small mono label. Used often enough to earn a class, and it labels
+     every field in the app as well as every list.
+
+     It is set in sentence case. Uppercasing it reads as shouting, and the
+     monospace face already separates a label from the writing around it. */
 	.label-meta {
 		font-family: var(--font-mono);
 		font-size: var(--text-meta);
 		line-height: var(--text-meta--line-height);
 		letter-spacing: var(--text-meta--letter-spacing);
-		text-transform: uppercase;
 		color: var(--color-faint);
 	}
 

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -40,6 +40,11 @@ const proposePlanChange = tool({
 		'deleteNode unplaces every Reference placed at the node it removes and at any node below',
 		"it. mergeNodes keeps the target's own fields, so carry the source's intent note over",
 		'with a setIntent op in the same batch when you want it kept.',
+		'',
+		'placeReference puts a Reference the writer has already Accepted at a Section, and',
+		'"value": null takes it off the one it sits at. Its "expected" is where it sits now, which',
+		'is null while it is unplaced. You cannot add a Reference to the Plan: research reaches it',
+		'by the writer Accepting an Offer.',
 	].join('\n'),
 	inputSchema: proposePlanChangeInput,
 })

--- a/src/shared/chat.ts
+++ b/src/shared/chat.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 
-import { planSchema, proposalSchema } from './plan'
+import { chatProposalSchema, planSchema } from './plan'
 
 /**
  * What the two ends of a Chat turn agree on. The Article Agent declares the
@@ -21,8 +21,13 @@ export const proposePlanChangeTool = 'proposePlanChange'
  * the suspended call. Strict, like the op payloads inside it: a model that
  * adds a field fails the whole call and retries with the validation error
  * rather than having the field silently stripped — `docs/architecture.md` §6.
+ *
+ * `chatProposalSchema` rather than `proposalSchema`: the applier understands
+ * three more ops, and they are the writer's own References. Research reaches
+ * the Plan through the Ledger (§5), so the model is never offered a way round
+ * it.
  */
-export const proposePlanChangeInput = z.strictObject({ ops: proposalSchema })
+export const proposePlanChangeInput = z.strictObject({ ops: chatProposalSchema })
 export type ProposePlanChangeInput = z.infer<typeof proposePlanChangeInput>
 
 /**

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -3,7 +3,7 @@ import type { z } from 'zod'
 import type { Anchor, OpName, ProposalOp } from './ops'
 import { proposalSchema } from './ops'
 import type { OutlineNode, Plan } from './schema'
-import { planSchema } from './schema'
+import { planSchema, referenceContent } from './schema'
 
 /**
  * The client-side applier, working on a copy so that the first op to refuse
@@ -275,6 +275,48 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			reference.nodeId = op.value
 			return null
 		}
+
+		case 'createReference': {
+			// checkIds catches a repeated id at the final parse, the same way it
+			// catches a repeated Section id, and cannot say which op carried it.
+			if (plan.references.some((held) => held.id === op.reference.id)) {
+				return refuse(
+					'invalid',
+					`${op.op} would leave two References carrying the id ${op.reference.id}.`,
+				)
+			}
+			if (op.reference.nodeId !== null && findNode(plan, op.reference.nodeId) === null)
+				return absent(`node ${op.reference.nodeId}`)
+
+			plan.references.push(op.reference)
+			return null
+		}
+
+		case 'deleteReference': {
+			const at = plan.references.findIndex((held) => held.id === op.referenceId)
+			if (at === -1) return absent(`Reference ${op.referenceId}`)
+
+			plan.references.splice(at, 1)
+			return null
+		}
+
+		case 'setReference': {
+			const reference = plan.references.find((held) => held.id === op.referenceId)
+			if (reference === undefined) return absent(`Reference ${op.referenceId}`)
+
+			const found = referenceContent(reference)
+			if (!matches(op.expected, found)) {
+				return stale(`Reference ${op.referenceId}`, op.expected, found)
+			}
+
+			// The content is replaced whole, so a field the op leaves out is a
+			// field the Reference no longer carries — §4's one spelling per state.
+			delete reference.text
+			delete reference.source
+			delete reference.note
+			Object.assign(reference, op.value)
+			return null
+		}
 	}
 }
 
@@ -338,16 +380,33 @@ function dropEmptyAdjectives(node: OutlineNode) {
 	node.children.forEach(dropEmptyAdjectives)
 }
 
-/** Whole-field comparison. Adjectives are the one list a content op sets, and
- * order counts there. */
+/**
+ * Whole-field comparison. Adjectives are the one list a content op sets, and
+ * order counts there. A Reference's content is the one field carrying an object,
+ * and it compares key by key — a key that is absent and a key that is undefined
+ * say the same thing, which is what lets an op leave a field out.
+ */
 function matches(expected: unknown, found: unknown): boolean {
-	if (Array.isArray(expected) && Array.isArray(found)) {
+	if (Array.isArray(expected) || Array.isArray(found)) {
+		if (!Array.isArray(expected) || !Array.isArray(found)) return false
+
 		return (
-			expected.length === found.length && expected.every((term, at) => term === found[at])
+			expected.length === found.length &&
+			expected.every((term, at) => matches(term, found[at]))
 		)
 	}
 
+	if (isRecord(expected) && isRecord(found)) {
+		const keys = new Set([...Object.keys(expected), ...Object.keys(found)])
+
+		return [...keys].every((key) => matches(expected[key], found[key]))
+	}
+
 	return expected === found
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null
 }
 
 function scopeName(nodeId: string | null): string {

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -167,7 +167,8 @@ export const setReferenceOpSchema = z.strictObject({
 	value: referenceContentSchema,
 })
 
-export const proposalOpSchema = z.discriminatedUnion('op', [
+/** The Outline and what a Scope says, which the Chat and the writer both change. */
+const planOps = [
 	createNodeOpSchema,
 	moveNodeOpSchema,
 	mergeNodesOpSchema,
@@ -178,13 +179,30 @@ export const proposalOpSchema = z.discriminatedUnion('op', [
 	setVoiceOpSchema,
 	setAdjectivesOpSchema,
 	placeReferenceOpSchema,
+] as const
+
+/** The writer's own References, which only the writer writes. */
+const referenceOps = [
 	createReferenceOpSchema,
 	deleteReferenceOpSchema,
 	setReferenceOpSchema,
-])
+] as const
+
+export const proposalOpSchema = z.discriminatedUnion('op', [...planOps, ...referenceOps])
 
 /** The whole Proposal, applied as one ordered batch. An empty list is not one. */
 export const proposalSchema = z.array(proposalOpSchema).min(1)
+
+/**
+ * What the Chat may propose, against `proposalSchema`, which is everything the
+ * applier understands. The Reference ops are left out: research reaches the
+ * Plan by being Accepted from an Offer, and the Ledger is that bridge —
+ * `docs/architecture.md` §5. A model handed `createReference` could put a
+ * source in the Plan that the writer never ruled on.
+ *
+ * This is the schema the Proposal tool declares, in `src/shared/chat.ts`.
+ */
+export const chatProposalSchema = z.array(z.discriminatedUnion('op', [...planOps])).min(1)
 
 export type ProposalOp = z.infer<typeof proposalOpSchema>
 export type Proposal = z.infer<typeof proposalSchema>

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -204,6 +204,19 @@ export const proposalSchema = z.array(proposalOpSchema).min(1)
  */
 export const chatProposalSchema = z.array(z.discriminatedUnion('op', [...planOps])).min(1)
 
+/**
+ * The names of those ops, read off the schema rather than listed again — a
+ * second list is a list that drifts. The Proposal tool's description has to
+ * teach every one of them, and a test holds it to that: an op added to
+ * `planOps` reaches the model whether or not anything tells the model what it
+ * does.
+ */
+export const chatOpNames: OpName[] = (
+	chatProposalSchema.element as unknown as {
+		options: { shape: { op: { value: OpName } } }[]
+	}
+).options.map((option) => option.shape.op.value)
+
 export type ProposalOp = z.infer<typeof proposalOpSchema>
 export type Proposal = z.infer<typeof proposalSchema>
 export type OpName = ProposalOp['op']

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -6,6 +6,8 @@ import {
 	idSchema,
 	intentSchema,
 	outlineNodeSchema,
+	referenceContentSchema,
+	referenceSchema,
 	targetSchema,
 	voiceSchema,
 } from './schema'
@@ -136,6 +138,35 @@ export const placeReferenceOpSchema = z.strictObject({
 	value: idSchema.nullable(),
 })
 
+/**
+ * The three ops below are the writer's own References — the ones they paste in
+ * rather than Accept from an Offer, which is why the payload states its
+ * Provenance.
+ *
+ * The applier understanding an op does not mean the Chat may propose it. What
+ * the model is offered is the tool schema, and research reaches the Plan
+ * through the Ledger — architecture §5. Leave these out of that schema.
+ */
+export const createReferenceOpSchema = z.strictObject({
+	op: z.literal('createReference'),
+	reference: referenceSchema,
+})
+
+export const deleteReferenceOpSchema = z.strictObject({
+	op: z.literal('deleteReference'),
+	referenceId: idSchema,
+})
+
+/** Replaces what a Reference says and leaves its id, its Provenance, and its
+ * placement alone. `expected` is the whole of what it said, compared key by
+ * key, because a Reference's content is short and one field. */
+export const setReferenceOpSchema = z.strictObject({
+	op: z.literal('setReference'),
+	referenceId: idSchema,
+	expected: referenceContentSchema,
+	value: referenceContentSchema,
+})
+
 export const proposalOpSchema = z.discriminatedUnion('op', [
 	createNodeOpSchema,
 	moveNodeOpSchema,
@@ -147,6 +178,9 @@ export const proposalOpSchema = z.discriminatedUnion('op', [
 	setVoiceOpSchema,
 	setAdjectivesOpSchema,
 	placeReferenceOpSchema,
+	createReferenceOpSchema,
+	deleteReferenceOpSchema,
+	setReferenceOpSchema,
 ])
 
 /** The whole Proposal, applied as one ordered batch. An empty list is not one. */

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -50,23 +50,45 @@ export const provenanceSchema = z
 		},
 	)
 
+/** What a Reference says, against the three fields that identify it, say where
+ * it came from, and place it. An op that edits one replaces this much and
+ * leaves those alone. */
+const referenceContentFields = {
+	type: referenceTypeSchema,
+	text: z.string().min(1).optional(),
+	source: sourceSchema.optional(),
+	note: z.string().min(1).optional(),
+}
+
+type ReferenceContentFields = { type: ReferenceType; text?: string }
+
+const carriesSomething = {
+	check: (reference: { text?: string; source?: unknown }) =>
+		reference.text !== undefined || reference.source !== undefined,
+	error: 'A Reference carries a text, a source, or both. One with neither is nothing.',
+}
+
+const quoteCarriesText = {
+	check: (reference: ReferenceContentFields) =>
+		reference.type !== 'quote' || reference.text !== undefined,
+	error: 'A Reference of type quote carries a text.',
+}
+
+export const referenceContentSchema = z
+	.strictObject(referenceContentFields)
+	.refine(carriesSomething.check, { error: carriesSomething.error })
+	.refine(quoteCarriesText.check, { error: quoteCarriesText.error })
+
 /** Something the writer is drawing on. */
 export const referenceSchema = z
 	.strictObject({
 		id: idSchema,
-		type: referenceTypeSchema,
 		provenance: provenanceSchema,
-		text: z.string().min(1).optional(),
-		source: sourceSchema.optional(),
 		nodeId: idSchema.nullable(),
-		note: z.string().min(1).optional(),
+		...referenceContentFields,
 	})
-	.refine((reference) => reference.text !== undefined || reference.source !== undefined, {
-		error: 'A Reference carries a text, a source, or both. One with neither is nothing.',
-	})
-	.refine((reference) => reference.type !== 'quote' || reference.text !== undefined, {
-		error: 'A Reference of type quote carries a text.',
-	})
+	.refine(carriesSomething.check, { error: carriesSomething.error })
+	.refine(quoteCarriesText.check, { error: quoteCarriesText.error })
 
 /** The unit of structure in the Plan. */
 export const outlineNodeSchema = z.strictObject({
@@ -95,11 +117,21 @@ const planObjectSchema = z.strictObject({
 
 export type Source = z.infer<typeof sourceSchema>
 export type Provenance = z.infer<typeof provenanceSchema>
+export type ReferenceContent = z.infer<typeof referenceContentSchema>
 export type Reference = z.infer<typeof referenceSchema>
 export type OutlineNode = z.infer<typeof outlineNodeSchema>
 export type Plan = z.infer<typeof planObjectSchema>
 
 export const planSchema = planObjectSchema.superRefine(checkIds)
+
+/** What a Reference says, without the three fields `setReference` leaves
+ * alone. Both the builder of that op and the applier read it here, so the two
+ * sides of an `expected` cannot disagree about what content is. */
+export function referenceContent(reference: Reference): ReferenceContent {
+	const { type, text, source, note } = reference
+
+	return { type, ...(text && { text }), ...(source && { source }), ...(note && { note }) }
+}
 
 /** What a new Article opens into, shaped so `validateStateChange` accepts it. */
 export function emptyPlan(title = ''): Plan {

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -15,10 +15,11 @@ export const adjectiveSchema = z.string().min(1)
 export const intentSchema = z.string().min(1)
 export const targetSchema = z.number().int().positive()
 
-/** Which type of Reference this is. Stored on the record rather than derived
- * from whether a text is present, so an Offer and the Reference it was copied
- * into carry one answer and the two Panels cannot label it differently. */
-export const referenceTypeSchema = z.enum(['reference', 'quote'])
+/** Which type of Reference this is: a Link or a Quote. Stored on the record
+ * rather than derived from whether a text is present, so an Offer and the
+ * Reference it was copied into carry one answer and the two Panels cannot
+ * label it differently. */
+export const referenceTypeSchema = z.enum(['link', 'quote'])
 export type ReferenceType = z.infer<typeof referenceTypeSchema>
 
 // strictObject throughout: the Plan has one writer, so an unknown key is a bug

--- a/test/client/plan-edits.test.ts
+++ b/test/client/plan-edits.test.ts
@@ -186,9 +186,7 @@ describe('the References', () => {
 
 	it('builds no edit for a Reference the Plan does not carry', () => {
 		expect(placeReference(plan, 'gone', 'a')).toBeNull()
-		expect(
-			setReference(plan, 'gone', { type: 'reference', text: 'A passage' }),
-		).toBeNull()
+		expect(setReference(plan, 'gone', { type: 'link', text: 'A passage' })).toBeNull()
 	})
 
 	it('pastes one in, carrying the writer as its Provenance', () => {

--- a/test/client/plan-edits.test.ts
+++ b/test/client/plan-edits.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+	addSection,
+	deleteSection,
+	liftSection,
+	moveSection,
+	nestSection,
+	placeReference,
+	setAdjectives,
+	setIntent,
+	setTarget,
+	setTitle,
+	setVoice,
+} from '../../src/client/plan/edits'
+import { outlineEntries } from '../../src/client/plan/outline'
+import type { Plan, ProposalInput } from '../../src/shared/plan'
+import { applyProposal } from '../../src/shared/plan'
+import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
+
+/** Apply an edit the way the Panel does, and fail loudly on a refusal. */
+function applied(plan: Plan, ops: ProposalInput | null): Plan {
+	if (ops === null) throw new Error('The edit was not built.')
+
+	const result = applyProposal(plan, ops)
+	if (!result.ok) throw new Error(result.refusal.message)
+
+	return result.plan
+}
+
+function threeSections(): Plan {
+	return makePlan({
+		totalTarget: 1200,
+		outline: [
+			makeNode({ id: 'a', title: 'A' }),
+			makeNode({ id: 'b', title: 'B' }),
+			makeNode({ id: 'c', title: 'C' }),
+		],
+	})
+}
+
+const ids = (plan: Plan) => outlineEntries(plan.outline).map((entry) => entry.node.id)
+
+describe('the fields', () => {
+	it('retitles the Article and a Section', () => {
+		const plan = threeSections()
+
+		expect(applied(plan, setTitle(plan, null, 'The new title')).title).toBe(
+			'The new title',
+		)
+		expect(applied(plan, setTitle(plan, 'b', 'Bee')).outline[1].title).toBe('Bee')
+	})
+
+	it('writes an intent note and clears it by absence', () => {
+		const plan = threeSections()
+
+		const noted = applied(plan, setIntent(plan, 'a', 'What this Section does'))
+		expect(noted.outline[0].intent).toBe('What this Section does')
+
+		const cleared = applied(noted, setIntent(noted, 'a', null))
+		expect('intent' in cleared.outline[0]).toBe(false)
+	})
+
+	it('sets the Article total and a Section target', () => {
+		const plan = threeSections()
+
+		expect(applied(plan, setTarget(plan, null, 2400)).totalTarget).toBe(2400)
+		expect(applied(plan, setTarget(plan, 'a', 400)).outline[0].target).toBe(400)
+		expect(applied(plan, setTarget(plan, null, null)).totalTarget).toBeNull()
+	})
+
+	it('replaces a Voice and accumulates Adjectives', () => {
+		const plan = threeSections()
+
+		const spoken = applied(plan, setVoice(plan, 'a', 'Explainer'))
+		expect(spoken.outline[0].voice).toBe('Explainer')
+
+		const described = applied(spoken, setAdjectives(spoken, 'a', ['wry', 'somber']))
+		expect(described.outline[0].adjectives).toEqual(['wry', 'somber'])
+
+		// A Section states no Adjectives by carrying no key at all — §4.
+		const emptied = applied(described, setAdjectives(described, 'a', []))
+		expect('adjectives' in emptied.outline[0]).toBe(false)
+	})
+
+	it('reads expected out of the Plan, so the writer never goes Stale', () => {
+		const plan = threeSections()
+		const once = applied(plan, setTitle(plan, 'b', 'Be'))
+
+		// The second edit is built against the Plan the first one produced, which
+		// is what the Panel holds.
+		expect(applied(once, setTitle(once, 'b', 'Bee')).outline[1].title).toBe('Bee')
+	})
+})
+
+describe('the structure', () => {
+	it('adds a Section last and a Subsection under one', () => {
+		const plan = threeSections()
+
+		const added = applied(plan, addSection({ parentId: null, beforeId: null }, 'd'))
+		expect(ids(added)).toEqual(['a', 'b', 'c', 'd'])
+		expect(added.outline[3].title).toBe('')
+
+		const nested = applied(added, addSection({ parentId: 'b', beforeId: null }, 'b1'))
+		expect(ids(nested)).toEqual(['a', 'b', 'b1', 'c', 'd'])
+	})
+
+	it('reorders without touching an id', () => {
+		const plan = threeSections()
+
+		const up = applied(plan, moveSection(plan, 'c', 'up'))
+		expect(ids(up)).toEqual(['a', 'c', 'b'])
+
+		const down = applied(up, moveSection(up, 'a', 'down'))
+		expect(ids(down)).toEqual(['c', 'a', 'b'])
+
+		// The same three Sections throughout, and the titles rode along with them.
+		expect(down.outline.map((node) => node.title)).toEqual(['C', 'A', 'B'])
+	})
+
+	it('offers no move past either end', () => {
+		const plan = threeSections()
+
+		expect(moveSection(plan, 'a', 'up')).toBeNull()
+		expect(moveSection(plan, 'c', 'down')).toBeNull()
+		expect(moveSection(plan, 'gone', 'up')).toBeNull()
+	})
+
+	it('nests a Section and lifts it back, keeping its id', () => {
+		const plan = threeSections()
+
+		const nested = applied(plan, nestSection(plan, 'b'))
+		expect(ids(nested)).toEqual(['a', 'b', 'c'])
+		expect(nested.outline[0].children.map((node) => node.id)).toEqual(['b'])
+
+		const lifted = applied(nested, liftSection(nested, 'b'))
+		expect(lifted.outline.map((node) => node.id)).toEqual(['a', 'b', 'c'])
+	})
+
+	it('offers no third level, and no nest with nothing above', () => {
+		const plan = applied(
+			threeSections(),
+			addSection({ parentId: 'b', beforeId: null }, 'b1'),
+		)
+
+		// b1 is a Subsection already, and nesting it again would make the writer
+		// think in trees — context.md, **Subsection**.
+		expect(nestSection(plan, 'b1')).toBeNull()
+		// b carries a Subsection, which would go a level too deep with it.
+		expect(nestSection(plan, 'b')).toBeNull()
+		expect(nestSection(plan, 'a')).toBeNull()
+		expect(liftSection(plan, 'a')).toBeNull()
+	})
+
+	it('unplaces the References of a Section it deletes', () => {
+		const plan = makePlan({
+			outline: [makeNode({ id: 'a' }), makeNode({ id: 'b' })],
+			references: [
+				makeReference({ id: 'r1', text: 'A passage', nodeId: 'a' }),
+				makeReference({ id: 'r2', text: 'Another', nodeId: 'b' }),
+			],
+		})
+
+		const deleted = applied(plan, deleteSection('a'))
+		expect(ids(deleted)).toEqual(['b'])
+		expect(deleted.references.map((reference) => reference.nodeId)).toEqual([null, 'b'])
+	})
+})
+
+describe('the References', () => {
+	const plan = makePlan({
+		outline: [makeNode({ id: 'a' })],
+		references: [makeReference({ id: 'r1', text: 'A passage' })],
+	})
+
+	it('places one at a Section and takes it off again', () => {
+		const placed = applied(plan, placeReference(plan, 'r1', 'a'))
+		expect(placed.references[0].nodeId).toBe('a')
+
+		const unplaced = applied(placed, placeReference(placed, 'r1', null))
+		expect(unplaced.references[0].nodeId).toBeNull()
+	})
+
+	it('builds no edit for a Reference the Plan does not carry', () => {
+		expect(placeReference(plan, 'gone', 'a')).toBeNull()
+	})
+})

--- a/test/client/plan-edits.test.ts
+++ b/test/client/plan-edits.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+	addReference,
 	addSection,
+	deleteReference,
 	deleteSection,
 	liftSection,
 	moveSection,
@@ -9,6 +11,7 @@ import {
 	placeReference,
 	setAdjectives,
 	setIntent,
+	setReference,
 	setTarget,
 	setTitle,
 	setVoice,
@@ -183,5 +186,40 @@ describe('the References', () => {
 
 	it('builds no edit for a Reference the Plan does not carry', () => {
 		expect(placeReference(plan, 'gone', 'a')).toBeNull()
+		expect(
+			setReference(plan, 'gone', { type: 'reference', text: 'A passage' }),
+		).toBeNull()
+	})
+
+	it('pastes one in, carrying the writer as its Provenance', () => {
+		const pasted = applied(
+			plan,
+			addReference(
+				{ type: 'quote', text: 'A passage they pasted', source: { title: 'The memo' } },
+				'a',
+				'r2',
+			),
+		)
+
+		expect(pasted.references).toHaveLength(2)
+		expect(pasted.references[1]).toEqual({
+			id: 'r2',
+			type: 'quote',
+			provenance: { type: 'writer' },
+			text: 'A passage they pasted',
+			source: { title: 'The memo' },
+			nodeId: 'a',
+		})
+	})
+
+	it('rewrites what one says, and deletes it', () => {
+		const fixed = applied(
+			plan,
+			setReference(plan, 'r1', { type: 'quote', text: 'A passage, corrected' }),
+		)
+		expect(fixed.references[0].text).toBe('A passage, corrected')
+		expect(fixed.references[0].type).toBe('quote')
+
+		expect(applied(fixed, deleteReference('r1')).references).toEqual([])
 	})
 })

--- a/test/client/plan-writer.test.ts
+++ b/test/client/plan-writer.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { addSection, setIntent, setTitle } from '../../src/client/plan/edits'
+import { createPlanWriter, WRITE_DELAY } from '../../src/client/plan/writer'
+import type { Plan } from '../../src/shared/plan'
+import { makeNode, makePlan } from '../shared/plan-fixtures'
+
+const start = makePlan({ outline: [makeNode({ id: 'a', title: 'A' })] })
+
+function harness() {
+	const sent: Plan[] = []
+	const seen: Plan[] = []
+	const writer = createPlanWriter({
+		send: (plan) => sent.push(plan),
+		onPlan: (plan) => seen.push(plan),
+	})
+	writer.receive(start)
+
+	return { writer, sent, seen }
+}
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+describe('typing', () => {
+	it('writes once per pause rather than once per character', () => {
+		const { writer, sent, seen } = harness()
+
+		for (const typed of ['W', 'Wh', 'Why']) {
+			writer.edit(setTitle(writer.plan as Plan, 'a', typed))
+			vi.advanceTimersByTime(50)
+		}
+
+		// The writer sees every keystroke, and the Article Agent sees the pause.
+		expect(seen.map((plan) => plan.outline[0].title)).toEqual(['A', 'W', 'Wh', 'Why'])
+		expect(sent).toHaveLength(0)
+
+		vi.advanceTimersByTime(WRITE_DELAY)
+		expect(sent).toHaveLength(1)
+		expect(sent[0].outline[0].title).toBe('Why')
+	})
+
+	it('starts a new pause on each keystroke', () => {
+		const { writer, sent } = harness()
+
+		writer.edit(setIntent(writer.plan as Plan, 'a', 'One'))
+		vi.advanceTimersByTime(WRITE_DELAY - 1)
+		writer.edit(setIntent(writer.plan as Plan, 'a', 'Two'))
+		vi.advanceTimersByTime(WRITE_DELAY - 1)
+		expect(sent).toHaveLength(0)
+
+		vi.advanceTimersByTime(1)
+		expect(sent).toHaveLength(1)
+		expect(sent[0].outline[0].intent).toBe('Two')
+	})
+})
+
+describe('everything that is not typing', () => {
+	it('writes at once, and carries the pending keystrokes with it', () => {
+		const { writer, sent } = harness()
+
+		writer.edit(setTitle(writer.plan as Plan, 'a', 'Half typed'))
+		writer.edit(addSection({ parentId: null, beforeId: null }, 'b'))
+
+		expect(sent).toHaveLength(1)
+		expect(sent[0].outline[0].title).toBe('Half typed')
+		expect(sent[0].outline[1].id).toBe('b')
+
+		// The pause that was pending has nothing left to send.
+		vi.advanceTimersByTime(WRITE_DELAY)
+		expect(sent).toHaveLength(1)
+	})
+})
+
+describe('what the Article Agent sends back', () => {
+	it('is taken when nothing is pending', () => {
+		const { writer, seen } = harness()
+		const elsewhere = makePlan({ title: 'From the Chat' })
+
+		writer.receive(elsewhere)
+		expect(writer.plan?.title).toBe('From the Chat')
+		expect(seen).toHaveLength(2)
+	})
+
+	it('is ignored over an edit the writer can see', () => {
+		const { writer } = harness()
+
+		writer.edit(setTitle(writer.plan as Plan, 'a', 'Mine'))
+		writer.receive(makePlan({ title: 'An older echo' }))
+
+		expect(writer.plan?.outline[0].title).toBe('Mine')
+	})
+})
+
+describe('a refusal', () => {
+	it('leaves the Plan alone and sends nothing', () => {
+		const { writer, sent, seen } = harness()
+
+		const refusal = writer.edit([{ op: 'deleteNode', nodeId: 'gone' }])
+
+		expect(refusal?.type).toBe('missing')
+		expect(writer.plan).toEqual(start)
+		expect(sent).toHaveLength(0)
+		expect(seen).toHaveLength(1)
+	})
+})
+
+describe('going away', () => {
+	it('sends the last keystroke of a burst', () => {
+		const { writer, sent } = harness()
+
+		writer.edit(setTitle(writer.plan as Plan, 'a', 'Unsaved'))
+		writer.dispose()
+
+		expect(sent).toHaveLength(1)
+		expect(sent[0].outline[0].title).toBe('Unsaved')
+
+		vi.advanceTimersByTime(WRITE_DELAY)
+		expect(sent).toHaveLength(1)
+	})
+})

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -410,6 +410,141 @@ describe('the content ops', () => {
 		expect(refusal.found).toBe('n2a')
 	})
 
+	it('takes a Reference the writer wrote themselves, placed or not', () => {
+		const next = applied([
+			{
+				op: 'createReference',
+				reference: {
+					id: 'r4',
+					type: 'quote',
+					provenance: { type: 'writer' },
+					text: 'A passage they pasted in',
+					source: { title: 'The memo', year: 2024 },
+					nodeId: 'n1',
+				},
+			},
+		])
+
+		expect(next.references).toHaveLength(4)
+		expect(next.references[3].provenance).toEqual({ type: 'writer' })
+		expect(next.references[3].nodeId).toBe('n1')
+	})
+
+	it('refuses a Reference placed at a node the Plan does not carry', () => {
+		const refusal = refused([
+			{
+				op: 'createReference',
+				reference: {
+					id: 'r4',
+					type: 'reference',
+					provenance: { type: 'writer' },
+					source: { title: 'The memo' },
+					nodeId: 'gone',
+				},
+			},
+		])
+
+		expect(refusal.type).toBe('missing')
+		expect(refusal.message).toContain('node gone')
+	})
+
+	it('refuses a Reference carrying an id the Plan already holds', () => {
+		const refusal = refused([
+			{
+				op: 'createReference',
+				reference: {
+					id: 'r1',
+					type: 'reference',
+					provenance: { type: 'writer' },
+					source: { title: 'The memo' },
+					nodeId: null,
+				},
+			},
+		])
+
+		expect(refusal.type).toBe('invalid')
+		expect(refusal.message).toContain('two References')
+	})
+
+	it('replaces what a Reference says, and keeps what identifies it', () => {
+		const next = applied([
+			{
+				op: 'setReference',
+				referenceId: 'r1',
+				expected: { type: 'reference', text: 'A pulled passage' },
+				value: {
+					type: 'quote',
+					text: 'A pulled passage, corrected',
+					source: { author: 'R. Okonkwo' },
+				},
+			},
+		])
+
+		expect(next.references[0]).toEqual({
+			id: 'r1',
+			type: 'quote',
+			provenance: { type: 'writer' },
+			text: 'A pulled passage, corrected',
+			source: { author: 'R. Okonkwo' },
+			nodeId: 'n2a',
+		})
+	})
+
+	it('drops a field the new content leaves out', () => {
+		const noted = applied([
+			{
+				op: 'setReference',
+				referenceId: 'r2',
+				expected: { type: 'reference', text: 'An unplaced passage' },
+				value: { type: 'reference', text: 'An unplaced passage', note: 'Worth a look' },
+			},
+		])
+		const next = applied(
+			[
+				{
+					op: 'setReference',
+					referenceId: 'r2',
+					expected: {
+						type: 'reference',
+						text: 'An unplaced passage',
+						note: 'Worth a look',
+					},
+					value: { type: 'reference', text: 'An unplaced passage' },
+				},
+			],
+			noted,
+		)
+
+		expect('note' in next.references[1]).toBe(false)
+	})
+
+	it('compares a Reference key by key, so one changed field is stale', () => {
+		const refusal = refused([
+			{
+				op: 'setReference',
+				referenceId: 'r1',
+				expected: { type: 'reference', text: 'A pulled passage', note: 'Never said' },
+				value: { type: 'reference', text: 'Something else' },
+			},
+		])
+
+		expect(refusal.type).toBe('stale')
+		expect(refusal.found).toEqual({ type: 'reference', text: 'A pulled passage' })
+	})
+
+	it('deletes a Reference and leaves the rest', () => {
+		const next = applied([{ op: 'deleteReference', referenceId: 'r2' }])
+
+		expect(next.references.map((reference) => reference.id)).toEqual(['r1', 'r3'])
+	})
+
+	it('refuses to delete a Reference the Plan does not carry', () => {
+		const refusal = refused([{ op: 'deleteReference', referenceId: 'gone' }])
+
+		expect(refusal.type).toBe('missing')
+		expect(refusal.message).toContain('Reference gone')
+	})
+
 	it('refuses a content op naming a node the Plan does not carry', () => {
 		const refusal = refused([
 			{ op: 'setTitle', nodeId: 'gone', expected: '', value: 'A title' },

--- a/test/shared/plan-apply.test.ts
+++ b/test/shared/plan-apply.test.ts
@@ -436,7 +436,7 @@ describe('the content ops', () => {
 				op: 'createReference',
 				reference: {
 					id: 'r4',
-					type: 'reference',
+					type: 'link',
 					provenance: { type: 'writer' },
 					source: { title: 'The memo' },
 					nodeId: 'gone',
@@ -454,7 +454,7 @@ describe('the content ops', () => {
 				op: 'createReference',
 				reference: {
 					id: 'r1',
-					type: 'reference',
+					type: 'link',
 					provenance: { type: 'writer' },
 					source: { title: 'The memo' },
 					nodeId: null,
@@ -471,7 +471,7 @@ describe('the content ops', () => {
 			{
 				op: 'setReference',
 				referenceId: 'r1',
-				expected: { type: 'reference', text: 'A pulled passage' },
+				expected: { type: 'link', text: 'A pulled passage' },
 				value: {
 					type: 'quote',
 					text: 'A pulled passage, corrected',
@@ -495,8 +495,8 @@ describe('the content ops', () => {
 			{
 				op: 'setReference',
 				referenceId: 'r2',
-				expected: { type: 'reference', text: 'An unplaced passage' },
-				value: { type: 'reference', text: 'An unplaced passage', note: 'Worth a look' },
+				expected: { type: 'link', text: 'An unplaced passage' },
+				value: { type: 'link', text: 'An unplaced passage', note: 'Worth a look' },
 			},
 		])
 		const next = applied(
@@ -505,11 +505,11 @@ describe('the content ops', () => {
 					op: 'setReference',
 					referenceId: 'r2',
 					expected: {
-						type: 'reference',
+						type: 'link',
 						text: 'An unplaced passage',
 						note: 'Worth a look',
 					},
-					value: { type: 'reference', text: 'An unplaced passage' },
+					value: { type: 'link', text: 'An unplaced passage' },
 				},
 			],
 			noted,
@@ -523,13 +523,13 @@ describe('the content ops', () => {
 			{
 				op: 'setReference',
 				referenceId: 'r1',
-				expected: { type: 'reference', text: 'A pulled passage', note: 'Never said' },
-				value: { type: 'reference', text: 'Something else' },
+				expected: { type: 'link', text: 'A pulled passage', note: 'Never said' },
+				value: { type: 'link', text: 'Something else' },
 			},
 		])
 
 		expect(refusal.type).toBe('stale')
-		expect(refusal.found).toEqual({ type: 'reference', text: 'A pulled passage' })
+		expect(refusal.found).toEqual({ type: 'link', text: 'A pulled passage' })
 	})
 
 	it('deletes a Reference and leaves the rest', () => {

--- a/test/shared/plan-fixtures.ts
+++ b/test/shared/plan-fixtures.ts
@@ -15,5 +15,5 @@ export function makeNode(node: Partial<OutlineNode> & { id: string }): OutlineNo
 /** A Reference the writer wrote themselves, unplaced. It carries neither a text
  * nor a source, so a test states whichever the invariant it is about needs. */
 export function makeReference(reference: Partial<Reference> & { id: string }): Reference {
-	return { type: 'reference', provenance: { type: 'writer' }, nodeId: null, ...reference }
+	return { type: 'link', provenance: { type: 'writer' }, nodeId: null, ...reference }
 }

--- a/test/shared/plan-ops.test.ts
+++ b/test/shared/plan-ops.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { proposalOpSchema, proposalSchema } from '../../src/shared/plan'
+import {
+	chatProposalSchema,
+	proposalOpSchema,
+	proposalSchema,
+} from '../../src/shared/plan'
 
 /** An op that parses, so each test states only the field it is about. */
 const setTitle = {
@@ -83,5 +87,30 @@ describe('the op vocabulary', () => {
 
 	it('refuses an empty Proposal, which changes nothing', () => {
 		expect(proposalSchema.safeParse([]).success).toBe(false)
+	})
+})
+
+describe('what the Chat may propose', () => {
+	const createReference = {
+		op: 'createReference',
+		reference: {
+			id: 'r1',
+			type: 'link',
+			provenance: { type: 'writer' },
+			source: { title: 'The memo' },
+			nodeId: null,
+		},
+	}
+
+	it('takes the ops that change the Plan', () => {
+		expect(chatProposalSchema.safeParse([setTitle, createNode]).success).toBe(true)
+	})
+
+	// Research reaches the Plan by being Accepted from an Offer, and the Ledger
+	// is that bridge — docs/architecture.md §5. The applier still understands
+	// the op, because the writer's own paste goes through it.
+	it('refuses the Reference ops, which the applier understands', () => {
+		expect(chatProposalSchema.safeParse([createReference]).success).toBe(false)
+		expect(proposalSchema.safeParse([createReference]).success).toBe(true)
 	})
 })

--- a/test/shared/plan-schema.test.ts
+++ b/test/shared/plan-schema.test.ts
@@ -180,7 +180,7 @@ describe('the Reference invariant', () => {
 	it('leaves a Reference carrying a text a Reference, not a Quote', () => {
 		const result = referenceSchema.safeParse({ ...base, text: 'They knew by March.' })
 
-		expect(result.success && result.data.type).toBe('reference')
+		expect(result.success && result.data.type).toBe('link')
 	})
 
 	it('rejects a Quote carrying no text', () => {

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -40,7 +40,7 @@ const quote = {
 }
 
 const reference = {
-	type: 'reference' as const,
+	type: 'link' as const,
 	source: { title: 'Zoning and the missing middle', author: 'A. Weill' },
 	note: 'Primary data for the opening figure.',
 }
@@ -132,7 +132,7 @@ describe('Offers in the Article Agent', () => {
 	// one refuses without the Article Agent ever reaching its table.
 	it('refuses an Offer carrying neither a text nor a source', async () => {
 		await expect(
-			createOffer('offer-empty', { type: 'reference' } as OfferContent),
+			createOffer('offer-empty', { type: 'link' } as OfferContent),
 		).rejects.toThrow(/text, a source, or both/)
 	})
 
@@ -177,7 +177,7 @@ describe('Offers in the Article Agent', () => {
 
 		const titles = await runInDurableObject(stub, (agent) => {
 			const recorded = ['first', 'second', 'third', 'fourth'].map((title) =>
-				agent.createOffer({ type: 'reference', source: { title } }),
+				agent.createOffer({ type: 'link', source: { title } }),
 			)
 
 			return {

--- a/test/worker/chat-tools.test.ts
+++ b/test/worker/chat-tools.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { chatTools } from '../../src/server/llm/tools'
+import { proposePlanChangeTool } from '../../src/shared/chat'
+import { chatOpNames } from '../../src/shared/plan'
+
+/**
+ * The Proposal tool's description is a string, so nothing typechecks it against
+ * the schema declared beside it. This is what does: an op added to the schema
+ * reaches the model whether or not anything tells the model what it does.
+ */
+describe('the Proposal tool', () => {
+	// The SDK types a description as a string or a function that builds one.
+	// Ours is a string, and a test that reads it says so rather than guessing.
+	const described = chatTools[proposePlanChangeTool].description
+	const description = typeof described === 'string' ? described : ''
+
+	it('teaches every op it offers', () => {
+		const taught = chatOpNames.filter((op) => description.includes(op))
+
+		expect(taught).toEqual(chatOpNames)
+	})
+
+	// The other half of the same rule. Research reaches the Plan by the writer
+	// Accepting an Offer — architecture §5 — so the ops that put a Reference in
+	// the Plan are neither offered nor described.
+	it('teaches no op it does not offer', () => {
+		for (const op of ['createReference', 'deleteReference', 'setReference']) {
+			expect(description).not.toContain(op)
+		}
+	})
+})

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -18,5 +18,13 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.client.tsbuildinfo"
   },
-  "include": ["src/shared", "src/client", ".storybook"]
+  // The Plan fixtures are named one by one rather than by folder: the rest of
+  // test/shared is the worker project's.
+  "include": [
+    "src/shared",
+    "src/client",
+    "test/client",
+    "test/shared/plan-fixtures.ts",
+    ".storybook"
+  ]
 }

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -18,6 +18,10 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.client.tsbuildinfo"
   },
+  // Every folder under test/ belongs to exactly one project — this one or
+  // tsconfig.worker.json — and a folder named in neither is typechecked by
+  // neither, silently. Add it here or there when you add it.
+  //
   // The Plan fixtures are named one by one rather than by folder: the rest of
   // test/shared is the worker project's.
   "include": [

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -18,6 +18,7 @@
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo"
   },
   // test/client holds pure client modules and belongs to the client project.
+  // A folder under test/ named in neither project is typechecked by neither.
   "include": [
     "src/shared",
     "src/server",

--- a/tsconfig.worker.json
+++ b/tsconfig.worker.json
@@ -17,5 +17,12 @@
     "composite": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo"
   },
-  "include": ["src/shared", "src/server", "test", "worker-configuration.d.ts"]
+  // test/client holds pure client modules and belongs to the client project.
+  "include": [
+    "src/shared",
+    "src/server",
+    "test/shared",
+    "test/worker",
+    "worker-configuration.d.ts"
+  ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,10 +2,15 @@ import { cloudflareTest } from '@cloudflare/vitest-pool-workers'
 import agents from 'agents/vite'
 import { defineConfig } from 'vitest/config'
 
-// Two projects, split by what the code under test needs. A test in test/shared
-// runs in node against a pure module; a test in test/worker runs in workerd
-// with the bindings. `pnpm test:shared` skips the Vite build and workerd
-// startup, which is most of the time a shared test takes.
+// Three projects, split by what the code under test needs. A test in
+// test/shared or test/client runs in node against a pure module; a test in
+// test/worker runs in workerd with the bindings. `pnpm test:shared` and
+// `pnpm test:client` skip the Vite build and workerd startup, which is most of
+// the time a worker test takes.
+//
+// The client project holds the Plan Panel's arithmetic — its op builders and
+// its debounced writer — which is pure TypeScript. Nothing here renders a
+// component, so there is no DOM environment to configure.
 export default defineConfig({
 	test: {
 		projects: [
@@ -13,6 +18,13 @@ export default defineConfig({
 				test: {
 					name: 'shared',
 					include: ['test/shared/**/*.test.ts'],
+					environment: 'node',
+				},
+			},
+			{
+				test: {
+					name: 'client',
+					include: ['test/client/**/*.test.ts'],
 					environment: 'node',
 				},
 			},


### PR DESCRIPTION
Closes #27. The Plan Panel, wired to the Article Agent.

## Every edit is an op

A field the writer types in builds the same op vocabulary a Proposal is written in,
`applyProposal` applies it, and the result goes to `setState`. One write path means the
Panel cannot make a change the applier would refuse, and a structural edit gets the
consequences the ops already state — deleting a Section unplaces its References. The
builders in `src/client/plan/edits.ts` read `expected` out of the Plan on screen, so the
writer's own edits never go Stale.

`src/client/plan/writer.ts` holds the Plan and the debounce: it sends after a pause for the
four ops a keystroke produces, and at once for everything else. An update arriving over an
unsent edit is the echo of an older write and is dropped. There is no React in it, which is
what lets the debounce be tested against a clock rather than a rendered field.

## Three ops for the writer's own References

`createReference`, `deleteReference`, and `setReference` join the vocabulary, so a passage
the writer pastes in goes through the same applier and carries
`provenance: { type: 'writer' }`. `setReference` replaces what a Reference says and leaves
its id, its Provenance, and its placement alone; its `expected` is the whole content, so
`matches` now compares an object key by key.

**The Chat is offered ten of the thirteen.** #25's Proposal tool declared `proposalSchema`,
which is everything the applier understands — so as the two branches landed together the
model would have been handed `createReference` and a way round the Ledger. `chatProposalSchema`
is what the tool declares now.

## A Reference is a Link or a Quote

The type value `'reference'` became `'link'`. Reference is the umbrella and never a type of
its own, so "a Reference of type reference" was a tautology and the Panel printed it: a list
headed References with its rows labelled reference. Most Links carry a url and some do not —
a print citation with an author, a publication, and a year is a Link — so the field keeps the
name `url` and the form's label for it changed from Link to URL.

`context.md` gains a **Link** entry and its Reference, Quote, Offer, and Type entries are
rewritten around it. ADR 0002 gets a second amendment rather than an edit: what it decided
still holds, and only the spelling of one value moved.

## What the Panel looks like

A Section is closed until the writer opens it — number, title, target, Tone, intent note —
and one is open at a time. Enter or Escape closes it, reaching for another field closes it,
and clicking another Section swaps which one is open. `+ section` asks where the Section
goes rather than appending, then opens it with the caret in its title. Each Section lists the
References placed at it as `link [2]` / `quote [3]`, and clicking one scrolls the References
list to it.

Two design changes came out of it. `.label-meta` dropped `text-transform: uppercase` and now
labels every field in the app, so a label reads the same everywhere and Voice and Adjectives
stopped being two kinds of label. And `min-w-0` joined the field frame: an input carries an
intrinsic width of about 20 characters, which a flex item's automatic minimum size takes, so
a narrow field spilled over whatever sat beside it.

## The showcase came along

The wireframes' sketch type — `{ n, title, words, state }` — is replaced by `OutlineNode` from
the schema, so Node stays the code word and the Panel says Section and Subsection, picked by
depth. `mock/content.ts` now exports a real `Plan`, and the screens render it through the same
components the live Panel uses. Two new stories, 2(h) and 2(i), drive the wired Panel from
local state with the applier behind it.

## Left for their own tickets

- **The route that mounts the Panel** and the article index — #29. `ArticlePlanPanel` takes an
  article id and is reachable in Storybook; nothing mounts it in the app yet.
- **Accepting an Offer into the Plan** — #28.
- **Subsections.** The Plan carries them, the Chat can propose one, and a row renders one at
  its depth, but no control makes, nests, or lifts one. `nestSection` and `liftSection` stay,
  tested, with a note saying nothing calls them.

## Checks

`pnpm lint`, `pnpm format:check`, `pnpm typecheck`, and `pnpm test` all pass — 148 tests, 32
of them new. A third vitest project, `client`, runs the Panel's op builders and its debounced
writer in node; nothing there renders a component. Every interaction claim above was checked
by driving the built Storybook in Chromium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0193SsGq1ZiSdQRTbFTQY8hg

---
_Generated by [Claude Code](https://claude.ai/code/session_0193SsGq1ZiSdQRTbFTQY8hg)_