### PR TITLE
Narrow the Offer ledger to the ruling, and fix three display bugs

### DIFF
--- a/context.md
+++ b/context.md
@@ -180,13 +180,6 @@ The disposition of an Offer the writer has ruled out. Restorable — nothing is 
 _Avoid_: cut (the writer cuts their own prose), rejected, dismissed (a Guidance note is
 dismissed), discarded
 
-**Stranded**:
-Describes an Accepted Offer that no Reference in the Plan points back at. Accepting is two
-writes against two stores, so a Plan write that never lands leaves the row Accepted and the
-Plan holding nothing. Distinct from an Accepted Reference carrying no Section, which is in
-the Plan and waiting to be placed. The Offer ledger shows it and offers the re-add.
-_Avoid_: orphaned, dangling, lost, missing
-
 **Provenance**:
 Where a record came from. An Accepted Offer is **copied** into the Plan as a new,
 editable record that keeps its Provenance — so the Plan's copy is the writer's to change,
@@ -194,12 +187,12 @@ and the Offer keeps what was actually turned up. A Lexicon entry carries Provena
 same way.
 _Avoid_: back-ref, origin, source, lineage
 
-**Ready**:
+**Ready** (Phase 2):
 Describes an Accepted Offer the writer has placed in a Section but not yet worked into
 the Draft.
 _Avoid_: pending, staged, assigned
 
