### PR TITLE
Say in the showcase that QuoteRow is unused

### DIFF
--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -5,6 +5,7 @@ import { offers, plan, sectionState } from '../mock/content'
 import { Button } from './Button'
 import { Check } from './Check'
 import { Chip } from './Chip'
+import { Divider } from './Divider'
 import { ExampleBlock, PolarityHeading } from './ExampleBlock'
 import { EmptySlot, Field } from './Field'
 import { GuidanceNote, NoteDot } from './GuidanceNote'
@@ -120,6 +121,12 @@ export const Research: Story = {
 			<ReferenceCard offer={offers[2]} variant="ledger" />
 			<ReferenceCard offer={offers[4]} variant="ledger" compact />
 			<ReferenceCard offer={offers[6]} variant="ledger" compact />
+			<Divider />
+			<p className="max-w-[28rem] text-[0.75rem] leading-relaxed text-muted">
+				<strong>The QuoteRow component (2 examples below) is unused.</strong> It was added
+				to show a read-only summary of the Plan Panel, which we stopped using, but may go
+				back to in Phase 2.
+			</p>
 			<QuoteRow reference={plan.references[2]} section="§2" showUsage />
 			<QuoteRow reference={plan.references[3]} showUsage />
 		</div>

--- a/src/client/components/QuoteRow.tsx
+++ b/src/client/components/QuoteRow.tsx
@@ -14,6 +14,13 @@ export interface QuoteRowProps {
 	className?: string
 }
 
+/**
+ * One placed Reference, with what it is doing in the Draft.
+ *
+ * **Unused** — the Primitives story is the only caller. It was added for a
+ * read-only summary of the Plan Panel, which we stopped using and may go back
+ * to at phase 2, where `used` against `ready` becomes a real distinction.
+ */
 export function QuoteRow({
 	reference,
 	section,


### PR DESCRIPTION
`QuoteRow` went unused in #45, when the Ledger Drawer's Plan half became the real
`PlanPanel`. The Primitives story is its only caller now, and nothing said so.

Two lines of prose, no behaviour change:

- A `Divider` and a plain paragraph in the Primitives **Research** story, sitting **above**
  the two examples. The story names none of the components it renders, so a note underneath
  them would read as being about whatever sits above it.
- A doc comment on the component, for whoever opens the file rather than the story.

It stays in the repo — it was added for a read-only summary of the Plan Panel, which may
come back at phase 2, where `used` against `ready` becomes a real distinction.

Two other exports have no screen rendering them, and neither wants this treatment:
`Annotation` is the showcase's own tool, and `ArticlePlanPanel` has no story to mark — its
file comment already records that #29 mounts it.

223 tests, lint, format, and typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011pUSKRvqVHEEVowR9YU6vo