-**Used**:
+**Used** (Phase 2):
 Describes an Accepted Offer that appears in the Draft.
 _Avoid_: applied, written, done
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,29 +119,26 @@ plan: {
   one walk, so no two Panels can number a Section differently.
 - **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
   Section or nowhere yet.
-- **Every Reference is a Link or a Quote**, and Reference is the umbrella rather than a
-  type of its own. One structure: a pulled passage, an attribution, or both, with at least
-  one present. The type is **stored, not derived from the text**, so an Offer and the
+- **References are type Link or Quote**, and Reference is the umbrella either type; type is **stored, not derived from the text**, so an Offer and the
   Reference it was Accepted into carry one answer and the Offer ledger and the Plan Panel
-  cannot label an item differently. A Quote carries a text; a Link may carry one without
+  label them the same way. A Quote carries a text; a Link may carry one without
   being a Quote. Amended in [ADR 0002](./adr/0002-the-plan-data-model.md).
-- **Voice replaces; Adjectives compose.** One Voice applies at a time and the nearest Scope
-  wins outright. Adjectives accumulate. Resolution runs House, then Article, then
+- **Voice cascades; Adjectives compose.** One Voice applies at a time and the nearest Scope
+  wins outright. Adjectives accumulate. Resolution runs House style, then Article, then
   Section, **at read time**. A Section's ancestors take part in that same order, so a Subsection
-  under a somber middle is somber unless it says otherwise.
-- **The word-count total is stored and nothing is derived.** The parts may disagree with the
-  whole; the gap is information. Auto-distributing the remainder is rejected.
-- **One spelling per state.** A field that may be absent says "nothing here" by being absent,
-  and never also by an empty string or an empty list — the blob is written whole, compared
-  whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a second
-  spelling is a second Plan for the same content. Three fields carry their key always and say
-  "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, the
-  Article's `adjectives`, and a Section's `children`, both of them the empty list. A
-  Section's own `adjectives` is the other way round, and says it by being absent.
+  under a "fast-paced" middle will be fast-paced unless it says otherwise.
+- **The word-count total is stored rather than derived/summed.** The parts may disagree with
+  the whole; the gap is information about under/over allocation.
+- **One spelling per state.** A field that may be absent can say "nothing here" by being
+  absent, but shouldn't _also_ allow an empty string or list — the blob is written whole,
+  compared whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a
+  second spelling is a second Plan for the same content. Three fields carry their key always
+  and say "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, the Article's `adjectives`, and a Section's `children`, both of them the empty
+  list. A Section's own `adjectives` is the other way round, and says it by being absent.
 
 **The schema guards client writes.** `validateStateChange` parses the whole Plan on every
-write, and nothing the model emits ever goes through it — the Chat proposes and the client
-applies, so the blob has exactly one writer. What the model does meet are the **piece**
+write, and the model's outputs don't goes through it — the Chat proposes and the client
+applies, so the blob has only client writes. What the model does meet are the **piece**
 schemas, `outlineNodeSchema`, `referenceSchema`, and `sourceSchema`, reused inside a
 Proposal's op payloads. It lives in `src/shared/plan/` with the Scope resolver and the
 word-count arithmetic.
@@ -160,22 +157,16 @@ relief valve is moving References into SQLite rows, which is the phase 2 move an
 
 ## 5. Offers and the Ledger
 
-The Chat turns up **Offers** — Links and Quotes — as SQLite rows in the Article Agent.
-Each carries a disposition: **Undecided**, **Accepted**, or **Declined**, and Declining is
-restorable. The **Ledger** is a View over Offers, not a store.
+The Chat turns up Offers — Links and Quotes — as SQLite rows in the Article Agent. The **Ledger** is a View over Offers in the Chat panel. Each offer carries a disposition:
+**Undecided**, **Accepted**, or **Declined** (Declining is restorable).
 
-**The Ledger belongs to the Chat Panel and reads nothing outside it.** It opens over the
-Chat, it closes, and the Plan Panel beside it does not move — which is why the `close ×`
-sits on the Ledger rather than on the screen. Its groups are the three dispositions, and
-Accepting sends the Reference across. Once it has gone across it is the Plan's: where it
-sits, and whether it sits anywhere yet, are the Plan Panel's to show and it shows both
-already. A Ledger group about placement is the Ledger restating the Panel next to it.
+**The Ledger belongs to the Chat Panel and doesn't read the Plan.** Its data model and its
+visual representation should both be understood to relate to the Chat Panel itself.
+Its groupings show the three dispositions; when the writer Accepts an offer, it sends the
+Reference over to the Plan Panel; then it belongs to the Plan, where it becomes an editable
+record carrying its Provenance (rule 5) back to the original Offer.
 
 Offers are flat. Two Quotes from one publication are two Offers.
-
-Accepting copies the Offer into the Plan as a new editable record carrying its Provenance —
-rule 5. The cross-store half of the View is `src/shared/ledger.ts`, derived on read and
-holding nothing of its own; reading the Plan half alone is `src/client/plan/references.ts`.
 
 **The research tool carries an `execute`**, where the Proposal tool does not. An Offer is an
 inert row rather than something the writer rules on mid-turn, so suspending the call would
@@ -393,11 +384,6 @@ already reactive through Article Agent state and, at 1b, party-db's TanStack DB 
 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen. The **Areas** are Articles (with Board and Archive Views), House, and Team.
-
-**A View over a Panel covers that Panel and no other.** The Offer ledger is the one at 1a:
-it opens over the Chat, and the Plan Panel beside it carries on unchanged. A screen that
-shows the two together renders the ordinary Plan Panel rather than its own reading of the
-Plan — §5.
 
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,19 +124,23 @@ plan: {
   Accepted into carry one answer and the Offer ledger and the Plan Panel label them the same
   way. A Quote carries a text; a Link may carry one without being a Quote. Amended in
   [ADR 0002](./adr/0002-the-plan-data-model.md).
-- **Voice cascades; Adjectives compose.** One Voice applies at a time and the nearest Scope
-  wins outright. Adjectives accumulate. Resolution runs House style, then Article, then
-  Section, **at read time**. A Section's ancestors take part in that same order, so a Subsection
-  under a "fast-paced" middle will be fast-paced unless it says otherwise.
+- **Voice cascades; Adjectives compose.** Both resolve down the same path — House, then
+  Article, then Section, **at read time** — and they differ when two Scopes each state one.
+  The nearest Voice wins outright. Adjectives accumulate instead: a "slow" Section inside a
+  "fast" Article carries both, and the resolved list runs widest first, so the nearest lands
+  last and reads as the strongest. Restating a term moves it to the end, which is how the
+  writer says it again for emphasis.
 - **The word-count total is stored rather than derived/summed.** The parts may disagree with
   the whole; the gap is information about under/over allocation.
-- **One spelling per state.** A field that may be absent can say "nothing here" by being
-  absent, but shouldn't _also_ allow an empty string or list — the blob is written whole,
-  compared whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a
-  second spelling is a second Plan for the same content. Three fields carry their key always
-  and say "nothing here" with a value: a Reference's `nodeId`, which is null until it is
-  placed, the Article's `adjectives`, and a Section's `children`, both of them the empty
-  list. A Section's own `adjectives` is the other way round, and says it by being absent.
+- **One spelling per state.** A field that may be absent says "nothing here" by being
+  absent, and not also by an empty string or an empty list — the blob is written whole,
+  compared whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so
+  two Plans that mean the same thing can differ byte for byte and an `expected` that should
+  match will not. The schema enforces this today: an empty `adjectives` on a Section is
+  refused. Three fields carry their key always and say "nothing here" with a value: a
+  Reference's `nodeId`, which is null until it is placed, the Article's `adjectives`, and a
+  Section's `children`, both of them the empty list. A Section's own `adjectives` is the
+  other way round, and says it by being absent.
 
 **The schema guards client writes.** `validateStateChange` parses the whole Plan on every
 write, and the model's outputs do not go through it — the Chat proposes and the client

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,10 +119,11 @@ plan: {
   one walk, so no two Panels can number a Section differently.
 - **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
   Section or nowhere yet.
-- **References are type Link or Quote**, and Reference is the umbrella either type; type is **stored, not derived from the text**, so an Offer and the
-  Reference it was Accepted into carry one answer and the Offer ledger and the Plan Panel
-  label them the same way. A Quote carries a text; a Link may carry one without
-  being a Quote. Amended in [ADR 0002](./adr/0002-the-plan-data-model.md).
+- **References are type Link or Quote**, and Reference is the umbrella over either type. The
+  type is **stored, not derived from the text**, so an Offer and the Reference it was
+  Accepted into carry one answer and the Offer ledger and the Plan Panel label them the same
+  way. A Quote carries a text; a Link may carry one without being a Quote. Amended in
+  [ADR 0002](./adr/0002-the-plan-data-model.md).
 - **Voice cascades; Adjectives compose.** One Voice applies at a time and the nearest Scope
   wins outright. Adjectives accumulate. Resolution runs House style, then Article, then
   Section, **at read time**. A Section's ancestors take part in that same order, so a Subsection
@@ -133,11 +134,12 @@ plan: {
   absent, but shouldn't _also_ allow an empty string or list — the blob is written whole,
   compared whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so a
   second spelling is a second Plan for the same content. Three fields carry their key always
-  and say "nothing here" with a value: a Reference's `nodeId`, which is null until it is placed, the Article's `adjectives`, and a Section's `children`, both of them the empty
+  and say "nothing here" with a value: a Reference's `nodeId`, which is null until it is
+  placed, the Article's `adjectives`, and a Section's `children`, both of them the empty
   list. A Section's own `adjectives` is the other way round, and says it by being absent.
 
 **The schema guards client writes.** `validateStateChange` parses the whole Plan on every
-write, and the model's outputs don't goes through it — the Chat proposes and the client
+write, and the model's outputs do not go through it — the Chat proposes and the client
 applies, so the blob has only client writes. What the model does meet are the **piece**
 schemas, `outlineNodeSchema`, `referenceSchema`, and `sourceSchema`, reused inside a
 Proposal's op payloads. It lives in `src/shared/plan/` with the Scope resolver and the
@@ -157,7 +159,8 @@ relief valve is moving References into SQLite rows, which is the phase 2 move an
 
 ## 5. Offers and the Ledger
 
-The Chat turns up Offers — Links and Quotes — as SQLite rows in the Article Agent. The **Ledger** is a View over Offers in the Chat panel. Each offer carries a disposition:
+The Chat turns up Offers — Links and Quotes — as SQLite rows in the Article Agent. The
+**Ledger** is a View over Offers in the Chat Panel. Each Offer carries a disposition:
 **Undecided**, **Accepted**, or **Declined** (Declining is restorable).
 
 **The Ledger belongs to the Chat Panel and doesn't read the Plan.** Its data model and its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,18 +191,26 @@ rather than writing a second one, still carrying the disposition the writer gave
 Asking whether an Offer is already in the Plan runs on the Provenance instead: the writer
 edits their copy, and content stops matching the moment they do.
 
-**Accepting is two writes against two stores, and nothing makes them atomic.**
-`setOfferDisposition` over RPC, then a `createReference` op through the applier like every
-other Plan edit. The row goes first, because what it returns is what the copy is built
-from. If the second write never lands, the Offer is Accepted and the Plan holds nothing — a
-**stranded** Offer. The Provenance pointer is what finds it: an Accepted Offer whose id
-appears in no `provenance.offerId`. The card carries the re-add, which is the second write
-on its own. No reconciliation pass, and nothing atomic to build.
+**Accepting is two writes against two stores, and nothing makes them atomic. The copy goes
+first.** A `createReference` op through the applier like every other Plan edit, then
+`setOfferDisposition` over RPC. `referenceFromOffer` reads what the Offer says and not what
+the writer ruled, so the copy needs nothing the ruling returns and the order is free to be
+this way round.
 
-Stranded is a write that did not land, not a fourth ruling, so it gets no group of its own
-— the writer reads Accepted and finds the re-add on the row. A Reference sitting at no
-Section is a different thing again, and an ordinary one: the Plan Panel lists it and its
-Section reads "not placed".
+**It is this way round so the failure does not outlive the click.** The Plan write is local
+and the RPC is the one that can fail, so what a half-done Accept leaves is a copy in the
+Plan and a row still reading Undecided. The writer sees an unticked row, Accepts again, and
+both halves are right: `acceptOffer` follows the Provenance, finds the copy, and builds no
+op, so the retry sends the ruling and nothing else. Nothing to reconcile, nothing to show,
+and no state that persists waiting to be noticed.
+
+The other order buys the opposite. The row would read Accepted with the Plan holding
+nothing — invisible on the Ledger, unfixable from it, and needing a group and a re-add of
+its own to get back out. That was the earlier design, and the group it needed was the
+Ledger reading the Plan.
+
+A Reference sitting at no Section is a different thing entirely, and an ordinary one: the
+Plan Panel lists it and its Section reads "not placed".
 
 **The writer pastes their own References straight into the Plan**, and those carry
 `provenance: { type: 'writer' }` rather than an Offer id. They never enter the Ledger: an
@@ -210,8 +218,9 @@ Offer is something the Chat turned up and handed over to rule on, and there is n
 rule on in a passage the writer typed.
 
 **One Offer becomes one Reference**, and `planSchema` refuses a Plan carrying two copies
-of one. §5 leans on it, `referenceForOffer` answers with the first match on the strength of
-it, and a second copy would quietly stop the Ledger reporting the Offer as stranded.
+of one. `referenceForOffer` answers with the first match on the strength of it, and that
+answer is what makes a retried Accept build no op — so a second copy would turn every retry
+into another copy.
 
 **A Proposal is not an Offer.** The writer rules on both the same way, but a Proposal lives
 in the Chat turn that made it, goes Stale, and leaves no record, where an Offer is a row that

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -388,6 +388,10 @@ already reactive through Article Agent state and, at 1b, party-db's TanStack DB 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen. The **Areas** are Articles (with Board and Archive Views), House, and Team.
 
+**Each Panel scrolls its own Y.** Reading down the Plan does not move the Chat beside it.
+The Panel is the scroll container and the Frame body gives it the height to scroll within,
+so a Panel header that should stay put is `sticky` inside its own Panel.
+
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
 `expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,10 +164,12 @@ The Chat turns up **Offers** — Links and Quotes — as SQLite rows in the Arti
 Each carries a disposition: **Undecided**, **Accepted**, or **Declined**, and Declining is
 restorable. The **Ledger** is a View over Offers, not a store.
 
-**The Ledger shows the ruling and stops there.** Its groups are the three dispositions.
-Once the writer Accepts, the Reference is the Plan's, and where it sits is the Plan Panel's
-to show — Section by Section, which it already does. A Ledger group about placement would
-be the Ledger restating the Panel beside it.
+**The Ledger belongs to the Chat Panel and reads nothing outside it.** It opens over the
+Chat, it closes, and the Plan Panel beside it does not move — which is why the `close ×`
+sits on the Ledger rather than on the screen. Its groups are the three dispositions, and
+Accepting sends the Reference across. Once it has gone across it is the Plan's: where it
+sits, and whether it sits anywhere yet, are the Plan Panel's to show and it shows both
+already. A Ledger group about placement is the Ledger restating the Panel next to it.
 
 Offers are flat. Two Quotes from one publication are two Offers.
 
@@ -382,6 +384,11 @@ already reactive through Article Agent state and, at 1b, party-db's TanStack DB 
 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen. The **Areas** are Articles (with Board and Archive Views), House, and Team.
+
+**A View over a Panel covers that Panel and no other.** The Offer ledger is the one at 1a:
+it opens over the Chat, and the Plan Panel beside it carries on unchanged. A screen that
+shows the two together renders the ordinary Plan Panel rather than its own reading of the
+Plan — §5.
 
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,11 @@ The Chat turns up **Offers** — Links and Quotes — as SQLite rows in the Arti
 Each carries a disposition: **Undecided**, **Accepted**, or **Declined**, and Declining is
 restorable. The **Ledger** is a View over Offers, not a store.
 
+**The Ledger shows the ruling and stops there.** Its groups are the three dispositions.
+Once the writer Accepts, the Reference is the Plan's, and where it sits is the Plan Panel's
+to show — Section by Section, which it already does. A Ledger group about placement would
+be the Ledger restating the Panel beside it.
+
 Offers are flat. Two Quotes from one publication are two Offers.
 
 Accepting copies the Offer into the Plan as a new editable record carrying its Provenance —
@@ -187,12 +192,15 @@ edits their copy, and content stops matching the moment they do.
 **Accepting is two writes against two stores, and nothing makes them atomic.**
 `setOfferDisposition` over RPC, then a `createReference` op through the applier like every
 other Plan edit. The row goes first, because what it returns is what the copy is built
-from. If the second write never lands, the Offer is
-Accepted and the Plan holds nothing — a **stranded** Offer, which is not the Ledger's
-"Accepted, no Section yet" group; that group is a Reference carrying `nodeId: null`. The
-Provenance pointer is what finds it: an Accepted Offer whose id appears in no
-`provenance.offerId`. The Ledger shows it and the writer re-adds, which is the second write
+from. If the second write never lands, the Offer is Accepted and the Plan holds nothing — a
+**stranded** Offer. The Provenance pointer is what finds it: an Accepted Offer whose id
+appears in no `provenance.offerId`. The card carries the re-add, which is the second write
 on its own. No reconciliation pass, and nothing atomic to build.
+
+Stranded is a write that did not land, not a fourth ruling, so it gets no group of its own
+— the writer reads Accepted and finds the re-add on the row. A Reference sitting at no
+Section is a different thing again, and an ordinary one: the Plan Panel lists it and its
+Section reads "not placed".
 
 **The writer pastes their own References straight into the Plan**, and those carry
 `provenance: { type: 'writer' }` rather than an Offer id. They never enter the Ledger: an

--- a/docs/later.md
+++ b/docs/later.md
@@ -78,3 +78,15 @@ Transitions are the connective prose between two Sections and belong to neither,
 per-Section word counts currently have nowhere to put them. This would attribute those
 words somewhere the writer can see, rather than leaving a Section's count quietly
 incomplete.
+
+## Soft word-count distribution
+
+The Plan stores a total and node targets, and nothing derives one from the other, so a
+writer who has stated a total and one Section's length sees the rest as unallocated. This
+would show them the piece as it would shake out if the remainder were spread evenly across
+the Sections that state nothing, as a suggestion they Accept rather than as a value the
+Plan holds. They then build specificity where they want it and leave the rest soft.
+
+The reason it is not built: the shape only becomes clear once the Plan Panel is something
+to touch. ADR 0002 records why auto-distributing silently is rejected, and that still
+holds — this is the version the writer rules on.

--- a/src/client/components/Frame.tsx
+++ b/src/client/components/Frame.tsx
@@ -49,7 +49,9 @@ export interface FrameBodyProps {
 export function FrameBody({ children, row = false, className, style }: FrameBodyProps) {
 	return (
 		<div
-			className={cx('flex min-h-0 flex-1', row ? 'flex-row' : 'flex-col', className)}
+			// `flex-auto` rather than `flex-1`: a basis of 0 would override the height
+			// a screen sets here, and that height is what the Panels scroll within.
+			className={cx('flex min-h-0 flex-auto', row ? 'flex-row' : 'flex-col', className)}
 			style={style}
 		>
 			{children}

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -18,6 +18,11 @@ export interface PanelProps {
 /**
  * One vertical Panel in the horizontal rail. Panels never stack — they slide in
  * and out beside each other, always in chat → plan → draft → notes order.
+ *
+ * **Each Panel scrolls its own Y.** Reading down the Plan does not move the Chat
+ * beside it, which is what lets two Panels of different lengths sit side by
+ * side. It needs a height to bite on: the Frame body gives it one, and a Panel
+ * inside a body with no height simply grows as it always did.
  */
 export function Panel({
 	variant = 'surface',
@@ -32,7 +37,7 @@ export function Panel({
 	return (
 		<section
 			className={cx(
-				'flex min-w-0 flex-col',
+				'flex min-h-0 min-w-0 flex-col overflow-y-auto',
 				variant === 'sunk' ? 'bg-sunk' : 'bg-surface',
 				divider === 'left' && 'border-l border-edge',
 				divider === 'right' && 'border-r border-edge',

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -114,7 +114,9 @@ export const Progress: Story = {
 export const Research: Story = {
 	render: () => (
 		<div className="flex w-[34rem] flex-col gap-4">
-			<ReferenceCard offer={offers[0]} favourite="publication" />
+			{/* Undecided, so the Chat card shows the two rulings it offers. */}
+			<ReferenceCard offer={offers[3]} favourite="publication" />
+			<ReferenceCard offer={offers[0]} />
 			<ReferenceCard offer={offers[2]} variant="ledger" />
 			<ReferenceCard offer={offers[4]} variant="ledger" compact />
 			<ReferenceCard offer={offers[6]} variant="ledger" compact />

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -117,7 +117,7 @@ export const Research: Story = {
 			<ReferenceCard offer={offers[0]} favourite="publication" />
 			<ReferenceCard offer={offers[2]} variant="ledger" />
 			<ReferenceCard offer={offers[4]} variant="ledger" compact />
-			<ReferenceCard offer={offers[6]} variant="ledger" compact inThePlan={false} />
+			<ReferenceCard offer={offers[6]} variant="ledger" compact />
 			<QuoteRow reference={plan.references[2]} section="§2" showUsage />
 			<QuoteRow reference={plan.references[3]} showUsage />
 		</div>

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -117,7 +117,7 @@ export const Research: Story = {
 			<ReferenceCard offer={offers[0]} favourite="publication" />
 			<ReferenceCard offer={offers[2]} variant="ledger" />
 			<ReferenceCard offer={offers[4]} variant="ledger" compact />
-			<ReferenceCard offer={offers[8]} variant="ledger" compact inThePlan={false} />
+			<ReferenceCard offer={offers[6]} variant="ledger" compact inThePlan={false} />
 			<QuoteRow reference={plan.references[2]} section="§2" showUsage />
 			<QuoteRow reference={plan.references[3]} showUsage />
 		</div>

--- a/src/client/components/QuoteRow.tsx
+++ b/src/client/components/QuoteRow.tsx
@@ -22,6 +22,10 @@ export function QuoteRow({
 	dimmed = false,
 	className,
 }: QuoteRowProps) {
+	// Empty where the heading already said the whole record — a Quote carrying
+	// no source, or a Link with nothing but a url.
+	const cite = citation(reference)
+
 	return (
 		<div className={cx('flex items-start gap-2.5', dimmed && 'opacity-50', className)}>
 			<Chip variant={section ? 'default' : 'muted'} className="mt-px">
@@ -36,14 +40,17 @@ export function QuoteRow({
 				<p className="text-[0.8125rem] leading-relaxed text-ink">
 					{referenceName(reference)}
 				</p>
-				<footer className="mt-1 flex items-center gap-2 text-[0.6875rem] text-faint">
-					<cite className="not-italic">{citation(reference)}</cite>
-					{showUsage ? (
-						<span className={used ? 'text-accent-ink' : undefined}>
-							· {used ? 'used' : 'ready'}
-						</span>
-					) : null}
-				</footer>
+				{cite === '' && !showUsage ? null : (
+					<footer className="mt-1 flex items-center gap-2 text-[0.6875rem] text-faint">
+						{cite === '' ? null : <cite className="not-italic">{cite}</cite>}
+						{showUsage ? (
+							<span className={used ? 'text-accent-ink' : undefined}>
+								{cite === '' ? null : <span aria-hidden>· </span>}
+								{used ? 'used' : 'ready'}
+							</span>
+						) : null}
+					</footer>
+				)}
 			</blockquote>
 		</div>
 	)

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -95,11 +95,6 @@ export function ReferenceCard({
 					{variant === 'ledger' && offer.disposition === 'undecided' ? (
 						<span className="text-[0.6875rem] text-faint">undecided</span>
 					) : null}
-					{accepted && !inThePlan ? (
-						<span className="text-[0.6875rem] text-faint">
-							Accepted, and not in the Plan
-						</span>
-					) : null}
 				</div>
 			</div>
 

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -57,7 +57,13 @@ export function ReferenceCard({
 			)}
 		>
 			{variant === 'ledger' && !declined ? (
-				<Check checked={accepted} label={`Accept ${heading}`} onChange={onAccept} />
+				// No handler once Accepted, which disables the tick: restoring undoes a
+				// Decline and nothing undoes an Accept, so there is no state to go back to.
+				<Check
+					checked={accepted}
+					label={`Accept ${heading}`}
+					onChange={accepted ? undefined : onAccept}
+				/>
 			) : null}
 			{variant === 'ledger' && declined ? (
 				<span className="label-meta mt-0.5 shrink-0">declined</span>

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -39,6 +39,7 @@ export function ReferenceCard({
 }: ReferenceCardProps) {
 	const declined = offer.disposition === 'declined'
 	const accepted = offer.disposition === 'accepted'
+	const ruled = accepted || declined
 	const heading = referenceName(offer)
 	// A Quote with no source is its own heading; do not print it twice.
 	const passage = offer.text !== undefined && offer.text !== heading
@@ -93,7 +94,7 @@ export function ReferenceCard({
 				</div>
 			</div>
 
-			{variant === 'offer' ? (
+			{variant === 'offer' && !ruled ? (
 				<div className="flex shrink-0 flex-col gap-1.5">
 					<Button size="sm" onClick={onAccept}>
 						Accept
@@ -102,6 +103,12 @@ export function ReferenceCard({
 						Decline
 					</Button>
 				</div>
+			) : null}
+			{/* A card in the Chat reports a ruling rather than offering it again.
+			    Declining one already Accepted would leave its copy in the Plan, and
+			    the Ledger is where a ruling is changed. */}
+			{variant === 'offer' && ruled ? (
+				<span className="label-meta mt-0.5 shrink-0">{offer.disposition}</span>
 			) : null}
 			{variant === 'ledger' && declined ? (
 				<Button size="sm" variant="link" className="self-start" onClick={onRestore}>

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -9,14 +9,11 @@ export interface ReferenceCardProps {
 	offer: Offer
 	variant?: 'offer' | 'ledger'
 	compact?: boolean
-	/** False is stranded, and the card offers the re-add. */
-	inThePlan?: boolean
 	/** Waits on the House, at 1b. */
 	favourite?: 'author' | 'publication'
 	onAccept?: () => void
 	onDecline?: () => void
 	onRestore?: () => void
-	onAddToPlan?: () => void
 	className?: string
 }
 
@@ -34,12 +31,10 @@ export function ReferenceCard({
 	offer,
 	variant = 'offer',
 	compact = false,
-	inThePlan = true,
 	favourite,
 	onAccept,
 	onDecline,
 	onRestore,
-	onAddToPlan,
 	className,
 }: ReferenceCardProps) {
 	const declined = offer.disposition === 'declined'
@@ -111,11 +106,6 @@ export function ReferenceCard({
 			{variant === 'ledger' && declined ? (
 				<Button size="sm" variant="link" className="self-start" onClick={onRestore}>
 					Restore
-				</Button>
-			) : null}
-			{variant === 'ledger' && accepted && !inThePlan ? (
-				<Button size="sm" variant="link" className="self-start" onClick={onAddToPlan}>
-					Add to the Plan
 				</Button>
 			) : null}
 		</article>

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -19,12 +19,10 @@ export type OfferLedgerHandle = {
 	accept: (offer: Offer) => void
 	decline: (offer: Offer) => void
 	restore: (offer: Offer) => void
-	/** The re-add for a stranded Offer — §5. */
-	addToPlan: (offer: Offer) => void
 }
 
 export function useOfferLedger(): OfferLedgerHandle {
-	const { offers: store, plan, edit } = useArticle()
+	const { offers: store, edit } = useArticle()
 	const [rows, setRows] = useState<Offer[] | null>(null)
 	const [failure, setFailure] = useState<string | null>(null)
 
@@ -58,20 +56,21 @@ export function useOfferLedger(): OfferLedgerHandle {
 	}
 
 	return {
-		ledger: offerLedger(plan, rows ?? []),
+		ledger: offerLedger(rows ?? []),
 		loading: rows === null,
 		failure,
 
-		// Two writes against two stores, decoupled — §5. The row goes first
-		// because it carries the Provenance the copy needs.
+		// Two writes against two stores, decoupled — §5. The Plan goes first and
+		// lands locally, because the copy is built from what the Offer says and
+		// needs nothing the ruling returns. A ruling that then fails leaves the
+		// copy in place and the row Undecided, which the writer clears by
+		// Accepting again: the second `acceptOffer` builds no op.
 		accept(offer) {
+			edit((held) => acceptOffer(held, offer))
 			run(
 				'This Offer was not Accepted.',
 				() => store.setOfferDisposition(offer.id, 'accepted'),
-				(ruled) => {
-					replace(ruled)
-					edit((held) => acceptOffer(held, ruled))
-				},
+				replace,
 			)
 		},
 
@@ -85,11 +84,6 @@ export function useOfferLedger(): OfferLedgerHandle {
 
 		restore(offer) {
 			run('This Offer was not restored.', () => store.restoreOffer(offer.id), replace)
-		},
-
-		addToPlan(offer) {
-			setFailure(null)
-			edit((held) => acceptOffer(held, offer))
 		},
 	}
 }

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -7,7 +7,8 @@ import { useArticle } from './article'
 
 /**
  * The Offer ledger, live. Rows are read once when the Panel opens, because
- * nothing tells a client a row changed; the Plan half is already reactive — §3.
+ * nothing tells a client a row changed — §3. It holds no Plan: Accepting writes
+ * one through `edit` and reads nothing back.
  */
 
 export type OfferLedgerHandle = {

--- a/src/client/mock/content.ts
+++ b/src/client/mock/content.ts
@@ -244,8 +244,8 @@ export const draftShort = [
 	'What replaced the cranes was not a decision. Nobody voted to stop building.',
 ]
 
-/** The Offers behind that Plan. `offer-sze` is the stranded case: Accepted, and
- * in the Plan nowhere. */
+/** The Offers behind that Plan. Every Accepted one has its copy over there,
+ * because Accepting writes the copy first and the ruling second. */
 export const offers: Offer[] = [
 	{
 		id: 'offer-throughput',
@@ -327,8 +327,8 @@ export const offers: Offer[] = [
 		id: 'offer-sze',
 		type: 'link',
 		source: { title: 'Interview — M. Sze, planning officer' },
-		disposition: 'accepted',
+		disposition: 'undecided',
 		createdAt: 7,
-		decidedAt: 15,
+		decidedAt: null,
 	},
 ]

--- a/src/client/plan/references.ts
+++ b/src/client/plan/references.ts
@@ -54,12 +54,6 @@ export function citation(content: ReferenceContent): string {
 		.join(' · ')
 }
 
-/** The ones no Section holds. In the Plan and ordinary — `ReferenceList` reads
- * the same state as "not placed" on its Section select. */
-export function unplacedReferences(plan: Plan): Reference[] {
-	return plan.references.filter((reference) => reference.nodeId === null)
-}
-
 /** Every Reference, numbered. */
 export function referenceEntries(plan: Plan): ReferenceEntry[] {
 	return plan.references.map((reference, index) => ({ reference, number: index + 1 }))

--- a/src/client/plan/references.ts
+++ b/src/client/plan/references.ts
@@ -43,9 +43,15 @@ export function sourceLine(source: Source | undefined): string {
 	return [...attribution(source), source?.url].filter(Boolean).join(' · ')
 }
 
-/** Falls back to the attribution rather than the text, which is the passage. */
+/** The line under `referenceName`, carrying what the heading did not say: the
+ * title under a passage, and the rest of the record under a title. A Link is
+ * headed by its own title, so naming it again would print it twice. */
 export function citation(content: ReferenceContent): string {
-	return content.source?.title ?? sourceLine(content.source)
+	const heading = referenceName(content)
+
+	return [content.source?.title, ...attribution(content.source), content.source?.url]
+		.filter((part) => part !== undefined && part !== heading)
+		.join(' · ')
 }
 
 /** Distinct from a stranded Offer, which is in the Plan nowhere at all — §5. */

--- a/src/client/plan/references.ts
+++ b/src/client/plan/references.ts
@@ -54,7 +54,8 @@ export function citation(content: ReferenceContent): string {
 		.join(' · ')
 }
 
-/** Distinct from a stranded Offer, which is in the Plan nowhere at all — §5. */
+/** The ones no Section holds. In the Plan and ordinary — `ReferenceList` reads
+ * the same state as "not placed" on its Section select. */
 export function unplacedReferences(plan: Plan): Reference[] {
 	return plan.references.filter((reference) => reference.nodeId === null)
 }

--- a/src/client/screens/article/BlankPlanScreen.tsx
+++ b/src/client/screens/article/BlankPlanScreen.tsx
@@ -15,7 +15,7 @@ export function BlankPlanScreen() {
 	return (
 		<Frame width={760}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="new" />
-			<FrameBody row className="min-h-[20rem]">
+			<FrameBody row className="h-[20rem]">
 				<Panel divider="right" className="gap-3">
 					<ChatMessage from="me">
 						I want to write about why permitting got so slow, using this city as the case.

--- a/src/client/screens/article/ChatAndDraftScreen.tsx
+++ b/src/client/screens/article/ChatAndDraftScreen.tsx
@@ -15,7 +15,7 @@ export function ChatAndDraftScreen() {
 	return (
 		<Frame width={760}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'draft']} status="§3" />
-			<FrameBody row className="min-h-[19rem]">
+			<FrameBody row className="h-[19rem]">
 				<Panel variant="sunk" divider="right" width="40%" className="gap-3">
 					<ChatMessage from="me">
 						Is there a number for what a stalled mid-rise costs per week?

--- a/src/client/screens/article/DraftOnlyScreen.tsx
+++ b/src/client/screens/article/DraftOnlyScreen.tsx
@@ -13,7 +13,7 @@ export function DraftOnlyScreen() {
 	return (
 		<Frame width={640}>
 			<ArticleBar title={ARTICLE_TITLE} open={['draft']} status="esc" divided={false} />
-			<FrameBody className="min-h-[19rem]">
+			<FrameBody className="h-[19rem]">
 				<DraftSurface paragraphs={draftParagraphs} caret />
 				<div className="flex justify-end px-5 pb-4">
 					<NoteDot count={3} />

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -5,37 +5,37 @@ import { ArticleBar } from '../../components/ArticleBar'
 import { Chip } from '../../components/Chip'
 import { EmptySlot } from '../../components/Field'
 import { Frame, FrameBody } from '../../components/Frame'
-import { MetaLabel } from '../../components/MetaLabel'
 import { Panel } from '../../components/Panel'
-import { QuoteRow } from '../../components/QuoteRow'
 import { ReferenceCard } from '../../components/ReferenceCard'
 import { useArticle } from '../../lib/article'
 import { useOfferLedger } from '../../lib/useOfferLedger'
 import { ARTICLE_TITLE } from '../../mock/content'
-import { outlineEntries, sectionLabel } from '../../plan/outline'
-import { referencesAt, unplacedReferences } from '../../plan/references'
+import { PlanPanel } from '../../plan/PlanPanel'
 
 type Filter = 'all' | Disposition
 
 const filters: Filter[] = ['all', 'undecided', 'accepted', 'declined']
 
 /**
- * 2(f) — The Offer ledger, as two equal halves: what has been offered, and the
- * Plan it goes into. It is the same list at every stage, which is why there is
- * no separate triage screen.
+ * 2(f) — The Offer ledger, open over the Chat.
  *
- * The left half says what the writer ruled and nothing else. Where a Reference
- * sits is the right half's to show, and it shows it Section by Section.
+ * The Ledger is a view on the Chat Panel and covers only that half: it is the
+ * record of what the Chat offered and what the writer ruled, and the `close ×`
+ * is on it because it is the half that opened. Accepting sends the Reference
+ * across.
+ *
+ * The Plan Panel beside it is the ordinary one, rendered here so the screen
+ * reads as the writer meets it. Nothing on this screen reaches into it — where
+ * a Reference sits, and which sit nowhere yet, are its own to show.
  */
 export function LedgerDrawerScreen() {
-	const { plan } = useArticle()
+	const { plan, edit } = useArticle()
 	const { ledger, loading, failure, accept, decline, restore, addToPlan } =
 		useOfferLedger()
 	const [filter, setFilter] = useState<Filter>('all')
 
 	const shown = filter === 'all' ? ledger.offers : ledger.byDisposition[filter]
 	const stranded = new Set(ledger.stranded.map((offer) => offer.id))
-	const unplaced = unplacedReferences(plan)
 
 	return (
 		<Frame width={820}>
@@ -91,56 +91,7 @@ export function LedgerDrawerScreen() {
 					</div>
 				</Panel>
 
-				<Panel variant="sunk" padded={false}>
-					<header className="flex items-center gap-2.5 border-b border-edge px-3.5 py-2.5">
-						<h3 className="text-[0.875rem] font-semibold text-ink">In the Plan</h3>
-						<span className="text-[0.75rem] text-faint">
-							{plan.references.length} References
-						</span>
-					</header>
-					<div className="flex flex-col gap-4 p-3.5">
-						{outlineEntries(plan.outline).map((entry) => {
-							const held = referencesAt(plan, entry.node.id)
-
-							return (
-								<div key={entry.node.id} className="flex flex-col gap-2">
-									<MetaLabel>
-										{sectionLabel(entry)} · {entry.node.title}
-									</MetaLabel>
-									{held.length === 0 ? (
-										<EmptySlot className="ml-2">
-											Place an Accepted Reference here
-										</EmptySlot>
-									) : (
-										<div className="flex flex-col gap-2.5 pl-2">
-											{held.map(({ reference }) => (
-												<QuoteRow
-													key={reference.id}
-													reference={reference}
-													section={sectionLabel(entry)}
-													showUsage
-												/>
-											))}
-										</div>
-									)}
-								</div>
-							)
-						})}
-
-						{/* In the Plan, and held by no Section — so the count above accounts
-						    for it. "Not placed" is the word the Panel's Section select uses. */}
-						{unplaced.length > 0 ? (
-							<div className="flex flex-col gap-2">
-								<MetaLabel count={unplaced.length}>Not placed</MetaLabel>
-								<div className="flex flex-col gap-2.5 pl-2">
-									{unplaced.map((reference) => (
-										<QuoteRow key={reference.id} reference={reference} showUsage />
-									))}
-								</div>
-							</div>
-						) : null}
-					</div>
-				</Panel>
+				<PlanPanel plan={plan} edit={edit} />
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -30,12 +30,10 @@ const filters: Filter[] = ['all', 'undecided', 'accepted', 'declined']
  */
 export function LedgerDrawerScreen() {
 	const { plan, edit } = useArticle()
-	const { ledger, loading, failure, accept, decline, restore, addToPlan } =
-		useOfferLedger()
+	const { ledger, loading, failure, accept, decline, restore } = useOfferLedger()
 	const [filter, setFilter] = useState<Filter>('all')
 
 	const shown = filter === 'all' ? ledger.offers : ledger.byDisposition[filter]
-	const stranded = new Set(ledger.stranded.map((offer) => offer.id))
 
 	return (
 		<Frame width={820}>
@@ -75,11 +73,9 @@ export function LedgerDrawerScreen() {
 								offer={offer}
 								variant="ledger"
 								compact
-								inThePlan={!stranded.has(offer.id)}
 								onAccept={() => accept(offer)}
 								onDecline={() => decline(offer)}
 								onRestore={() => restore(offer)}
-								onAddToPlan={() => addToPlan(offer)}
 							/>
 						))}
 						{!loading && shown.length === 0 ? (

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -38,9 +38,10 @@ export function LedgerDrawerScreen() {
 	return (
 		<Frame width={820}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="ledger" />
-			<FrameBody row className="min-h-[22rem]">
+			<FrameBody row className="h-[22rem]">
 				<Panel divider="right" padded={false}>
-					<header className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
+					{/* Sticky: the Panel scrolls under it, and `close ×` has to stay reachable. */}
+					<header className="sticky top-0 z-10 flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
 						<h3 className="text-[0.875rem] font-semibold text-ink">Offered</h3>
 						<span className="text-[0.75rem] text-faint">
 							{ledger.counts.all} · {ledger.counts.accepted} Accepted

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -13,7 +13,7 @@ import { useArticle } from '../../lib/article'
 import { useOfferLedger } from '../../lib/useOfferLedger'
 import { ARTICLE_TITLE } from '../../mock/content'
 import { outlineEntries, sectionLabel } from '../../plan/outline'
-import { referenceName, referencesAt, unplacedReferences } from '../../plan/references'
+import { referencesAt, unplacedReferences } from '../../plan/references'
 
 type Filter = 'all' | Disposition
 
@@ -23,6 +23,9 @@ const filters: Filter[] = ['all', 'undecided', 'accepted', 'declined']
  * 2(f) — The Offer ledger, as two equal halves: what has been offered, and the
  * Plan it goes into. It is the same list at every stage, which is why there is
  * no separate triage screen.
+ *
+ * The left half says what the writer ruled and nothing else. Where a Reference
+ * sits is the right half's to show, and it shows it Section by Section.
  */
 export function LedgerDrawerScreen() {
 	const { plan } = useArticle()
@@ -124,24 +127,16 @@ export function LedgerDrawerScreen() {
 							)
 						})}
 
+						{/* In the Plan, and held by no Section — so the count above accounts
+						    for it. "Not placed" is the word the Panel's Section select uses. */}
 						{unplaced.length > 0 ? (
-							<div className="flex flex-col gap-1.5">
-								<MetaLabel count={unplaced.length}>Accepted, no Section yet</MetaLabel>
-								<p className="text-[0.75rem] text-muted">
-									{unplaced.map(referenceName).join(' · ')}
-								</p>
-							</div>
-						) : null}
-
-						{/* Not the group above, which is placed nowhere yet — §5. */}
-						{ledger.stranded.length > 0 ? (
-							<div className="flex flex-col gap-1.5">
-								<MetaLabel count={ledger.stranded.length}>
-									Accepted, and not in the Plan
-								</MetaLabel>
-								<p className="text-[0.75rem] text-muted">
-									{ledger.stranded.map(referenceName).join(' · ')}
-								</p>
+							<div className="flex flex-col gap-2">
+								<MetaLabel count={unplaced.length}>Not placed</MetaLabel>
+								<div className="flex flex-col gap-2.5 pl-2">
+									{unplaced.map((reference) => (
+										<QuoteRow key={reference.id} reference={reference} showUsage />
+									))}
+								</div>
 							</div>
 						) : null}
 					</div>

--- a/src/client/screens/article/LedgerPopoverScreen.tsx
+++ b/src/client/screens/article/LedgerPopoverScreen.tsx
@@ -1,65 +1,25 @@
-import { Chip } from '../../components/Chip'
+import type { Disposition } from '../../../shared/offer'
 import { Frame, FrameBody } from '../../components/Frame'
 import { MetaLabel } from '../../components/MetaLabel'
-import { useArticle } from '../../lib/article'
 import { cx } from '../../lib/cx'
 import { useOfferLedger } from '../../lib/useOfferLedger'
-import { outlineEntries, sectionLabel } from '../../plan/outline'
-import { referenceName, referencesAt, unplacedReferences } from '../../plan/references'
-
-type Row = { key: string; text: string; section?: string }
-type Group = { label: string; rows: Row[]; variant?: 'ready' | 'plain' | 'declined' }
+import { referenceName } from '../../plan/references'
 
 /**
- * 2(g) — The Offer ledger opened from the composer. The groups *are* the
- * lifecycle and their order is fixed, so the Undecided pile visibly shrinks as
- * you work. Used waits on the Draft, at phase 2.
+ * 2(g) — The Offer ledger opened from the composer. The groups are the three
+ * rulings and their order is fixed, so the Undecided pile visibly shrinks as
+ * you work.
+ *
+ * It reads no Plan. Once the writer Accepts, where the Reference goes and which
+ * Section it lands at are the Plan Panel's to show.
  */
 export function LedgerPopoverScreen() {
-	const { plan } = useArticle()
 	const { ledger } = useOfferLedger()
 
-	const groups: Group[] = [
-		{
-			label: 'Ready in the Plan',
-			variant: 'ready',
-			rows: outlineEntries(plan.outline).flatMap((entry) =>
-				referencesAt(plan, entry.node.id).map(({ reference }) => ({
-					key: reference.id,
-					text: referenceName(reference),
-					section: sectionLabel(entry),
-				})),
-			),
-		},
-		{
-			label: 'Accepted, no Section yet',
-			rows: unplacedReferences(plan).map((reference) => ({
-				key: reference.id,
-				text: referenceName(reference),
-			})),
-		},
-		{
-			label: 'Accepted, and not in the Plan',
-			rows: ledger.stranded.map((offer) => ({
-				key: offer.id,
-				text: referenceName(offer),
-			})),
-		},
-		{
-			label: 'Offered, Undecided',
-			rows: ledger.byDisposition.undecided.map((offer) => ({
-				key: offer.id,
-				text: referenceName(offer),
-			})),
-		},
-		{
-			label: 'Declined',
-			variant: 'declined',
-			rows: ledger.byDisposition.declined.map((offer) => ({
-				key: offer.id,
-				text: referenceName(offer),
-			})),
-		},
+	const groups: { label: string; disposition: Disposition }[] = [
+		{ label: 'Accepted', disposition: 'accepted' },
+		{ label: 'Undecided', disposition: 'undecided' },
+		{ label: 'Declined', disposition: 'declined' },
 	]
 
 	return (
@@ -76,27 +36,22 @@ export function LedgerPopoverScreen() {
 			</div>
 			<FrameBody className="gap-4 p-3.5">
 				{groups
-					.filter((group) => group.rows.length > 0)
+					.filter((group) => ledger.counts[group.disposition] > 0)
 					.map((group) => (
 						<section
 							key={group.label}
 							className={cx(
 								'flex flex-col gap-1.5',
-								group.variant === 'declined' && 'opacity-50',
+								group.disposition === 'declined' && 'opacity-50',
 							)}
 						>
-							<MetaLabel count={group.rows.length}>{group.label}</MetaLabel>
-							{group.rows.map((row) => (
-								<div key={row.key} className="flex items-start gap-2">
-									{row.section ? (
-										<Chip variant={group.variant === 'ready' ? 'accent' : 'outline'}>
-											{row.section}
-										</Chip>
-									) : null}
-									<p className="min-w-0 flex-1 truncate text-[0.75rem] text-muted">
-										{row.text}
-									</p>
-								</div>
+							<MetaLabel count={ledger.counts[group.disposition]}>
+								{group.label}
+							</MetaLabel>
+							{ledger.byDisposition[group.disposition].map((offer) => (
+								<p key={offer.id} className="min-w-0 truncate text-[0.75rem] text-muted">
+									{referenceName(offer)}
+								</p>
 							))}
 						</section>
 					))}

--- a/src/client/screens/article/MarginNotesScreen.tsx
+++ b/src/client/screens/article/MarginNotesScreen.tsx
@@ -13,7 +13,7 @@ export function MarginNotesScreen() {
 	return (
 		<Frame width={720}>
 			<ArticleBar title={ARTICLE_TITLE} open={['draft', 'notes']} status="§3" />
-			<FrameBody className="min-h-[19rem] gap-5 px-5 py-5">
+			<FrameBody className="h-[19rem] gap-5 px-5 py-5">
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1">
 						<p className="text-[0.9375rem]">{draftParagraphs[0]}</p>

--- a/src/client/screens/article/MidChatScreen.tsx
+++ b/src/client/screens/article/MidChatScreen.tsx
@@ -15,7 +15,7 @@ export function MidChatScreen() {
 	return (
 		<Frame width={800}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
-			<FrameBody row className="min-h-[24rem]">
+			<FrameBody row className="h-[24rem]">
 				<Panel divider="right" className="gap-3">
 					<ChatMessage from="me">
 						The process, then — but I want one developer in it so it isn't all

--- a/src/client/screens/article/NotesRailScreen.tsx
+++ b/src/client/screens/article/NotesRailScreen.tsx
@@ -16,7 +16,7 @@ export function NotesRailScreen() {
 	return (
 		<Frame width={720}>
 			<ArticleBar title={ARTICLE_TITLE} open={['draft', 'notes']} status="§3 of 4" />
-			<FrameBody row className="min-h-[19rem]">
+			<FrameBody row className="h-[19rem]">
 				<DraftSurface paragraphs={draftParagraphs} measure="narrow" caret />
 
 				<aside className="flex w-[13rem] shrink-0 flex-col gap-3 border-l border-edge bg-sunk p-3.5">

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -44,7 +44,7 @@ function EditablePlan({ start }: { start: Plan }) {
 
 	return (
 		<Frame width={520}>
-			<FrameBody>
+			<FrameBody className="h-[26rem]">
 				<PlanPanel edit={edit} plan={plan} refusal={refusal} />
 			</FrameBody>
 		</Frame>

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -148,9 +148,9 @@ export const G_LedgerPopover: Story = {
 				<LedgerPopoverScreen />
 			</MockArticle>
 			<Annotation>
-				The groups are the lifecycle and their order is fixed, so the Undecided pile
-				visibly shrinks as you work. Used waits on the Draft, which arrives at phase 2, so
-				a placed Reference reads Ready.
+				The groups are the three rulings and their order is fixed, so the Undecided pile
+				visibly shrinks as you work. It reads no Plan: once an Offer is Accepted, where
+				the Reference sits is the Plan Panel's to show.
 			</Annotation>
 		</div>
 	),

--- a/src/client/screens/article/PlanAndDraftScreen.tsx
+++ b/src/client/screens/article/PlanAndDraftScreen.tsx
@@ -12,7 +12,7 @@ export function PlanAndDraftScreen() {
 	return (
 		<Frame width={720}>
 			<ArticleBar title={ARTICLE_TITLE} open={['plan', 'draft']} status="draft 1" />
-			<FrameBody row className="min-h-[19rem]">
+			<FrameBody row className="h-[19rem]">
 				<PlanRail
 					outline={plan.outline}
 					written={[300, 700, 520, 0]}

--- a/src/client/screens/article/ReadyToDraftScreen.tsx
+++ b/src/client/screens/article/ReadyToDraftScreen.tsx
@@ -15,7 +15,7 @@ export function ReadyToDraftScreen() {
 	return (
 		<Frame width={780}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
-			<FrameBody row className="min-h-[21rem]">
+			<FrameBody row className="h-[21rem]">
 				<Panel divider="right" className="gap-3">
 					<p className="text-center text-[0.6875rem] text-faint">
 						↑ earlier in this chat

--- a/src/client/screens/global/SettingsShell.tsx
+++ b/src/client/screens/global/SettingsShell.tsx
@@ -53,7 +53,7 @@ export function SettingsShell({
 					</Chip>
 				))}
 			/>
-			<FrameBody row className="min-h-[19rem]">
+			<FrameBody row className="h-[19rem]">
 				<nav
 					className="flex shrink-0 flex-col gap-1 border-r border-edge bg-sunk p-3"
 					style={{ width: listWidth }}

--- a/src/client/screens/review/NotesToChatScreen.tsx
+++ b/src/client/screens/review/NotesToChatScreen.tsx
@@ -18,7 +18,7 @@ export function NotesToChatScreen() {
 	return (
 		<Frame width={800}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="after review 2" />
-			<FrameBody row className="min-h-[21rem]">
+			<FrameBody row className="h-[21rem]">
 				<Panel divider="right" className="gap-3">
 					<ChatMessage from="me">
 						<MetaLabel className="mb-1.5">4 accepted notes, pasted in</MetaLabel>

--- a/src/client/screens/review/ReviewRailScreen.tsx
+++ b/src/client/screens/review/ReviewRailScreen.tsx
@@ -16,7 +16,7 @@ export function ReviewRailScreen() {
 	return (
 		<Frame width={660}>
 			<ArticleBar title={ARTICLE_TITLE} open={['draft', 'notes']} status="round 2" />
-			<FrameBody row className="min-h-[18rem]">
+			<FrameBody row className="h-[18rem]">
 				<DraftSurface paragraphs={draftParagraphs.slice(0, 3)} measure="narrow" dimmed />
 
 				<aside className="flex w-[14rem] shrink-0 flex-col gap-3.5 border-l border-edge bg-sunk p-3.5">

--- a/src/server/llm/prompt.ts
+++ b/src/server/llm/prompt.ts
@@ -34,7 +34,9 @@ const guideRules = [
 	'supplying a preference of your own.',
 	'',
 	'One Voice applies at a time and the nearest Scope wins outright, so switching a Voice replaces',
-	'it. Adjectives compose instead, accumulating from the Article down to the Section.',
+	'it. Adjectives compose instead, accumulating from the Article down to the Section. They arrive',
+	'widest first, so the nearest ones weigh most: where a Section and the Article pull against each',
+	"other, the Section's term is the one to write to.",
 ].join('\n')
 
 /**

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -2,8 +2,10 @@ import type { Disposition, Offer } from './offer'
 import type { Plan, Reference } from './plan'
 
 /**
- * The Offer ledger — docs/architecture.md §5. What is here needs both stores at
- * once, joined on Provenance; the Plan half alone is `client/plan/references.ts`.
+ * The Offer ledger — docs/architecture.md §5. The View reads Offers and nothing
+ * else, because the Ledger belongs to the Chat Panel and what the Plan did with
+ * a copy is the Plan Panel's. The two below are the copy Accepting sends across,
+ * which is the one thing that does travel between them.
  */
 
 export type OfferLedger = {
@@ -12,16 +14,16 @@ export type OfferLedger = {
 	byDisposition: Record<Disposition, Offer[]>
 	/** `all` included, so the filter chips read from one place. */
 	counts: Record<'all' | Disposition, number>
-	/** Accepted Offers that did not make it to the Plan's References. */
-	stranded: Offer[]
 }
 
-/** Found on Provenance, not on content: the writer edits their copy. */
+/** Found on Provenance, not on content: the writer edits their copy. It guards
+ * the send, so Accepting twice copies once. */
 export function referenceForOffer(plan: Plan, offerId: string): Reference | undefined {
 	return plan.references.find((reference) => reference.provenance.offerId === offerId)
 }
 
-/** Copied rather than moved — §3, rule 5. */
+/** Copied rather than moved — §3, rule 5. It reads what the Offer says and not
+ * what the writer ruled, so the copy can be built before the ruling is sent. */
 export function referenceFromOffer(offer: Offer, id: string): Reference {
 	// Absent rather than undefined — §4.
 	const reference: Reference = {
@@ -37,17 +39,15 @@ export function referenceFromOffer(offer: Offer, id: string): Reference {
 	return reference
 }
 
-/** Derived on read. Both halves arrive whole from their own store, so a third
- * copy would only need keeping in step. */
-export function offerLedger(plan: Plan, offers: readonly Offer[]): OfferLedger {
+/** Derived on read. The Offers arrive whole from their store, so a second copy
+ * would only need keeping in step. */
+export function offerLedger(offers: readonly Offer[]): OfferLedger {
 	const byDisposition: Record<Disposition, Offer[]> = {
 		undecided: [],
 		accepted: [],
 		declined: [],
 	}
 	for (const offer of offers) byDisposition[offer.disposition].push(offer)
-
-	const copied = new Set(plan.references.map((reference) => reference.provenance.offerId))
 
 	return {
 		offers,
@@ -58,6 +58,5 @@ export function offerLedger(plan: Plan, offers: readonly Offer[]): OfferLedger {
 			accepted: byDisposition.accepted.length,
 			declined: byDisposition.declined.length,
 		},
-		stranded: byDisposition.accepted.filter((offer) => !copied.has(offer.id)),
 	}
 }

--- a/test/client/offer-accept.test.ts
+++ b/test/client/offer-accept.test.ts
@@ -49,7 +49,7 @@ describe('Accepting an Offer into the Plan', () => {
 		expect(result.plan.references[0]).toMatchObject({ id: 'r1', nodeId: null })
 	})
 
-	// A double click, or the re-add of an Offer whose write had landed.
+	// A double click, or the retry of an Accept whose ruling did not land.
 	it('is not an edit at all once the Plan holds a copy', () => {
 		const result = applyProposal(plan, acceptOffer(plan, offer, 'r1'))
 		if (!result.ok) throw new Error(result.refusal.message)

--- a/test/client/reference-card.test.ts
+++ b/test/client/reference-card.test.ts
@@ -1,0 +1,72 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { ReferenceCard } from '../../src/client/components/ReferenceCard'
+import type { Disposition, Offer } from '../../src/shared/offer'
+
+/**
+ * What a card offers against what the writer has already ruled. A Chat card
+ * that offers Decline on an Accepted Offer would leave its copy in the Plan
+ * under a Declined row, which nothing then reconciles.
+ */
+
+function card(disposition: Disposition, variant: 'offer' | 'ledger' = 'offer') {
+	const offer: Offer = {
+		id: 'o1',
+		type: 'link',
+		source: { title: 'Permit throughput in six mid-sized cities' },
+		disposition,
+		createdAt: 0,
+		decidedAt: disposition === 'undecided' ? null : 1,
+	}
+
+	// Every handler supplied: `Check` disables itself when it is given none, and
+	// these tests are about what the disposition does rather than that.
+	return renderToStaticMarkup(
+		createElement(ReferenceCard, {
+			offer,
+			variant,
+			onAccept: () => {},
+			onDecline: () => {},
+			onRestore: () => {},
+		}),
+	)
+}
+
+describe('the rulings a Chat card offers', () => {
+	it('offers both while the Offer is Undecided', () => {
+		const html = card('undecided')
+
+		expect(html).toContain('Accept')
+		expect(html).toContain('Decline')
+	})
+
+	it('offers neither once the Offer is Accepted, and says so', () => {
+		const html = card('accepted')
+
+		expect(html).not.toContain('>Accept<')
+		expect(html).not.toContain('>Decline<')
+		expect(html).toContain('accepted')
+	})
+
+	it('offers neither once the Offer is Declined', () => {
+		const html = card('declined')
+
+		expect(html).not.toContain('>Accept<')
+		expect(html).not.toContain('>Decline<')
+		expect(html).toContain('declined')
+	})
+})
+
+describe('the tick a Ledger card carries', () => {
+	// Nothing undoes an Accept — `restoreOffer` undoes a Decline — so the tick
+	// does not offer a state to go back to.
+	it('is disabled once Accepted', () => {
+		expect(card('accepted', 'ledger')).toContain('disabled')
+	})
+
+	it('is live while Undecided', () => {
+		expect(card('undecided', 'ledger')).not.toContain('disabled')
+	})
+})

--- a/test/client/reference-display.test.ts
+++ b/test/client/reference-display.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { citation, referenceName } from '../../src/client/plan/references'
+import type { ReferenceContent } from '../../src/shared/plan'
+
+/**
+ * What a Reference is headed by, against what is printed under it. A row shows
+ * the two together, so neither may say what the other already said.
+ */
+
+describe('naming one piece of Reference material', () => {
+	it('heads a Link with its title, and cites the rest of the record', () => {
+		const link: ReferenceContent = {
+			type: 'link',
+			source: {
+				title: 'Permit throughput in six mid-sized cities',
+				author: 'R. Okonkwo',
+				publication: 'the Quarterly',
+				year: 2023,
+			},
+		}
+
+		expect(referenceName(link)).toBe('Permit throughput in six mid-sized cities')
+		expect(citation(link)).toBe('R. Okonkwo · the Quarterly · 2023')
+	})
+
+	it('heads a Quote with its passage, and cites the source', () => {
+		const quote: ReferenceContent = {
+			type: 'quote',
+			text: 'Forty separate times.',
+			source: {
+				title: 'Permit throughput in six mid-sized cities',
+				author: 'R. Okonkwo',
+			},
+		}
+
+		expect(referenceName(quote)).toBe('“Forty separate times.”')
+		expect(citation(quote)).toBe('Permit throughput in six mid-sized cities · R. Okonkwo')
+	})
+
+	// The row drops the line rather than printing the heading a second time.
+	it('cites nothing where the heading is the whole record', () => {
+		expect(citation({ type: 'link', source: { url: 'https://example.test/a' } })).toBe('')
+		expect(citation({ type: 'quote', text: 'Forty separate times.' })).toBe('')
+	})
+})

--- a/test/client/stories.test.ts
+++ b/test/client/stories.test.ts
@@ -1,0 +1,54 @@
+import { createElement, type ReactElement } from 'react'
+import { renderToString } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every story renders without throwing.
+ *
+ * Storybook is where a component is looked at, and nothing else in CI mounts
+ * one: a prop that arrives undefined typechecks, because `noUncheckedIndexedAccess`
+ * is off and `offers[8]` is an `Offer` as far as the compiler is concerned. It
+ * then throws on the screen, where only a person looking at Storybook finds it.
+ *
+ * This renders to a string rather than to a DOM, so it needs no environment and
+ * no browser. Effects do not run, so what it catches is a render that throws
+ * rather than a screen that behaves — which is the class of thing that got
+ * through.
+ */
+
+// The titles are the file paths and the story names, which is the point: a
+// failure names the story to open rather than the index it came from.
+/* eslint-disable vitest/valid-title */
+
+type Story = { render?: () => ReactElement }
+
+const modules = import.meta.glob<Record<string, unknown>>(
+	'../../src/client/**/*.stories.tsx',
+	{ eager: true },
+)
+
+const files = Object.entries(modules).sort(([a], [b]) => a.localeCompare(b))
+
+it('finds the stories', () => {
+	expect(files.length).toBeGreaterThan(0)
+})
+
+for (const [path, module] of files) {
+	// The default export is the meta, and every other export is a story.
+	const stories = Object.entries(module).filter(([name]) => name !== 'default')
+
+	describe(path.replace('../../', ''), () => {
+		for (const [name, story] of stories) {
+			it(name, () => {
+				const { render } = story as Story
+				// A story with no render is one this cannot check, rather than one
+				// that passes.
+				expect(render).toBeTypeOf('function')
+
+				// Mounted rather than called: Storybook treats `render` as a component,
+				// and a story holding `useState` throws when it is called as a function.
+				renderToString(createElement(render!))
+			})
+		}
+	})
+}

--- a/test/shared/ledger.test.ts
+++ b/test/shared/ledger.test.ts
@@ -130,36 +130,24 @@ describe('reading the Offer ledger', () => {
 	})
 
 	it('counts each disposition, and the whole list', () => {
-		const ledger = offerLedger(held, offers)
+		const ledger = offerLedger(offers)
 
 		expect(ledger.counts).toEqual({ all: 5, undecided: 1, accepted: 2, declined: 2 })
 		expect(ledger.byDisposition.declined.map((offer) => offer.id)).toEqual(['o4', 'o5'])
 	})
 
-	// It was not offered, so no Offer group holds it.
-	it('leaves a Reference the writer wrote out of the Offer counts', () => {
-		expect(offerLedger(held, offers).counts.all).toBe(5)
+	// The Ledger belongs to the Chat Panel, so what the Plan holds — `r3`, which
+	// the writer typed, and `r2`, which sits at no Section — never reaches it.
+	it('reads the Offers alone, whatever the Plan holds', () => {
+		expect(held.references).toHaveLength(3)
+		expect(offerLedger(offers).counts.all).toBe(5)
 	})
 
-	it('strands an Accepted Offer that no Reference points back at', () => {
-		const ledger = offerLedger(held, [
-			...offers,
-			makeOffer({ id: 'o6', disposition: 'accepted' }),
-		])
-
-		expect(ledger.stranded.map((offer) => offer.id)).toEqual(['o6'])
-	})
-
-	// `r2` above is unplaced, which is not stranded — §5.
-	it('does not strand an Accepted Offer whose Reference carries no Section', () => {
-		expect(offerLedger(held, offers).stranded).toEqual([])
-	})
-
-	it('reads an empty Article as an empty Ledger', () => {
-		const ledger = offerLedger(makePlan(), [])
+	it('reads an Article with no Offers as an empty Ledger', () => {
+		const ledger = offerLedger([])
 
 		expect(ledger.counts).toEqual({ all: 0, undecided: 0, accepted: 0, declined: 0 })
-		expect(ledger.stranded).toEqual([])
+		expect(ledger.offers).toEqual([])
 	})
 })
 

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -2,7 +2,7 @@ import { env, evictDurableObject, runInDurableObject } from 'cloudflare:test'
 import { describe, expect, it } from 'vitest'
 
 import type { RecordedOffer } from '../../src/server/article-agent'
-import { offerLedger, referenceFromOffer } from '../../src/shared/ledger'
+import { referenceForOffer, referenceFromOffer } from '../../src/shared/ledger'
 import type { Offer } from '../../src/shared/offer'
 import type { Plan, ReferenceContent } from '../../src/shared/plan'
 import { emptyPlan, isPlanRefused } from '../../src/shared/plan'
@@ -310,8 +310,9 @@ describe('Accepting an Offer into the Plan', () => {
 		writer.setState(opening)
 		const [{ offer }] = await recordOffers('accept-and-edit', [quote])
 
+		// The copy first, built from what the Offer says; then the ruling.
+		writer.setState(copiedInto(opening, offer))
 		const ruled = await writer.call<Offer>('setOfferDisposition', offer.id, 'accepted')
-		writer.setState(copiedInto(opening, ruled))
 
 		const accepted = await readPlan('accept-and-edit')
 		expect(accepted.references).toEqual([
@@ -354,24 +355,27 @@ describe('Accepting an Offer into the Plan', () => {
 		await expect(readPlan('decline-and-restore')).resolves.toEqual(opening)
 	})
 
-	// If the second write does not land, the row is Accepted and the Plan holds
-	// nothing. The Provenance pointer is what finds it.
-	it('leaves an Accepted Offer stranded when the Plan write does not land', async () => {
-		const writer = await openAgentSocket('accept-stranded')
+	// The copy goes first, so the write left to fail is the ruling. What that
+	// leaves is a copy in the Plan and a row still Undecided — the writer sees an
+	// unticked row and Accepts again, and nothing is stranded anywhere.
+	it('keeps the copy when the ruling does not land, and copies once on the retry', async () => {
+		const writer = await openAgentSocket('accept-no-ruling')
 		await writer.next('cf_agent_state')
 		writer.setState(opening)
-		const [{ offer }] = await recordOffers('accept-stranded', [reference])
+		const [{ offer }] = await recordOffers('accept-no-ruling', [reference])
 
+		writer.setState(copiedInto(opening, offer))
+		// The tab closes here, and the ruling is never sent.
+
+		const held = await readPlan('accept-no-ruling')
+		expect(held.references.map((copy) => copy.provenance.offerId)).toEqual([offer.id])
+		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual([offer])
+
+		// Accepting again sends the ruling. `acceptOffer` finds the copy on the
+		// Provenance and builds no op, so the Plan is not written a second time.
 		const ruled = await writer.call<Offer>('setOfferDisposition', offer.id, 'accepted')
-		// The tab closes here, and the second write does not happen.
-
-		const ledger = offerLedger(await readPlan('accept-stranded'), [ruled])
-		expect(ledger.stranded).toEqual([ruled])
-
-		// The re-add is the same second write, and it is the only one missing.
-		writer.setState(copiedInto(opening, ruled))
-		const replaced = await readPlan('accept-stranded')
-		expect(offerLedger(replaced, [ruled]).stranded).toEqual([])
-		expect(replaced.references.map((held) => held.provenance.offerId)).toEqual([offer.id])
+		expect(ruled.disposition).toBe('accepted')
+		expect(referenceForOffer(held, offer.id)?.id).toBe('r1')
+		await expect(readPlan('accept-no-ruling')).resolves.toEqual(held)
 	})
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,8 +9,9 @@ import { defineConfig } from 'vitest/config'
 // the time a worker test takes.
 //
 // The client project holds the Plan Panel's arithmetic — its op builders and
-// its debounced writer — which is pure TypeScript. Nothing here renders a
-// component, so there is no DOM environment to configure.
+// its debounced writer — plus the story smoke test, which renders every story
+// to a string. `renderToString` needs no DOM, so there is still no environment
+// to configure here.
 export default defineConfig({
 	test: {
 		projects: [


### PR DESCRIPTION
Follow-up on the review of #44, which merged the Offer ledger through a sequence of
simplify, merge, reconcile, and simplify again. The reconciling commits did what they said —
each claim in them checks out against the tree. What they left behind was a Ledger that knew
about the Plan, and bugs in what the screens draw.

## The Offer ledger stops reading the Plan

The largest change, and the one worth reviewing first.

The Ledger is a View over the Chat Panel's Offers. It covers that Panel, it closes again, and
it opens nothing — so it shows the ruling and nothing about where a copy ended up.

- **`offerLedger(offers)`**, where it took `(plan, offers)`. The only field needing the Plan
  was `stranded`, which is gone. `useOfferLedger` no longer takes a Plan at all.
- **Accepting writes the copy first**, then the ruling. `referenceFromOffer` reads what the
  Offer says rather than what the writer ruled, so the copy never needed the RPC's answer
  and the order was free. A half-done Accept now leaves the copy in the Plan and the row
  reading Undecided — an unticked row the writer ticks again, where `acceptOffer` follows the
  Provenance, finds the copy, and builds no op. The failure clears itself rather than
  persisting as a state to notice. The double-Accept race goes with it: the op is built
  against the Plan the writer holds, so a second click sees the copy and returns null.
- **The Ledger Drawer renders the real `PlanPanel`** where it had built its own reading of
  the Plan — Sections walked, References grouped, a "Not placed" group of its own. The Plan
  Panel in that story is open because its `ArticleBar` carries `open={['chat', 'plan']}`,
  not because the Ledger put it there; with `open={['chat']}` the Ledger is the full width.
  `unplacedReferences` goes too — the Panel's References list already carries every one with
  its Section on a select.
- **The Popover reads no Plan.** Five groups over two stores became three over one.

Gone with `stranded`: `addToPlan`, `inThePlan`, and the "Add to the Plan" button. Every one
of them existed to service a state the write ordering created.

## Four display bugs

All in what a component draws rather than what it computes, which is why four review passes
over the diff missed them.

- **`Primitives.stories.tsx` read `offers[8]` against an array of seven.** The merge rewrote
  the mock Offers and the index went stale. `noUncheckedIndexedAccess` is off, so it
  typechecks as an `Offer` and throws on the screen.
- **`QuoteRow` printed a Link's title twice.** `referenceName` heads a Link with its title
  and `citation` returned that same title, and the row shows both. `citation` now carries
  what the heading did not say, and the row drops the line where that is nothing.
- **The Accept tick claimed a state the writer cannot leave.** `Check` is a `role="checkbox"`
  calling `onChange(!checked)`, and the card dropped the argument — so clicking an Accepted
  row re-stamped `decided_at`, built no op, and changed nothing on screen. Nothing undoes an
  Accept, so the tick is disabled once Accepted.
- **A Chat card offered a ruling already made.** The `offer` variant drew Accept and Decline
  whatever the row said, so Declining an Offer Accepted from the Ledger left its copy in the
  Plan under a Declined row. A ruled card reports the ruling instead; changing one stays with
  the Ledger, where Restore already lives. Found in review of this PR.

## Each Panel scrolls its own Y

Reading down the Plan moved the Chat beside it. The Panel is now the scroll container, and
the Frame body carries a height for it to scroll within.

The height alone did nothing: `flex-1` is `flex: 1 1 0%`, and a basis of `0` overrides it —
the body measured 1182px against the 352 it asked for. `FrameBody` takes `flex-auto`, so the
height it is given is the basis. The Drawer's Panel header is `sticky`, since the Panel now
scrolls under it and `close ×` has to stay reachable.

Measured in a browser across all 35 stories: no frame collapsed, and scrolling one Panel
leaves its neighbour at 0.

## What CI gained, and what it still cannot see

`test/client/stories.test.ts` renders every story through `renderToString` — no DOM, no new
dependency, in the existing `client` project. It catches the `offers[8]` read with the error
a person would have met in Storybook.

It computes no layout and runs no effects, so it could not have caught the scroll bug, the
title printed twice, or the Chat card. `test/client/reference-card.test.ts` covers that last
one directly, by asserting what each variant offers against what the writer has ruled.

The wider gap is #46, which also records that `renderToString` runs no effects — so every
story reaching `useOfferLedger` mounts in its loading state and no other, and the corpus is
smaller than "every story" suggests.

223 tests, up from 181. Lint, format, and typecheck pass.

## Docs

`architecture.md` §5 argues the write ordering rather than stating it, including why the
other way round needed a group and a re-add. §8 records that each Panel scrolls its own Y.
§4's Scope bullet says what the Adjective order buys — `resolveScope` moves a restated term
to the end, and only the model can act on that, so `prompt.ts` now says it too. §4's
one-spelling paragraph separates the rule from what the schema enforces today.

`context.md` loses the **Stranded** entry, which named a state the client can no longer
produce. `docs/later.md` gains soft word-count distribution, which is a UX idea rather than
an architectural rule.

One commit here is @mhsnook's own pass over `architecture.md`.

Related to #28. The Ledger-covers-the-Chat-Panel behaviour lands with #26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pUSKRvqVHEEVowR9YU6vo