### PR TITLE
1a-06 The Chat Panel, and a refusal's two readers

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,6 +238,21 @@ server is what consumes it.
 
 **The Chat proposes; the client applies.** The Chat never writes to the Plan.
 
+**The Chat Panel is `src/client/chat/`.** `useArticleChat` is the wiring — the transcript,
+the composer, and the two rulings — and `ChatPanel` is the surface, taking a transcript and
+the rulings the way `PlanPanel` takes a Plan and one `edit`. The rule itself is
+`ruleProposal`, a pure function the app and the showcase both run, so a story cannot rule
+differently from the product.
+
+**Accepting is `edit(ops)`, the same call every Plan edit makes.** The Proposal's ops go
+through `createPlanWriter` rather than a `setState` of their own: the writer holds the Plan
+the writer sees, debounces, and drops an incoming update over an unsent write, and a second
+writer around it would undo what is on screen (§3, rule 1).
+
+**A refused Accept answers nothing and leaves the card open.** The card shows the applier's
+sentence, the writer may fix the Plan and Accept again, and Declining sends that sentence
+back — so the model learns the Plan moved rather than that the writer said no.
+
 **Proposals are `execute`-less tools** (AI SDK v7). A tool with no `execute` suspends for the
 client, which is the Proposal. Four API details, each easy to get wrong:
 
@@ -398,6 +413,11 @@ so a Panel header that should stay put is `sticky` inside its own Panel. The `st
 Vitest project holds every story to that in a real browser, so a class chain that reads as
 though it works has to measure as though it does — see `.storybook/vitest.setup.ts`.
 
+A sticky footer wants one thing more: the Panel's bottom padding is inside the scrollport,
+so the Panel gives it up — `pb-0` — and the footer takes that padding itself. The Chat
+composer is the one that does. Without it a card scrolls into the padding and shows below
+the composer.
+
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
 `expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to
@@ -415,6 +435,13 @@ is nothing else it can be.
 **The Article Agent's WebSocket is multiplexed.** It carries `cf_agent_*` control frames for
 state, RPC, and scheduling on one socket. In phase 1 this is free, because the SDK's own
 client handles them. It becomes work if a party-db transport ever shares that socket.
+
+**One connection per Article, opened above the Panels.** `useArticleAgent` makes the single
+`useAgent` call and hands out three things: the Plan channel, the Offer store built on the
+same socket's RPC, and the client itself, which is what `useAgentChat` takes. The Panels read
+it through `ArticleProvider` rather than connecting themselves. A Panel opening its own would
+be a second socket, a second `createPlanWriter`, and a second debounce timer against a blob
+whose whole design is that it has one writer.
 
 ## 9. Auth
 
@@ -494,7 +521,8 @@ Settings and known defects. None is a decision to make; all are things to get ri
   callable" — a silent failure where the missing plugin is a loud one.
 - **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
   completeness server-side with **no orphan timeout**, so a Proposal the writer neither
-  Accepts nor Declines stalls the Chat silently. Surface it in the UI.
+  Accepts nor Declines stalls the Chat silently. The composer counts the suspended calls and
+  says what it is waiting on rather than sitting dead; nothing expires them.
 - **Local development** is unsolved: running the Worker with seeded data so a coding agent
   executing a build ticket can run what it writes.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -312,6 +312,20 @@ where they cannot drift away from the union. It also parses the Plan it produces
 Proposal the Article Agent would reject is refused here, where there is a reason to show,
 rather than there, where there is none.
 
+**A refusal has two readers, and the applier writes for one of them.** `refusal.message` is
+the model's: a Declined Proposal sends it back, so it names the op and the ids and may run
+long. The writer's sentence is built at the edge from `refusal.reason` — a closed code
+naming exactly what went wrong — plus the records it is about, in
+`src/client/plan/refusalText.ts`. The Panel that shows it holds the Plan, so it can name a
+Section the way the Outline numbers it, where the applier only has an id.
+
+Two things follow. **One English string lives in `src/shared`**, aimed at a reader with no
+eyes, and it never needs translating — the model is taught in English by `llm/tools.ts`
+already. And the writer's half is a table over a closed union, so a second language is a
+second table rather than a sweep through the applier. `refusalText.ts` is total over
+`RefusalReason`, so a new refusal site stops it compiling until it says what the new one
+reads as.
+
 **The op payloads are strict, and a rejected tool call retries with the validation error.**
 The piece schemas the payloads reuse are `strictObject`, so a model that adds one field fails
 the whole tool call rather than having the field stripped. Stripping would produce a Proposal

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -427,10 +427,11 @@ so a Panel header that should stay put is `sticky` inside its own Panel. The `st
 Vitest project holds every story to that in a real browser, so a class chain that reads as
 though it works has to measure as though it does — see `.storybook/vitest.setup.ts`.
 
-A sticky footer wants one thing more: the Panel's bottom padding is inside the scrollport,
-so the Panel gives it up — `pb-0` — and the footer takes that padding itself. The Chat
-composer is the one that does. Without it a card scrolls into the padding and shows below
-the composer.
+A control that must stay reachable while the Panel scrolls goes in `Panel`'s `footer` slot,
+which owns what a sticky element needs: the Panel's own bottom padding is inside the
+scrollport, so the slot takes that padding and the body gives it up. The Chat composer is the
+one that uses it. Passing such a control as an ordinary child leaves it to scroll away, and
+splitting the padding across the caller would let one hold half the contract.
 
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -427,18 +427,6 @@ so a Panel header that should stay put is `sticky` inside its own Panel. The `st
 Vitest project holds every story to that in a real browser, so a class chain that reads as
 though it works has to measure as though it does — see `.storybook/vitest.setup.ts`.
 
-**Chrome on a Panel edge is one shape**, and `Panel` has no slot for it: the Panel is
-unpadded, a `flex-1 p-3.5` body owns the reading area, and a full-bleed bar owns its own
-padding — `sticky` where it has to stay put. `LedgerDrawerScreen`'s header and the Chat
-composer are the two that stay put; `ReadyToDraftScreen`'s footer is the same shape without
-the sticking.
-
-An earlier version of this put the composer in the Panel's own padding and gave `Panel` a
-`footer` slot to hand that padding over. It worked, and it was a fourth way to do a thing the
-app already did three times — and an inset one, where every existing bar is full-bleed. The
-handoff it formalised was a problem it had created: when the body and the bar each own their
-padding, there is nothing to hand over.
-
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
 `expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -427,11 +427,17 @@ so a Panel header that should stay put is `sticky` inside its own Panel. The `st
 Vitest project holds every story to that in a real browser, so a class chain that reads as
 though it works has to measure as though it does — see `.storybook/vitest.setup.ts`.
 
-A control that must stay reachable while the Panel scrolls goes in `Panel`'s `footer` slot,
-which owns what a sticky element needs: the Panel's own bottom padding is inside the
-scrollport, so the slot takes that padding and the body gives it up. The Chat composer is the
-one that uses it. Passing such a control as an ordinary child leaves it to scroll away, and
-splitting the padding across the caller would let one hold half the contract.
+**Chrome on a Panel edge is one shape**, and `Panel` has no slot for it: the Panel is
+unpadded, a `flex-1 p-3.5` body owns the reading area, and a full-bleed bar owns its own
+padding — `sticky` where it has to stay put. `LedgerDrawerScreen`'s header and the Chat
+composer are the two that stay put; `ReadyToDraftScreen`'s footer is the same shape without
+the sticking.
+
+An earlier version of this put the composer in the Panel's own padding and gave `Panel` a
+`footer` slot to hand that padding over. It worked, and it was a fourth way to do a thing the
+app already did three times — and an inset one, where every existing bar is full-bleed. The
+handoff it formalised was a problem it had created: when the body and the bar each own their
+padding, there is nothing to hand over.
 
 **The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
 in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -5,11 +5,8 @@ import type { ArticleSocket } from '../lib/useArticleAgent'
 import { ChatPanel } from './ChatPanel'
 import { useArticleChat } from './useArticleChat'
 
-/**
- * The Chat Panel, wired to one Article Agent. It takes the socket rather than
- * opening one: the wire is multiplexed and the Plan already holds it — §8.
- * Laying it out beside the other three Panels is issue #29.
- */
+/** Drives `ChatPanel` from one Article Agent. Takes the socket rather than
+ * opening one — §8. */
 
 export interface ArticleChatPanelProps {
 	agent: ArticleSocket
@@ -29,9 +26,8 @@ export function ArticleChatPanel({
 	const chat = useArticleChat(agent)
 	const { ledger } = chat
 
-	// A Proposal is described against the Plan on screen, so the Panel waits for
-	// the first state update the way the Plan Panel does. It settles in well
-	// under a second, and #29 hoists this gate above every Panel.
+	// A Proposal card names Sections out of the Plan, so there is nothing to draw
+	// until one arrives.
 	if (plan === null) {
 		return (
 			<div className={className}>

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react'
+
+import { useArticle } from '../lib/article'
+import type { ArticleSocket } from '../lib/useArticleAgent'
+import { ChatPanel } from './ChatPanel'
+import { useArticleChat } from './useArticleChat'
+
+/**
+ * The Chat Panel, wired to one Article Agent. It takes the socket rather than
+ * opening one: the wire is multiplexed and the Plan already holds it — §8.
+ * Laying it out beside the other three Panels is issue #29.
+ */
+
+export interface ArticleChatPanelProps {
+	agent: ArticleSocket
+	placeholder?: string
+	/** Left of send — the Offer ledger toggle. */
+	leading?: ReactNode
+	className?: string
+}
+
+export function ArticleChatPanel({
+	agent,
+	placeholder,
+	leading,
+	className,
+}: ArticleChatPanelProps) {
+	const { plan } = useArticle().plan
+	const chat = useArticleChat(agent)
+	const { ledger } = chat
+
+	// A Proposal is described against the Plan on screen, so the Panel waits for
+	// the first state update the way the Plan Panel does. It settles in well
+	// under a second, and #29 hoists this gate above every Panel.
+	if (plan === null) {
+		return (
+			<div className={className}>
+				<p className="p-3.5 text-[0.75rem] text-faint">Opening the Chat…</p>
+			</div>
+		)
+	}
+
+	return (
+		<ChatPanel
+			busy={chat.busy}
+			className={className}
+			failure={chat.failure ?? ledger.failure}
+			leading={leading}
+			messages={chat.messages}
+			offers={ledger.ledger.offers}
+			onAccept={chat.accept}
+			onAcceptOffer={ledger.accept}
+			onDecline={chat.decline}
+			onDeclineOffer={ledger.decline}
+			onRestoreOffer={ledger.restore}
+			onSend={chat.send}
+			placeholder={placeholder}
+			plan={plan}
+			refusals={chat.refusals}
+			waiting={chat.waiting}
+		/>
+	)
+}

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -48,7 +48,6 @@ export function ArticleChatPanel({
 			onAcceptOffer={ledger.accept}
 			onDecline={chat.decline}
 			onDeclineOffer={ledger.decline}
-			onRestoreOffer={ledger.restore}
 			onSend={chat.send}
 			placeholder={placeholder}
 			plan={plan}

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -13,24 +13,19 @@ import { ProposalCard } from './ProposalCard'
 import { readProposal, type ProposalCall, type Refusals } from './proposals'
 
 /**
- * The Chat Panel. It takes a transcript and the rulings the writer can make on
- * it, so a story drives it from a fixture and `ArticleChatPanel` drives it from
- * the Article Agent — the same split as `PlanPanel` and `ArticlePlanPanel`.
- *
- * Two things a turn returns get their own card. A Proposal suspends and waits
- * for the writer (§6). Offers do not: `recordOffers` runs inside the Article
- * Agent, and what the turn hands back is a list of ids the Offer ledger holds
- * the rows for (§5).
+ * The Chat Panel takes a transcript & rulings; `ArticleChatPanel` drives it from
+ * the Article Agent — the same split as `PlanPanel` and `ArticlePlanPanel`. A turn
+ * can return Proposals and Offers; each gets its own card. Proposals suspend and
+ * wait for the writer (§6), but Offers just accumulate in the Ledger.
  */
 
 export interface ChatPanelProps {
 	messages: readonly UIMessage[]
-	/** The Plan a Proposal is described against, so a card names a Section the
-	 * way the Outline does. */
+	/** What a Proposal card names its Sections and References out of. */
 	plan: Plan
 	/** A turn is in flight. */
 	busy: boolean
-	/** How many tool calls are suspended. While this is not 0 the turn is parked. */
+	/** Suspended tool calls; above zero the turn is parked — §11. */
 	waiting: number
 	/** Why an Accept did not land, by tool call id. */
 	refusals: Refusals
@@ -111,11 +106,8 @@ export function ChatPanel({
 	)
 }
 
-/**
- * An abandoned tool batch parks indefinitely: Cloudflare's `ai-chat` enforces
- * batch completeness server-side with no orphan timeout (§11). This is the
- * sentence that says so, rather than a composer that quietly does nothing.
- */
+/** Why the composer will not send, and null when it will. Nothing expires an
+ * unruled call, so the writer has to be told to go and rule on it — §11. */
 function parked(waiting: number): string | null {
 	if (waiting === 0) return null
 	if (waiting === 1) {

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -33,7 +33,6 @@ export interface ChatPanelProps {
 	onDecline: (call: ProposalCall) => void
 	onAcceptOffer: (offer: Offer) => void
 	onDeclineOffer: (offer: Offer) => void
-	onRestoreOffer: (offer: Offer) => void
 	failure?: string | null
 	placeholder?: string
 	/** Left of send — the Offer ledger toggle. */
@@ -53,7 +52,6 @@ export function ChatPanel({
 	onDecline,
 	onAcceptOffer,
 	onDeclineOffer,
-	onRestoreOffer,
 	failure = null,
 	placeholder,
 	leading,
@@ -72,7 +70,6 @@ export function ChatPanel({
 						onAcceptOffer={onAcceptOffer}
 						onDecline={onDecline}
 						onDeclineOffer={onDeclineOffer}
-						onRestoreOffer={onRestoreOffer}
 						plan={plan}
 						refusals={refusals}
 						rows={rows}
@@ -122,7 +119,6 @@ type TurnProps = {
 	onDecline: (call: ProposalCall) => void
 	onAcceptOffer: (offer: Offer) => void
 	onDeclineOffer: (offer: Offer) => void
-	onRestoreOffer: (offer: Offer) => void
 }
 
 function Turn({
@@ -134,7 +130,6 @@ function Turn({
 	onDecline,
 	onAcceptOffer,
 	onDeclineOffer,
-	onRestoreOffer,
 }: TurnProps) {
 	const from = message.role === 'user' ? 'me' : 'guide'
 
@@ -198,7 +193,6 @@ function Turn({
 									offer={offer}
 									onAccept={() => onAcceptOffer(offer)}
 									onDecline={() => onDeclineOffer(offer)}
-									onRestore={() => onRestoreOffer(offer)}
 								/>
 							))}
 							{found.length < recorded.length ? (

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -71,9 +71,38 @@ export function ChatPanel({
 	const rows = new Map(offers.map((offer) => [offer.id, offer]))
 
 	return (
-		<Panel
-			className={className}
-			footer={
+		<Panel className={className} padded={false}>
+			<div className="flex flex-1 flex-col gap-3.5 p-3.5">
+				{messages.map((message) => (
+					<Turn
+						key={message.id}
+						message={message}
+						onAccept={onAccept}
+						onAcceptOffer={onAcceptOffer}
+						onDecline={onDecline}
+						onDeclineOffer={onDeclineOffer}
+						onRestoreOffer={onRestoreOffer}
+						plan={plan}
+						refusals={refusals}
+						rows={rows}
+					/>
+				))}
+
+				{messages.length === 0 ? (
+					<ChatNote>
+						Say what the piece is about. The Plan fills in beside you as you agree on it.
+					</ChatNote>
+				) : null}
+
+				{busy ? <ChatNote>The guide is answering…</ChatNote> : null}
+				{failure === null ? null : <Notice>{failure}</Notice>}
+			</div>
+
+			{/* Sticky, because the Panel scrolls its own Y and a composer that
+			    scrolled away with the transcript would be the one control on the
+			    Panel you cannot reach. Full-bleed and owning its own padding, which
+			    is how every other Panel edge is built. */}
+			<div className="sticky bottom-0 z-10 border-t border-edge bg-surface px-3.5 py-2.5">
 				<ChatComposer
 					blocked={parked(waiting)}
 					disabled={busy}
@@ -81,31 +110,7 @@ export function ChatPanel({
 					onSend={onSend}
 					placeholder={placeholder}
 				/>
-			}
-		>
-			{messages.map((message) => (
-				<Turn
-					key={message.id}
-					message={message}
-					onAccept={onAccept}
-					onAcceptOffer={onAcceptOffer}
-					onDecline={onDecline}
-					onDeclineOffer={onDeclineOffer}
-					onRestoreOffer={onRestoreOffer}
-					plan={plan}
-					refusals={refusals}
-					rows={rows}
-				/>
-			))}
-
-			{messages.length === 0 ? (
-				<ChatNote>
-					Say what the piece is about. The Plan fills in beside you as you agree on it.
-				</ChatNote>
-			) : null}
-
-			{busy ? <ChatNote>The guide is answering…</ChatNote> : null}
-			{failure === null ? null : <Notice>{failure}</Notice>}
+			</div>
 		</Panel>
 	)
 }

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -23,13 +23,10 @@ export interface ChatPanelProps {
 	messages: readonly UIMessage[]
 	/** What a Proposal card names its Sections and References out of. */
 	plan: Plan
-	/** A turn is in flight. */
 	busy: boolean
 	/** Suspended tool calls; above zero the turn is parked — §11. */
 	waiting: number
-	/** Why an Accept did not land, by tool call id. */
 	refusals: Refusals
-	/** The Offer rows the recorded ids resolve to. */
 	offers: readonly Offer[]
 	onSend: (text: string) => void
 	onAccept: (call: ProposalCall) => void
@@ -37,7 +34,6 @@ export interface ChatPanelProps {
 	onAcceptOffer: (offer: Offer) => void
 	onDeclineOffer: (offer: Offer) => void
 	onRestoreOffer: (offer: Offer) => void
-	/** The connection or the turn failed, in one sentence. */
 	failure?: string | null
 	placeholder?: string
 	/** Left of send — the Offer ledger toggle. */

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -5,17 +5,12 @@ import { proposePlanChangeTool, recordOffersTool } from '../../shared/chat'
 import type { Offer } from '../../shared/offer'
 import type { Plan } from '../../shared/plan'
 import { ChatComposer, ChatMessage, ChatNote } from '../components/Chat'
+import { Notice } from '../components/Notice'
 import { Panel } from '../components/Panel'
 import { ReferenceCard } from '../components/ReferenceCard'
-import { cx } from '../lib/cx'
 import { readRecordedOffers } from './offers'
 import { ProposalCard } from './ProposalCard'
-import {
-	readProposal,
-	type ProposalCall,
-	type Refusals,
-	type WaitingCall,
-} from './proposals'
+import { readProposal, type ProposalCall, type Refusals } from './proposals'
 
 /**
  * The Chat Panel. It takes a transcript and the rulings the writer can make on
@@ -35,8 +30,8 @@ export interface ChatPanelProps {
 	plan: Plan
 	/** A turn is in flight. */
 	busy: boolean
-	/** Every suspended tool call. While this is not empty the turn is parked. */
-	waiting: readonly WaitingCall[]
+	/** How many tool calls are suspended. While this is not 0 the turn is parked. */
+	waiting: number
 	/** Why an Accept did not land, by tool call id. */
 	refusals: Refusals
 	/** The Offer rows the recorded ids resolve to. */
@@ -76,10 +71,18 @@ export function ChatPanel({
 	const rows = new Map(offers.map((offer) => [offer.id, offer]))
 
 	return (
-		// `pb-0`, with the composer taking that padding instead: the Panel's own
-		// bottom padding is inside the scrollport, so a card would scroll into it
-		// and show under a composer that stopped short of it.
-		<Panel className={cx('pb-0', className)}>
+		<Panel
+			className={className}
+			footer={
+				<ChatComposer
+					blocked={parked(waiting)}
+					disabled={busy}
+					leading={leading}
+					onSend={onSend}
+					placeholder={placeholder}
+				/>
+			}
+		>
 			{messages.map((message) => (
 				<Turn
 					key={message.id}
@@ -102,20 +105,7 @@ export function ChatPanel({
 			) : null}
 
 			{busy ? <ChatNote>The guide is answering…</ChatNote> : null}
-			{failure === null ? null : (
-				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
-					{failure}
-				</p>
-			)}
-
-			<ChatComposer
-				blocked={parked(waiting)}
-				className="pb-3.5"
-				disabled={busy}
-				leading={leading}
-				onSend={onSend}
-				placeholder={placeholder}
-			/>
+			{failure === null ? null : <Notice>{failure}</Notice>}
 		</Panel>
 	)
 }
@@ -125,13 +115,13 @@ export function ChatPanel({
  * batch completeness server-side with no orphan timeout (§11). This is the
  * sentence that says so, rather than a composer that quietly does nothing.
  */
-function parked(waiting: readonly WaitingCall[]): string | null {
-	if (waiting.length === 0) return null
-	if (waiting.length === 1) {
+function parked(waiting: number): string | null {
+	if (waiting === 0) return null
+	if (waiting === 1) {
 		return 'The Chat is waiting on a Proposal. Accept or Decline it to carry on.'
 	}
 
-	return `The Chat is waiting on ${waiting.length} Proposals. Accept or Decline each one to carry on.`
+	return `The Chat is waiting on ${waiting} Proposals. Accept or Decline each one to carry on.`
 }
 
 type TurnProps = {
@@ -197,7 +187,10 @@ function Turn({
 						case 'output-available':
 							return <ChatNote key={key}>Proposal Accepted.</ChatNote>
 						case 'output-error':
-							return <ChatNote key={key}>Proposal Declined. {part.errorText}</ChatNote>
+							// Not `part.errorText`: that is the sentence written for the
+							// model, ids and op name included. The writer read the reason on
+							// the card before they ruled — §6.
+							return <ChatNote key={key}>Proposal Declined.</ChatNote>
 						default:
 							return null
 					}

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -98,10 +98,6 @@ export function ChatPanel({
 				{failure === null ? null : <Notice>{failure}</Notice>}
 			</div>
 
-			{/* Sticky, because the Panel scrolls its own Y and a composer that
-			    scrolled away with the transcript would be the one control on the
-			    Panel you cannot reach. Full-bleed and owning its own padding, which
-			    is how every other Panel edge is built. */}
 			<div className="sticky bottom-0 z-10 border-t border-edge bg-surface px-3.5 py-2.5">
 				<ChatComposer
 					blocked={parked(waiting)}
@@ -192,9 +188,6 @@ function Turn({
 						case 'output-available':
 							return <ChatNote key={key}>Proposal Accepted.</ChatNote>
 						case 'output-error':
-							// Not `part.errorText`: that is the sentence written for the
-							// model, ids and op name included. The writer read the reason on
-							// the card before they ruled — §6.
 							return <ChatNote key={key}>Proposal Declined.</ChatNote>
 						default:
 							return null

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -1,0 +1,239 @@
+import { getToolName, isTextUIPart, isToolUIPart, type UIMessage } from 'ai'
+import type { ReactNode } from 'react'
+
+import { proposePlanChangeTool, recordOffersTool } from '../../shared/chat'
+import type { Offer } from '../../shared/offer'
+import type { Plan } from '../../shared/plan'
+import { ChatComposer, ChatMessage, ChatNote } from '../components/Chat'
+import { Panel } from '../components/Panel'
+import { ReferenceCard } from '../components/ReferenceCard'
+import { cx } from '../lib/cx'
+import { readRecordedOffers } from './offers'
+import { ProposalCard } from './ProposalCard'
+import {
+	readProposal,
+	type ProposalCall,
+	type Refusals,
+	type WaitingCall,
+} from './proposals'
+
+/**
+ * The Chat Panel. It takes a transcript and the rulings the writer can make on
+ * it, so a story drives it from a fixture and `ArticleChatPanel` drives it from
+ * the Article Agent — the same split as `PlanPanel` and `ArticlePlanPanel`.
+ *
+ * Two things a turn returns get their own card. A Proposal suspends and waits
+ * for the writer (§6). Offers do not: `recordOffers` runs inside the Article
+ * Agent, and what the turn hands back is a list of ids the Offer ledger holds
+ * the rows for (§5).
+ */
+
+export interface ChatPanelProps {
+	messages: readonly UIMessage[]
+	/** The Plan a Proposal is described against, so a card names a Section the
+	 * way the Outline does. */
+	plan: Plan
+	/** A turn is in flight. */
+	busy: boolean
+	/** Every suspended tool call. While this is not empty the turn is parked. */
+	waiting: readonly WaitingCall[]
+	/** Why an Accept did not land, by tool call id. */
+	refusals: Refusals
+	/** The Offer rows the recorded ids resolve to. */
+	offers: readonly Offer[]
+	onSend: (text: string) => void
+	onAccept: (call: ProposalCall) => void
+	onDecline: (call: ProposalCall) => void
+	onAcceptOffer: (offer: Offer) => void
+	onDeclineOffer: (offer: Offer) => void
+	onRestoreOffer: (offer: Offer) => void
+	/** The connection or the turn failed, in one sentence. */
+	failure?: string | null
+	placeholder?: string
+	/** Left of send — the Offer ledger toggle. */
+	leading?: ReactNode
+	className?: string
+}
+
+export function ChatPanel({
+	messages,
+	plan,
+	busy,
+	waiting,
+	refusals,
+	offers,
+	onSend,
+	onAccept,
+	onDecline,
+	onAcceptOffer,
+	onDeclineOffer,
+	onRestoreOffer,
+	failure = null,
+	placeholder,
+	leading,
+	className,
+}: ChatPanelProps) {
+	const rows = new Map(offers.map((offer) => [offer.id, offer]))
+
+	return (
+		// `pb-0`, with the composer taking that padding instead: the Panel's own
+		// bottom padding is inside the scrollport, so a card would scroll into it
+		// and show under a composer that stopped short of it.
+		<Panel className={cx('pb-0', className)}>
+			{messages.map((message) => (
+				<Turn
+					key={message.id}
+					message={message}
+					onAccept={onAccept}
+					onAcceptOffer={onAcceptOffer}
+					onDecline={onDecline}
+					onDeclineOffer={onDeclineOffer}
+					onRestoreOffer={onRestoreOffer}
+					plan={plan}
+					refusals={refusals}
+					rows={rows}
+				/>
+			))}
+
+			{messages.length === 0 ? (
+				<ChatNote>
+					Say what the piece is about. The Plan fills in beside you as you agree on it.
+				</ChatNote>
+			) : null}
+
+			{busy ? <ChatNote>The guide is answering…</ChatNote> : null}
+			{failure === null ? null : (
+				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
+					{failure}
+				</p>
+			)}
+
+			<ChatComposer
+				blocked={parked(waiting)}
+				className="pb-3.5"
+				disabled={busy}
+				leading={leading}
+				onSend={onSend}
+				placeholder={placeholder}
+			/>
+		</Panel>
+	)
+}
+
+/**
+ * An abandoned tool batch parks indefinitely: Cloudflare's `ai-chat` enforces
+ * batch completeness server-side with no orphan timeout (§11). This is the
+ * sentence that says so, rather than a composer that quietly does nothing.
+ */
+function parked(waiting: readonly WaitingCall[]): string | null {
+	if (waiting.length === 0) return null
+	if (waiting.length === 1) {
+		return 'The Chat is waiting on a Proposal. Accept or Decline it to carry on.'
+	}
+
+	return `The Chat is waiting on ${waiting.length} Proposals. Accept or Decline each one to carry on.`
+}
+
+type TurnProps = {
+	message: UIMessage
+	plan: Plan
+	refusals: Refusals
+	rows: Map<string, Offer>
+	onAccept: (call: ProposalCall) => void
+	onDecline: (call: ProposalCall) => void
+	onAcceptOffer: (offer: Offer) => void
+	onDeclineOffer: (offer: Offer) => void
+	onRestoreOffer: (offer: Offer) => void
+}
+
+function Turn({
+	message,
+	plan,
+	refusals,
+	rows,
+	onAccept,
+	onDecline,
+	onAcceptOffer,
+	onDeclineOffer,
+	onRestoreOffer,
+}: TurnProps) {
+	const from = message.role === 'user' ? 'me' : 'guide'
+
+	return (
+		<>
+			{message.parts.map((part, index) => {
+				const key = `${message.id}-${index}`
+
+				if (isTextUIPart(part)) {
+					if (part.text === '') return null
+
+					return (
+						<ChatMessage key={key} from={from}>
+							{part.text}
+						</ChatMessage>
+					)
+				}
+
+				if (!isToolUIPart(part)) return null
+
+				if (getToolName(part) === proposePlanChangeTool) {
+					switch (part.state) {
+						case 'input-streaming':
+							return <ChatNote key={key}>Writing a Proposal…</ChatNote>
+						case 'input-available': {
+							const call = readProposal(part)
+
+							return (
+								<ProposalCard
+									key={key}
+									call={call}
+									onAccept={() => onAccept(call)}
+									onDecline={() => onDecline(call)}
+									plan={plan}
+									refusal={refusals[call.toolCallId] ?? null}
+								/>
+							)
+						}
+						case 'output-available':
+							return <ChatNote key={key}>Proposal Accepted.</ChatNote>
+						case 'output-error':
+							return <ChatNote key={key}>Proposal Declined. {part.errorText}</ChatNote>
+						default:
+							return null
+					}
+				}
+
+				if (getToolName(part) === recordOffersTool) {
+					const recorded = readRecordedOffers(part)
+					if (recorded === null) return <ChatNote key={key}>Looking things up…</ChatNote>
+
+					const found = recorded
+						.map(({ id }) => rows.get(id))
+						.filter((offer): offer is Offer => offer !== undefined)
+
+					return (
+						<div key={key} className="flex flex-col gap-2">
+							{found.map((offer) => (
+								<ReferenceCard
+									key={offer.id}
+									offer={offer}
+									onAccept={() => onAcceptOffer(offer)}
+									onDecline={() => onDeclineOffer(offer)}
+									onRestore={() => onRestoreOffer(offer)}
+								/>
+							))}
+							{found.length < recorded.length ? (
+								<ChatNote>
+									{recorded.length} found, and the Offer ledger has not read them all back
+									yet.
+								</ChatNote>
+							) : null}
+						</div>
+					)
+				}
+
+				return null
+			})}
+		</>
+	)
+}

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -1,7 +1,8 @@
 import type { Plan, Refusal } from '../../shared/plan'
 import { Button } from '../components/Button'
+import { Notice } from '../components/Notice'
 import { cx } from '../lib/cx'
-import { refusalText } from '../plan/refusalText'
+import { refusalText, unreadableText } from '../plan/refusalText'
 import { describeProposal, type ProposalCall } from './proposals'
 
 /**
@@ -55,16 +56,14 @@ export function ProposalCard({
 					))}
 				</ul>
 			) : (
-				<p className="text-[0.8125rem] leading-snug text-ink">
-					This Proposal did not parse, so there is nothing to Accept. {call.unreadable}
-				</p>
+				<p className="text-[0.8125rem] leading-snug text-ink">{unreadableText}</p>
 			)}
 
 			{refusal === null ? null : (
-				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
+				<Notice>
 					{refusalText(plan, refusal)} Decline to send that back, or edit the Plan and
 					Accept again.
-				</p>
+				</Notice>
 			)}
 
 			<div className="flex items-center gap-1.5">

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -1,6 +1,7 @@
 import type { Plan, Refusal } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { cx } from '../lib/cx'
+import { refusalText } from '../plan/refusalText'
 import { describeProposal, type ProposalCall } from './proposals'
 
 /**
@@ -61,7 +62,8 @@ export function ProposalCard({
 
 			{refusal === null ? null : (
 				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
-					{refusal.message} Decline to send that back, or edit the Plan and Accept again.
+					{refusalText(plan, refusal)} Decline to send that back, or edit the Plan and
+					Accept again.
 				</p>
 			)}
 

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -1,0 +1,78 @@
+import type { Plan, Refusal } from '../../shared/plan'
+import { Button } from '../components/Button'
+import { cx } from '../lib/cx'
+import { describeProposal, type ProposalCall } from './proposals'
+
+/**
+ * One suspended Proposal, for the writer to Accept or Decline —
+ * docs/architecture.md §6. Accepting applies the ops through the Plan's one
+ * writer; Declining answers the tool call with the reason.
+ *
+ * **A refused Proposal says why.** Whole-field `expected` comparison is
+ * conservative and will refuse a Proposal against a field the writer has since
+ * touched, so a card that just greyed out would be a card the writer cannot
+ * account for. The applier writes that sentence; this renders it.
+ */
+
+export interface ProposalCardProps {
+	call: ProposalCall
+	plan: Plan
+	/** Why the last Accept did not land, and null while it has not been tried. */
+	refusal?: Refusal | null
+	onAccept: () => void
+	onDecline: () => void
+	className?: string
+}
+
+export function ProposalCard({
+	call,
+	plan,
+	refusal = null,
+	onAccept,
+	onDecline,
+	className,
+}: ProposalCardProps) {
+	const changes = call.ops === null ? [] : describeProposal(plan, call.ops)
+
+	return (
+		<article
+			className={cx(
+				'flex flex-col gap-2 rounded-lg border border-accent-edge bg-surface p-2.5',
+				className,
+			)}
+		>
+			<h4 className="label-meta text-muted">
+				Proposal · {changes.length === 1 ? '1 change' : `${changes.length} changes`}
+			</h4>
+
+			{call.unreadable === null ? (
+				<ul className="flex list-none flex-col gap-1">
+					{changes.map((change) => (
+						<li key={change} className="text-[0.8125rem] leading-snug text-ink">
+							{change}
+						</li>
+					))}
+				</ul>
+			) : (
+				<p className="text-[0.8125rem] leading-snug text-ink">
+					This Proposal did not parse, so there is nothing to Accept. {call.unreadable}
+				</p>
+			)}
+
+			{refusal === null ? null : (
+				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
+					{refusal.message} Decline to send that back, or edit the Plan and Accept again.
+				</p>
+			)}
+
+			<div className="flex items-center gap-1.5">
+				<Button size="sm" disabled={call.ops === null} onClick={onAccept}>
+					Accept
+				</Button>
+				<Button size="sm" variant="quiet" onClick={onDecline}>
+					Decline
+				</Button>
+			</div>
+		</article>
+	)
+}

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -11,7 +11,6 @@ import { describeProposal, type ProposalCall } from './proposals'
 export interface ProposalCardProps {
 	call: ProposalCall
 	plan: Plan
-	/** Why the last Accept did not land, and null while it has not been tried. */
 	refusal?: Refusal | null
 	onAccept: () => void
 	onDecline: () => void

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -5,16 +5,8 @@ import { cx } from '../lib/cx'
 import { refusalText, unreadableText } from '../plan/refusalText'
 import { describeProposal, type ProposalCall } from './proposals'
 
-/**
- * One suspended Proposal, for the writer to Accept or Decline —
- * docs/architecture.md §6. Accepting applies the ops through the Plan's one
- * writer; Declining answers the tool call with the reason.
- *
- * **A refused Proposal says why.** Whole-field `expected` comparison is
- * conservative and will refuse a Proposal against a field the writer has since
- * touched, so a card that just greyed out would be a card the writer cannot
- * account for. The applier writes that sentence; this renders it.
- */
+/** One suspended Proposal to Accept or Decline — §6. Renders its ops as
+ * sentences, and the refusal if an Accept was turned down. */
 
 export interface ProposalCardProps {
 	call: ProposalCall

--- a/src/client/chat/offers.ts
+++ b/src/client/chat/offers.ts
@@ -13,10 +13,8 @@ import {
 } from '../../shared/chat'
 
 /**
- * Reading a research turn's result out of the transcript. The `recordOffers`
- * tool carries an `execute` and resolves inside the Article Agent (§5), so
- * nothing here rules on it — what it hands back is a list of ids, and the Chat
- * Panel shows the rows the Offer ledger holds for them.
+ * Reading a research turn's result out of the transcript. `recordOffers`
+ * resolves server-side and hands back ids, not rows — §5.
  */
 
 /** What one `recordOffers` call turned up, or null for a part that is not one. */
@@ -31,12 +29,7 @@ export function readRecordedOffers(
 	return parsed.success ? parsed.data : null
 }
 
-/**
- * Every Offer id the transcript names, in order. The Ledger reads its rows once
- * when it opens, because nothing tells a client a row changed — so a turn that
- * recorded some is what tells it to read again, and this is the key that says
- * the set moved.
- */
+/** A fresh array of every Offer id the transcript names, in order, deduped. */
 export function recordedOfferIds(messages: readonly UIMessage[]): string[] {
 	const ids: string[] = []
 

--- a/src/client/chat/offers.ts
+++ b/src/client/chat/offers.ts
@@ -1,0 +1,54 @@
+import {
+	type DynamicToolUIPart,
+	getToolName,
+	isToolUIPart,
+	type ToolUIPart,
+	type UIMessage,
+} from 'ai'
+
+import {
+	type RecordedOffers,
+	recordedOffersOutput,
+	recordOffersTool,
+} from '../../shared/chat'
+
+/**
+ * Reading a research turn's result out of the transcript. The `recordOffers`
+ * tool carries an `execute` and resolves inside the Article Agent (§5), so
+ * nothing here rules on it — what it hands back is a list of ids, and the Chat
+ * Panel shows the rows the Offer ledger holds for them.
+ */
+
+/** What one `recordOffers` call turned up, or null for a part that is not one. */
+export function readRecordedOffers(
+	part: ToolUIPart | DynamicToolUIPart,
+): RecordedOffers | null {
+	if (getToolName(part) !== recordOffersTool) return null
+	if (part.state !== 'output-available') return null
+
+	const parsed = recordedOffersOutput.safeParse(part.output)
+
+	return parsed.success ? parsed.data : null
+}
+
+/**
+ * Every Offer id the transcript names, in order. The Ledger reads its rows once
+ * when it opens, because nothing tells a client a row changed — so a turn that
+ * recorded some is what tells it to read again, and this is the key that says
+ * the set moved.
+ */
+export function recordedOfferIds(messages: readonly UIMessage[]): string[] {
+	const ids: string[] = []
+
+	for (const message of messages) {
+		for (const part of message.parts) {
+			if (!isToolUIPart(part)) continue
+
+			for (const recorded of readRecordedOffers(part) ?? []) {
+				if (!ids.includes(recorded.id)) ids.push(recorded.id)
+			}
+		}
+	}
+
+	return ids
+}

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -1,10 +1,4 @@
-import {
-	type DynamicToolUIPart,
-	getToolName,
-	isToolUIPart,
-	type ToolUIPart,
-	type UIMessage,
-} from 'ai'
+import { type DynamicToolUIPart, isToolUIPart, type ToolUIPart, type UIMessage } from 'ai'
 import { z } from 'zod'
 
 import { proposePlanChangeInput } from '../../shared/chat'
@@ -30,36 +24,28 @@ export type ProposalCall = {
 	unreadable: string | null
 }
 
-/** A tool call the Chat is still waiting on an answer for. */
-export type WaitingCall = { toolCallId: string; toolName: string }
-
 type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
 /**
- * Every tool call whose input is complete and whose output has not been sent.
+ * How many tool calls have their input complete and no output sent.
  *
  * This is what parks a turn. Cloudflare's `ai-chat` enforces batch completeness
  * server-side with **no orphan timeout** (§11), so a call the writer neither
  * Accepts nor Declines stalls the conversation with nothing on screen to say
- * so. The composer reads this and says it.
+ * so. The composer reads this and says it. A count, because which tool parked
+ * the turn changes nothing the writer can do about it: the cards are in the
+ * transcript either way.
  */
-export function waitingCalls(messages: readonly UIMessage[]): WaitingCall[] {
-	return suspended(messages).map((part) => ({
-		toolCallId: part.toolCallId,
-		toolName: getToolName(part),
-	}))
-}
-
-function suspended(messages: readonly UIMessage[]): AnyToolPart[] {
-	const calls: AnyToolPart[] = []
+export function waitingCount(messages: readonly UIMessage[]): number {
+	let waiting = 0
 
 	for (const message of messages) {
 		for (const part of message.parts) {
-			if (isToolUIPart(part) && part.state === 'input-available') calls.push(part)
+			if (isToolUIPart(part) && part.state === 'input-available') waiting += 1
 		}
 	}
 
-	return calls
+	return waiting
 }
 
 /**

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -1,0 +1,258 @@
+import {
+	type DynamicToolUIPart,
+	getToolName,
+	isToolUIPart,
+	type ToolUIPart,
+	type UIMessage,
+} from 'ai'
+import { z } from 'zod'
+
+import { proposePlanChangeInput } from '../../shared/chat'
+import type { Anchor, Plan, Proposal, ProposalOp, Refusal } from '../../shared/plan'
+import { outlineEntries, sectionLabel } from '../plan/outline'
+import { referenceName } from '../plan/references'
+
+/**
+ * Reading Proposals out of a Chat transcript, and writing what a card says.
+ *
+ * A Proposal is a suspended tool call: `proposePlanChange` carries no `execute`,
+ * so the turn stops with the call's input available and no output, waiting for
+ * the writer — docs/architecture.md §6. Nothing here touches the socket or
+ * React, so a test drives it with a transcript and a Plan.
+ */
+
+/** One Proposal the writer has not ruled on yet. */
+export type ProposalCall = {
+	toolCallId: string
+	/** The ops, and null when the model's payload did not parse. */
+	ops: Proposal | null
+	/** Why the payload could not be read, and null when it was. */
+	unreadable: string | null
+}
+
+/** A tool call the Chat is still waiting on an answer for. */
+export type WaitingCall = { toolCallId: string; toolName: string }
+
+type AnyToolPart = ToolUIPart | DynamicToolUIPart
+
+/**
+ * Every tool call whose input is complete and whose output has not been sent.
+ *
+ * This is what parks a turn. Cloudflare's `ai-chat` enforces batch completeness
+ * server-side with **no orphan timeout** (§11), so a call the writer neither
+ * Accepts nor Declines stalls the conversation with nothing on screen to say
+ * so. The composer reads this and says it.
+ */
+export function waitingCalls(messages: readonly UIMessage[]): WaitingCall[] {
+	return suspended(messages).map((part) => ({
+		toolCallId: part.toolCallId,
+		toolName: getToolName(part),
+	}))
+}
+
+function suspended(messages: readonly UIMessage[]): AnyToolPart[] {
+	const calls: AnyToolPart[] = []
+
+	for (const message of messages) {
+		for (const part of message.parts) {
+			if (isToolUIPart(part) && part.state === 'input-available') calls.push(part)
+		}
+	}
+
+	return calls
+}
+
+/**
+ * The tool's input schema is strict and a rejected call retries with the
+ * validation error (§6), so an unreadable payload here is a payload that
+ * survived every retry. The card says so rather than rendering blank.
+ */
+export function readProposal(part: AnyToolPart): ProposalCall {
+	const parsed = proposePlanChangeInput.safeParse(part.input)
+	if (!parsed.success) {
+		return {
+			toolCallId: part.toolCallId,
+			ops: null,
+			unreadable: z.prettifyError(parsed.error),
+		}
+	}
+
+	return { toolCallId: part.toolCallId, ops: parsed.data.ops, unreadable: null }
+}
+
+/** What goes back on a Decline, as `is_error: true` with the reason in the
+ * content — §6. A Proposal the Plan refused sends the refusal, so the model
+ * knows the Plan moved rather than that the writer said no. */
+export function declineReason(call: ProposalCall, refusal: Refusal | null): string {
+	if (call.unreadable !== null) {
+		return `This Proposal did not parse, so there was nothing to Accept. ${call.unreadable}`
+	}
+	if (refusal !== null) {
+		return `The Plan refused this Proposal. ${refusal.message}`
+	}
+
+	return 'The writer Declined this Proposal.'
+}
+
+/** What goes back on an Accept. The next turn carries the whole Plan in `body`,
+ * so this says the ruling and nothing about the result. */
+export function acceptReason(ops: Proposal): string {
+	const count = ops.length === 1 ? 'change' : `${ops.length} changes`
+
+	return `The writer Accepted this Proposal, and the Plan now carries the ${count}.`
+}
+
+/** What the tool call is answered with. An `errorText` is the `is_error: true`
+ * half — §6. */
+export type ToolAnswer = { output: string } | { errorText: string }
+
+/** Why an Accept did not land, by tool call. A Panel holds one of these because
+ * a transcript can carry more than one open Proposal. */
+export type Refusals = Record<string, Refusal>
+
+/** Fold a ruling into what the Panel holds: an Accept that landed clears the
+ * refusal the card was showing, and a Decline clears it on the way out. */
+export function afterRuling(
+	held: Refusals,
+	toolCallId: string,
+	refusal: Refusal | null,
+): Refusals {
+	const rest = { ...held }
+	delete rest[toolCallId]
+
+	return refusal === null ? rest : { ...rest, [toolCallId]: refusal }
+}
+
+export type Ruling = {
+	/** What to send back, and null where the Proposal stays open. */
+	answer: ToolAnswer | null
+	/** Why the Accept did not land, and null where it did. */
+	refusal: Refusal | null
+}
+
+export type RulingOptions = {
+	call: ProposalCall
+	/** True Accepts, false Declines. */
+	accepted: boolean
+	/** The Plan's one writer — the same `edit` every other Plan change makes. */
+	edit: (ops: Proposal) => Refusal | null
+	/** Why an earlier Accept on this call did not land. */
+	refusal: Refusal | null
+}
+
+/**
+ * One ruling: apply the ops if it is an Accept, then say what goes back on the
+ * tool call. The app and a story both run this, so a story cannot rule
+ * differently from the product.
+ *
+ * **A refused Accept answers nothing and leaves the card open.** Whole-field
+ * `expected` comparison is conservative and refuses against a field the writer
+ * has since touched, so the writer may fix the Plan and Accept again. Declining
+ * then sends the refusal back, which tells the model the Plan moved rather than
+ * that the writer said no.
+ */
+export function ruleProposal({ call, accepted, edit, refusal }: RulingOptions): Ruling {
+	if (!accepted || call.ops === null) {
+		return { answer: { errorText: declineReason(call, refusal) }, refusal: null }
+	}
+
+	const refused = edit(call.ops)
+	if (refused !== null) return { answer: null, refusal: refused }
+
+	return { answer: { output: acceptReason(call.ops) }, refusal: null }
+}
+
+/**
+ * The Proposal in the writer's words, one sentence per op, read against the
+ * Plan on screen. A Section is named the way every other Panel names it, so the
+ * card and the Outline cannot number one differently.
+ */
+export function describeProposal(plan: Plan, ops: Proposal): string[] {
+	const named = new Map(
+		outlineEntries(plan.outline).map((entry) => [
+			entry.node.id,
+			entry.node.title === ''
+				? sectionLabel(entry)
+				: `${sectionLabel(entry)} ${entry.node.title}`,
+		]),
+	)
+	const section = (nodeId: string) =>
+		named.get(nodeId) ?? 'a Section the Plan does not carry'
+	const reference = (referenceId: string) => {
+		const held = plan.references.find((entry) => entry.id === referenceId)
+
+		return held === undefined
+			? 'a Reference the Plan does not carry'
+			: referenceName(held)
+	}
+
+	// A structural op states exactly one of the two, so the branch not taken is
+	// the one the op left out — `afterId: null` is first child and
+	// `beforeId: null` is last.
+	const anchored = (parentId: string | null, op: Anchor) => {
+		if (op.beforeId !== undefined) {
+			return op.beforeId === null ? lastIn(parentId) : `before ${section(op.beforeId)}`
+		}
+		if (op.afterId !== undefined && op.afterId !== null) {
+			return `after ${section(op.afterId)}`
+		}
+
+		return firstIn(parentId)
+	}
+	const lastIn = (parentId: string | null) =>
+		parentId === null ? 'last in the Outline' : `last inside ${section(parentId)}`
+	const firstIn = (parentId: string | null) =>
+		parentId === null ? 'first in the Outline' : `first inside ${section(parentId)}`
+
+	const scope = (nodeId: string | null) =>
+		nodeId === null ? 'the Article' : section(nodeId)
+
+	return ops.map((op) => describe(op))
+
+	function describe(op: ProposalOp): string {
+		switch (op.op) {
+			case 'createNode':
+				return `Add ${titled(op.node.title)}, ${anchored(op.parentId, op)}.`
+			case 'moveNode':
+				return `Move ${section(op.nodeId)} ${anchored(op.parentId, op)}.`
+			case 'mergeNodes':
+				return `Merge ${section(op.nodeId)} into ${section(op.intoId)}, keeping what the second one says.`
+			case 'deleteNode':
+				return `Delete ${section(op.nodeId)}, and unplace the References sitting there.`
+			case 'setTitle':
+				return op.value === ''
+					? `Clear the title of ${scope(op.nodeId)}.`
+					: `Retitle ${scope(op.nodeId)} “${op.value}”.`
+			case 'setIntent':
+				return op.value === null
+					? `Clear the intent note on ${section(op.nodeId)}.`
+					: `Note on ${section(op.nodeId)}: “${op.value}”.`
+			case 'setTarget':
+				return op.value === null
+					? `Clear the length of ${scope(op.nodeId)}.`
+					: `Set the length of ${scope(op.nodeId)} to ${op.value} words.`
+			case 'setVoice':
+				return op.value === null
+					? `Clear the Voice of ${scope(op.nodeId)}.`
+					: `Set the Voice of ${scope(op.nodeId)} to ${op.value}.`
+			case 'setAdjectives':
+				return op.value.length === 0
+					? `Clear the Adjectives of ${scope(op.nodeId)}.`
+					: `Set the Adjectives of ${scope(op.nodeId)} to ${op.value.join(', ')}.`
+			case 'placeReference':
+				return op.value === null
+					? `Take ${reference(op.referenceId)} off the Section it sits at.`
+					: `Place ${reference(op.referenceId)} at ${section(op.value)}.`
+			case 'createReference':
+				return `Add ${referenceName(op.reference)} to the References.`
+			case 'deleteReference':
+				return `Delete ${reference(op.referenceId)} from the References.`
+			case 'setReference':
+				return `Replace what ${reference(op.referenceId)} says.`
+		}
+	}
+}
+
+function titled(title: string): string {
+	return title === '' ? 'an untitled Section' : `a Section, “${title}”`
+}

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -14,12 +14,10 @@ import { referenceName } from '../plan/references'
  * No socket and no React here, so a test drives it with a transcript and a Plan.
  */
 
-/** One Proposal the writer has not ruled on yet. */
 export type ProposalCall = {
 	toolCallId: string
-	/** The ops, and null when the model's payload did not parse. */
 	ops: Proposal | null
-	/** Why the payload could not be read, and null when it was. */
+	/** Why the ops could not be read. */
 	unreadable: string | null
 }
 
@@ -82,8 +80,8 @@ export type ToolAnswer = { output: string } | { errorText: string }
 /** Refusals by tool call, since a transcript can carry several open Proposals. */
 export type Refusals = Record<string, Refusal>
 
-/** Fold a ruling into what the Panel holds: an Accept that landed clears the
- * refusal the card was showing, and a Decline clears it on the way out. */
+/** Folds a ruling into the refusals a Panel holds. Landing or declining clears
+ * whatever the card was showing. */
 export function afterRuling(
 	held: Refusals,
 	toolCallId: string,
@@ -96,19 +94,17 @@ export function afterRuling(
 }
 
 export type Ruling = {
-	/** What to send back, and null where the Proposal stays open. */
+	/** Null where the Proposal stays open. */
 	answer: ToolAnswer | null
-	/** Why the Accept did not land, and null where it did. */
 	refusal: Refusal | null
 }
 
 export type RulingOptions = {
 	call: ProposalCall
-	/** True Accepts, false Declines. */
 	accepted: boolean
-	/** The Plan's one writer — the same `edit` every other Plan change makes. */
+	/** The Plan's one writer, so a ruling lands like any other edit. */
 	edit: (ops: Proposal) => Refusal | null
-	/** Why an earlier Accept on this call did not land. */
+	/** From an earlier Accept on this same call. */
 	refusal: Refusal | null
 }
 

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -9,7 +9,7 @@ import { z } from 'zod'
 
 import { proposePlanChangeInput } from '../../shared/chat'
 import type { Anchor, Plan, Proposal, ProposalOp, Refusal } from '../../shared/plan'
-import { outlineEntries, sectionLabel } from '../plan/outline'
+import { planNames } from '../plan/names'
 import { referenceName } from '../plan/references'
 
 /**
@@ -168,23 +168,7 @@ export function ruleProposal({ call, accepted, edit, refusal }: RulingOptions): 
  * card and the Outline cannot number one differently.
  */
 export function describeProposal(plan: Plan, ops: Proposal): string[] {
-	const named = new Map(
-		outlineEntries(plan.outline).map((entry) => [
-			entry.node.id,
-			entry.node.title === ''
-				? sectionLabel(entry)
-				: `${sectionLabel(entry)} ${entry.node.title}`,
-		]),
-	)
-	const section = (nodeId: string) =>
-		named.get(nodeId) ?? 'a Section the Plan does not carry'
-	const reference = (referenceId: string) => {
-		const held = plan.references.find((entry) => entry.id === referenceId)
-
-		return held === undefined
-			? 'a Reference the Plan does not carry'
-			: referenceName(held)
-	}
+	const { section, reference, scope } = planNames(plan)
 
 	// A structural op states exactly one of the two, so the branch not taken is
 	// the one the op left out — `afterId: null` is first child and
@@ -203,9 +187,6 @@ export function describeProposal(plan: Plan, ops: Proposal): string[] {
 		parentId === null ? 'last in the Outline' : `last inside ${section(parentId)}`
 	const firstIn = (parentId: string | null) =>
 		parentId === null ? 'first in the Outline' : `first inside ${section(parentId)}`
-
-	const scope = (nodeId: string | null) =>
-		nodeId === null ? 'the Article' : section(nodeId)
 
 	return ops.map((op) => describe(op))
 

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -7,12 +7,11 @@ import { planNames } from '../plan/names'
 import { referenceName } from '../plan/references'
 
 /**
- * Reading Proposals out of a Chat transcript, and writing what a card says.
+ * Reading Proposals out of a Chat transcript, ruling on one, and wording what a
+ * card says. A Proposal is a suspended tool call: input present, no output,
+ * parked until the writer rules — §6.
  *
- * A Proposal is a suspended tool call: `proposePlanChange` carries no `execute`,
- * so the turn stops with the call's input available and no output, waiting for
- * the writer — docs/architecture.md §6. Nothing here touches the socket or
- * React, so a test drives it with a transcript and a Plan.
+ * No socket and no React here, so a test drives it with a transcript and a Plan.
  */
 
 /** One Proposal the writer has not ruled on yet. */
@@ -26,14 +25,8 @@ export type ProposalCall = {
 
 type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
-/**
- * How many tool calls have their input complete and no output sent.
- *
- * This is what parks a turn. Cloudflare's `ai-chat` enforces batch completeness
- * server-side with **no orphan timeout** (§11), so a call the writer neither
- * Accepts nor Declines stalls the conversation with nothing on screen to say
- * so. The composer reads this and says it.
- */
+/** How many tool calls have their input complete and no output sent, which is
+ * what parks a turn — §11. */
 export function waitingCount(messages: readonly UIMessage[]): number {
 	let waiting = 0
 
@@ -46,11 +39,8 @@ export function waitingCount(messages: readonly UIMessage[]): number {
 	return waiting
 }
 
-/**
- * The tool's input schema is strict and a rejected call retries with the
- * validation error (§6), so an unreadable payload here is a payload that
- * survived every retry. The card says so rather than rendering blank.
- */
+/** Reads the ops off a suspended call. A payload that fails here has already
+ * survived the schema's own retries (§6), so the card reports it. */
 export function readProposal(part: AnyToolPart): ProposalCall {
 	const parsed = proposePlanChangeInput.safeParse(part.input)
 	if (!parsed.success) {
@@ -64,9 +54,8 @@ export function readProposal(part: AnyToolPart): ProposalCall {
 	return { toolCallId: part.toolCallId, ops: parsed.data.ops, unreadable: null }
 }
 
-/** What goes back on a Decline, as `is_error: true` with the reason in the
- * content — §6. A Proposal the Plan refused sends the refusal, so the model
- * knows the Plan moved rather than that the writer said no. */
+/** The `is_error: true` content a Decline sends back — §6. A refused Accept
+ * sends the refusal, so the model learns the Plan moved under it. */
 export function declineReason(call: ProposalCall, refusal: Refusal | null): string {
 	if (call.unreadable !== null) {
 		return `This Proposal did not parse, so there was nothing to Accept. ${call.unreadable}`
@@ -78,8 +67,8 @@ export function declineReason(call: ProposalCall, refusal: Refusal | null): stri
 	return 'The writer Declined this Proposal.'
 }
 
-/** What goes back on an Accept. The next turn carries the whole Plan in `body`,
- * so this says the ruling and nothing about the result. */
+/** What an Accept sends back. Just the ruling: the next turn carries the whole
+ * Plan in `body` anyway. */
 export function acceptReason(ops: Proposal): string {
 	const count = ops.length === 1 ? 'change' : `${ops.length} changes`
 
@@ -90,8 +79,7 @@ export function acceptReason(ops: Proposal): string {
  * half — §6. */
 export type ToolAnswer = { output: string } | { errorText: string }
 
-/** Why an Accept did not land, by tool call. A Panel holds one of these because
- * a transcript can carry more than one open Proposal. */
+/** Refusals by tool call, since a transcript can carry several open Proposals. */
 export type Refusals = Record<string, Refusal>
 
 /** Fold a ruling into what the Panel holds: an Accept that landed clears the
@@ -125,15 +113,10 @@ export type RulingOptions = {
 }
 
 /**
- * One ruling: apply the ops if it is an Accept, then say what goes back on the
- * tool call. The app and a story both run this, so a story cannot rule
- * differently from the product.
- *
- * **A refused Accept answers nothing and leaves the card open.** Whole-field
- * `expected` comparison is conservative and refuses against a field the writer
- * has since touched, so the writer may fix the Plan and Accept again. Declining
- * then sends the refusal back, which tells the model the Plan moved rather than
- * that the writer said no.
+ * Applies the ops on an Accept, then says what goes back on the tool call. A
+ * refused Accept answers nothing and hands back the refusal, leaving the card
+ * open for the writer to fix the Plan and try again. The app and the showcase
+ * both run this.
  */
 export function ruleProposal({ call, accepted, edit, refusal }: RulingOptions): Ruling {
 	if (!accepted || call.ops === null) {
@@ -146,17 +129,13 @@ export function ruleProposal({ call, accepted, edit, refusal }: RulingOptions): 
 	return { answer: { output: acceptReason(call.ops) }, refusal: null }
 }
 
-/**
- * The Proposal in the writer's words, one sentence per op, read against the
- * Plan on screen. A Section is named the way every other Panel names it, so the
- * card and the Outline cannot number one differently.
- */
+/** The Proposal in the writer's words, one sentence per op, named out of the
+ * Plan on screen. */
 export function describeProposal(plan: Plan, ops: Proposal): string[] {
 	const { section, reference, scope } = planNames(plan)
 
-	// A structural op states exactly one of the two, so the branch not taken is
-	// the one the op left out — `afterId: null` is first child and
-	// `beforeId: null` is last.
+	// A structural op states exactly one of the two — ops.ts. Null means an end
+	// rather than a neighbour: `afterId` first child, `beforeId` last.
 	const anchored = (parentId: string | null, op: Anchor) => {
 		if (op.beforeId !== undefined) {
 			return op.beforeId === null ? lastIn(parentId) : `before ${section(op.beforeId)}`

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -32,9 +32,7 @@ type AnyToolPart = ToolUIPart | DynamicToolUIPart
  * This is what parks a turn. Cloudflare's `ai-chat` enforces batch completeness
  * server-side with **no orphan timeout** (§11), so a call the writer neither
  * Accepts nor Declines stalls the conversation with nothing on screen to say
- * so. The composer reads this and says it. A count, because which tool parked
- * the turn changes nothing the writer can do about it: the cards are in the
- * transcript either way.
+ * so. The composer reads this and says it.
  */
 export function waitingCount(messages: readonly UIMessage[]): number {
 	let waiting = 0

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -1,6 +1,6 @@
 import { useAgentChat } from '@cloudflare/ai-chat/react'
 import type { UIMessage } from 'ai'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { proposePlanChangeTool } from '../../shared/chat'
 import type { Plan } from '../../shared/plan'
@@ -13,8 +13,7 @@ import {
 	type ProposalCall,
 	type Refusals,
 	ruleProposal,
-	type WaitingCall,
-	waitingCalls,
+	waitingCount,
 } from './proposals'
 
 /**
@@ -38,9 +37,9 @@ export type ChatHandle = {
 	messages: UIMessage[]
 	/** A turn is in flight, whether the writer started it or the server did. */
 	busy: boolean
-	/** Every suspended tool call. While this is not empty
-	 * the turn is parked and the composer says so — §11. */
-	waiting: WaitingCall[]
+	/** How many tool calls are suspended. While this is not 0 the turn is parked
+	 * and the composer says so — §11. */
+	waiting: number
 	/** Why an Accept did not land, by tool call id. */
 	refusals: Refusals
 	/** The Offers the turns in this transcript recorded. */
@@ -76,63 +75,57 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 	// A research turn writes rows this client never asked for, and nothing on the
 	// socket announces a row — §3. The ids the transcript names are what says the
 	// set moved.
+	//
+	// The first set it names is skipped: that is the persisted transcript
+	// arriving, and the Ledger's own read on mount already covers those rows. Only
+	// a turn that records something after that is worth a second RPC.
 	const recorded = recordedOfferIds(messages).join(' ')
+	const seen = useRef<string | null>(null)
 	const { reload } = ledger
 	useEffect(() => {
-		if (recorded !== '') reload()
+		if (recorded === '') return
+
+		const first = seen.current === null
+		seen.current = recorded
+		if (!first) reload()
 	}, [recorded, reload])
 
-	const { edit } = connection
-	const rule = useCallback(
-		(call: ProposalCall, accepted: boolean) => {
-			// Through the Plan's one writer, like every other Plan edit: it holds the
-			// Plan the writer sees, debounces, and refuses an update over an unsent
-			// write. A second writer around it would undo what is on screen — §3.
-			const ruling = ruleProposal({
-				call,
-				accepted,
-				edit,
-				refusal: refusals[call.toolCallId] ?? null,
-			})
+	const rule = (call: ProposalCall, accepted: boolean) => {
+		// Through the Plan's one writer, like every other Plan edit: it holds the
+		// Plan the writer sees, debounces, and refuses an update over an unsent
+		// write. A second writer around it would undo what is on screen — §3.
+		const ruling = ruleProposal({
+			call,
+			accepted,
+			edit: connection.edit,
+			refusal: refusals[call.toolCallId] ?? null,
+		})
 
-			setRefusals((was) => afterRuling(was, call.toolCallId, ruling.refusal))
-			if (ruling.answer === null) return
+		setRefusals((was) => afterRuling(was, call.toolCallId, ruling.refusal))
+		if (ruling.answer === null) return
 
-			// No await. The AI SDK docs warn twice about deadlock.
-			addToolOutput({
-				toolCallId: call.toolCallId,
-				toolName: proposePlanChangeTool,
-				...('output' in ruling.answer
-					? { output: ruling.answer.output }
-					: { state: 'output-error' as const, errorText: ruling.answer.errorText }),
-			})
-		},
-		[addToolOutput, edit, refusals],
-	)
-
-	const accept = useCallback((call: ProposalCall) => rule(call, true), [rule])
-	const decline = useCallback((call: ProposalCall) => rule(call, false), [rule])
-
-	const { sendMessage } = chat
-	const send = useCallback(
-		(text: string) => {
-			const said = text.trim()
-			if (said === '') return
-
-			sendMessage({ text: said })
-		},
-		[sendMessage],
-	)
+		// No await. The AI SDK docs warn twice about deadlock.
+		addToolOutput({
+			toolCallId: call.toolCallId,
+			toolName: proposePlanChangeTool,
+			...('output' in ruling.answer
+				? { output: ruling.answer.output }
+				: { state: 'output-error' as const, errorText: ruling.answer.errorText }),
+		})
+	}
 
 	return {
 		messages,
+		send: (text: string) => {
+			const said = text.trim()
+			if (said !== '') chat.sendMessage({ text: said })
+		},
+		accept: (call: ProposalCall) => rule(call, true),
+		decline: (call: ProposalCall) => rule(call, false),
 		busy: chat.isStreaming || chat.isRecovering || chat.status === 'submitted',
-		waiting: waitingCalls(messages),
+		waiting: waitingCount(messages),
 		refusals,
 		ledger,
-		send,
-		accept,
-		decline,
 		failure: chat.error?.message ?? chat.connectionError?.message ?? null,
 	}
 }

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -95,16 +95,19 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 		})
 	}
 
+	const waiting = waitingCount(messages)
+
 	return {
 		messages,
+		// A turn sent over an unanswered call is refused server-side — §11.
 		send: (text: string) => {
 			const said = text.trim()
-			if (said !== '') chat.sendMessage({ text: said })
+			if (said !== '' && waiting === 0) chat.sendMessage({ text: said })
 		},
 		accept: (call: ProposalCall) => rule(call, true),
 		decline: (call: ProposalCall) => rule(call, false),
 		busy: chat.isStreaming || chat.isRecovering || chat.status === 'submitted',
-		waiting: waitingCount(messages),
+		waiting,
 		refusals,
 		ledger,
 		failure: chat.error?.message ?? chat.connectionError?.message ?? null,

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -17,28 +17,21 @@ import {
 } from './proposals'
 
 /**
- * One Chat, on the socket the Plan already holds — docs/architecture.md §6 and
- * §8. The Chat proposes and the client applies: Accepting runs the Proposal's
- * ops through the Plan's one writer, which is the same `edit` every Plan change
- * makes, and then answers the tool call.
+ * One Chat on the socket the Plan already holds — §6 and §8. A ruling applies
+ * the ops through `edit` and then answers the tool call.
  *
- * Three API details this leans on, each easy to get wrong:
- *
- * - `addToolOutput`, not the deprecated `addToolResult`, and **never awaited** —
- *   the AI SDK docs warn twice about deadlock.
- * - A Decline answers with `is_error: true`, which is `state: 'output-error'`
- *   plus the reason in `errorText`.
- * - `addToolApprovalResponse` and `needsApproval` are for a server-side
- *   `execute` this product does not have (§6). Both rulings go through
- *   `addToolOutput`.
+ * Three SDK traps sit under this. `addToolResult` is deprecated in favour of
+ * `addToolOutput`, and awaiting either deadlocks. A rejection is
+ * `state: 'output-error'` with the reason in `errorText`. And
+ * `addToolApprovalResponse` and `needsApproval` gate a server-side `execute`
+ * this product does not have, so both rulings go out as tool output.
  */
 
 export type ChatHandle = {
 	messages: UIMessage[]
 	/** A turn is in flight, whether the writer started it or the server did. */
 	busy: boolean
-	/** How many tool calls are suspended. While this is not 0 the turn is parked
-	 * and the composer says so — §11. */
+	/** Suspended tool calls; above zero the turn is parked — §11. */
 	waiting: number
 	/** Why an Accept did not land, by tool call id. */
 	refusals: Refusals
@@ -56,10 +49,8 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 	const ledger = useOfferLedger()
 	const [refusals, setRefusals] = useState<Refusals>({})
 
-	// The turn is about the Plan the writer is looking at, which the body carries
-	// because `body` is request-only where `metadata` re-rides every turn (§6).
-	// Held in a ref because the body is built when the turn is sent, not when
-	// this renders.
+	// A ref, because the body is built when the turn is sent rather than when
+	// this renders. The Plan goes in `body` and not `metadata` — §6.
 	const held = useRef<Plan | null>(connection.plan)
 	useEffect(() => {
 		held.current = connection.plan
@@ -72,13 +63,9 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 
 	const { messages, addToolOutput } = chat
 
-	// A research turn writes rows this client never asked for, and nothing on the
-	// socket announces a row — §3. The ids the transcript names are what says the
-	// set moved.
-	//
-	// The first set it names is skipped: that is the persisted transcript
-	// arriving, and the Ledger's own read on mount already covers those rows. Only
-	// a turn that records something after that is worth a second RPC.
+	// Nothing on the socket announces a new Offer row (§3), so a turn naming ids
+	// the Ledger has not seen is the signal to read again. The first set is the
+	// persisted transcript landing, which the Ledger's own read already covers.
 	const recorded = recordedOfferIds(messages).join(' ')
 	const seen = useRef<string | null>(null)
 	const { reload } = ledger
@@ -91,9 +78,6 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 	}, [recorded, reload])
 
 	const rule = (call: ProposalCall, accepted: boolean) => {
-		// Through the Plan's one writer, like every other Plan edit: it holds the
-		// Plan the writer sees, debounces, and refuses an update over an unsent
-		// write. A second writer around it would undo what is on screen — §3.
 		const ruling = ruleProposal({
 			call,
 			accepted,
@@ -104,7 +88,7 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 		setRefusals((was) => afterRuling(was, call.toolCallId, ruling.refusal))
 		if (ruling.answer === null) return
 
-		// No await. The AI SDK docs warn twice about deadlock.
+		// Awaiting this deadlocks.
 		addToolOutput({
 			toolCallId: call.toolCallId,
 			toolName: proposePlanChangeTool,

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -1,0 +1,138 @@
+import { useAgentChat } from '@cloudflare/ai-chat/react'
+import type { UIMessage } from 'ai'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import { proposePlanChangeTool } from '../../shared/chat'
+import type { Plan } from '../../shared/plan'
+import { useArticle } from '../lib/article'
+import type { ArticleSocket } from '../lib/useArticleAgent'
+import { useOfferLedger, type OfferLedgerHandle } from '../lib/useOfferLedger'
+import { recordedOfferIds } from './offers'
+import {
+	afterRuling,
+	type ProposalCall,
+	type Refusals,
+	ruleProposal,
+	type WaitingCall,
+	waitingCalls,
+} from './proposals'
+
+/**
+ * One Chat, on the socket the Plan already holds — docs/architecture.md §6 and
+ * §8. The Chat proposes and the client applies: Accepting runs the Proposal's
+ * ops through the Plan's one writer, which is the same `edit` every Plan change
+ * makes, and then answers the tool call.
+ *
+ * Three API details this leans on, each easy to get wrong:
+ *
+ * - `addToolOutput`, not the deprecated `addToolResult`, and **never awaited** —
+ *   the AI SDK docs warn twice about deadlock.
+ * - A Decline answers with `is_error: true`, which is `state: 'output-error'`
+ *   plus the reason in `errorText`.
+ * - `addToolApprovalResponse` and `needsApproval` are for a server-side
+ *   `execute` this product does not have (§6). Both rulings go through
+ *   `addToolOutput`.
+ */
+
+export type ChatHandle = {
+	messages: UIMessage[]
+	/** A turn is in flight, whether the writer started it or the server did. */
+	busy: boolean
+	/** Every suspended tool call. While this is not empty
+	 * the turn is parked and the composer says so — §11. */
+	waiting: WaitingCall[]
+	/** Why an Accept did not land, by tool call id. */
+	refusals: Refusals
+	/** The Offers the turns in this transcript recorded. */
+	ledger: OfferLedgerHandle
+	send: (text: string) => void
+	accept: (call: ProposalCall) => void
+	decline: (call: ProposalCall) => void
+	/** The connection or the turn failed, in one sentence. */
+	failure: string | null
+}
+
+export function useArticleChat(agent: ArticleSocket): ChatHandle {
+	const { plan: connection } = useArticle()
+	const ledger = useOfferLedger()
+	const [refusals, setRefusals] = useState<Refusals>({})
+
+	// The turn is about the Plan the writer is looking at, which the body carries
+	// because `body` is request-only where `metadata` re-rides every turn (§6).
+	// Held in a ref because the body is built when the turn is sent, not when
+	// this renders.
+	const held = useRef<Plan | null>(connection.plan)
+	useEffect(() => {
+		held.current = connection.plan
+	})
+
+	const chat = useAgentChat({
+		agent,
+		body: () => (held.current === null ? {} : { plan: held.current }),
+	})
+
+	const { messages, addToolOutput } = chat
+
+	// A research turn writes rows this client never asked for, and nothing on the
+	// socket announces a row — §3. The ids the transcript names are what says the
+	// set moved.
+	const recorded = recordedOfferIds(messages).join(' ')
+	const { reload } = ledger
+	useEffect(() => {
+		if (recorded !== '') reload()
+	}, [recorded, reload])
+
+	const { edit } = connection
+	const rule = useCallback(
+		(call: ProposalCall, accepted: boolean) => {
+			// Through the Plan's one writer, like every other Plan edit: it holds the
+			// Plan the writer sees, debounces, and refuses an update over an unsent
+			// write. A second writer around it would undo what is on screen — §3.
+			const ruling = ruleProposal({
+				call,
+				accepted,
+				edit,
+				refusal: refusals[call.toolCallId] ?? null,
+			})
+
+			setRefusals((was) => afterRuling(was, call.toolCallId, ruling.refusal))
+			if (ruling.answer === null) return
+
+			// No await. The AI SDK docs warn twice about deadlock.
+			addToolOutput({
+				toolCallId: call.toolCallId,
+				toolName: proposePlanChangeTool,
+				...('output' in ruling.answer
+					? { output: ruling.answer.output }
+					: { state: 'output-error' as const, errorText: ruling.answer.errorText }),
+			})
+		},
+		[addToolOutput, edit, refusals],
+	)
+
+	const accept = useCallback((call: ProposalCall) => rule(call, true), [rule])
+	const decline = useCallback((call: ProposalCall) => rule(call, false), [rule])
+
+	const { sendMessage } = chat
+	const send = useCallback(
+		(text: string) => {
+			const said = text.trim()
+			if (said === '') return
+
+			sendMessage({ text: said })
+		},
+		[sendMessage],
+	)
+
+	return {
+		messages,
+		busy: chat.isStreaming || chat.isRecovering || chat.status === 'submitted',
+		waiting: waitingCalls(messages),
+		refusals,
+		ledger,
+		send,
+		accept,
+		decline,
+		failure: chat.error?.message ?? chat.connectionError?.message ?? null,
+	}
+}

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -29,18 +29,15 @@ import {
 
 export type ChatHandle = {
 	messages: UIMessage[]
-	/** A turn is in flight, whether the writer started it or the server did. */
+	/** True for a server-driven turn as well as the writer's own. */
 	busy: boolean
 	/** Suspended tool calls; above zero the turn is parked — §11. */
 	waiting: number
-	/** Why an Accept did not land, by tool call id. */
 	refusals: Refusals
-	/** The Offers the turns in this transcript recorded. */
 	ledger: OfferLedgerHandle
 	send: (text: string) => void
 	accept: (call: ProposalCall) => void
 	decline: (call: ProposalCall) => void
-	/** The connection or the turn failed, in one sentence. */
 	failure: string | null
 }
 

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -83,11 +83,7 @@ export function ChatComposer({
 	}
 
 	return (
-		// A Panel that scrolls puts this in its `footer` slot, which is what keeps
-		// it reachable — the composer itself only says it is the end of the Panel.
-		<div
-			className={cx('mt-auto flex flex-col gap-1.5 border-t border-edge pt-2', className)}
-		>
+		<div className={cx('mt-auto flex flex-col gap-1.5 pt-1', className)}>
 			{blocked === null ? null : <Notice>{blocked}</Notice>}
 			<div className="flex items-center gap-2">
 				{leading}

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -43,12 +43,11 @@ export interface ChatComposerProps {
 	placeholder?: string
 	/** Extra controls to the left of send — the ledger toggle, attachments. */
 	leading?: ReactNode
-	/** Sends what the writer typed. A screen with none renders a still frame. */
+	/** Absent on the wireframe screens, which render a still frame. */
 	onSend?: (text: string) => void
 	/** Why the composer will not send, and null when it will. A Proposal nobody
 	 * ruled on is the case worth wording — nothing expires it (§11). */
 	blocked?: string | null
-	/** Held while a turn is in flight. */
 	disabled?: boolean
 	className?: string
 }

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { type KeyboardEvent, type ReactNode, useState } from 'react'
 
 import { cx } from '../lib/cx'
 import { Button } from './Button'
@@ -18,7 +18,7 @@ export function ChatMessage({ from, children, className }: ChatMessageProps) {
 		return (
 			<div
 				className={cx(
-					'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-[0.8125rem] leading-relaxed text-ink',
+					'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-[0.8125rem] leading-relaxed whitespace-pre-wrap text-ink',
 					className,
 				)}
 			>
@@ -28,7 +28,10 @@ export function ChatMessage({ from, children, className }: ChatMessageProps) {
 	}
 	return (
 		<div
-			className={cx('max-w-[95%] text-[0.8125rem] leading-relaxed text-ink', className)}
+			className={cx(
+				'max-w-[95%] text-[0.8125rem] leading-relaxed whitespace-pre-wrap text-ink',
+				className,
+			)}
 		>
 			{children}
 		</div>
@@ -39,21 +42,80 @@ export interface ChatComposerProps {
 	placeholder?: string
 	/** Extra controls to the left of send — the ledger toggle, attachments. */
 	leading?: ReactNode
+	/** Sends what the writer typed. A screen with none renders a still frame. */
+	onSend?: (text: string) => void
+	/**
+	 * Why the composer will not send, and null when it will. A parked tool batch
+	 * is the case that matters: Cloudflare's batch-completeness rule has no
+	 * orphan timeout, so a Proposal nobody ruled on stalls the turn — say it here
+	 * rather than letting the composer sit dead (docs/architecture.md §11).
+	 */
+	blocked?: string | null
+	/** Held while a turn is in flight, which needs no sentence to explain it. */
+	disabled?: boolean
 	className?: string
 }
 
 export function ChatComposer({
 	placeholder = 'Ask, argue, or paste something in…',
 	leading,
+	onSend,
+	blocked = null,
+	disabled = false,
 	className,
 }: ChatComposerProps) {
+	const [said, setSaid] = useState('')
+	const stopped = blocked !== null || disabled || onSend === undefined
+
+	const send = () => {
+		if (stopped || onSend === undefined || said.trim() === '') return
+
+		onSend(said)
+		setSaid('')
+	}
+
+	const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+		if (event.key !== 'Enter' || event.shiftKey) return
+
+		event.preventDefault()
+		send()
+	}
+
 	return (
-		<div className={cx('mt-auto flex items-center gap-2 pt-1', className)}>
-			{leading}
-			<div className="flex h-9 flex-1 items-center rounded-md border border-edge bg-surface px-2.5 text-[0.8125rem] text-faint">
-				{placeholder}
+		// Sticky, because the Panel scrolls its own Y and a composer that scrolled
+		// away with the transcript would be the one control on the Panel you
+		// cannot reach. `bg-inherit` carries the Panel's own background under it.
+		// The Panel's bottom padding is inside the scrollport, so a Panel that
+		// scrolls hands that padding to the composer — see `ChatPanel`.
+		<div
+			className={cx(
+				'sticky bottom-0 z-10 mt-auto flex flex-col gap-1.5 border-t border-edge bg-inherit pt-2',
+				className,
+			)}
+		>
+			{blocked === null ? null : (
+				<p className="rounded-md border border-accent-edge bg-accent-soft px-2 py-1.5 text-[0.75rem] text-accent-ink">
+					{blocked}
+				</p>
+			)}
+			<div className="flex items-center gap-2">
+				{leading}
+				<div className="flex h-9 flex-1 items-center rounded-md border border-edge bg-surface px-2.5 text-[0.8125rem]">
+					<input
+						aria-label="Message the guide"
+						className="min-w-0 flex-1 bg-transparent text-ink outline-none placeholder:text-faint"
+						disabled={stopped}
+						onChange={(event) => setSaid(event.target.value)}
+						onKeyDown={onKeyDown}
+						placeholder={placeholder}
+						type="text"
+						value={said}
+					/>
+				</div>
+				<Button size="sm" disabled={stopped || said.trim() === ''} onClick={send}>
+					send
+				</Button>
 			</div>
-			<Button size="sm">send</Button>
 		</div>
 	)
 }
@@ -66,4 +128,15 @@ export interface ChatRepliesProps {
 /** The reply chips a guide turn can end with. */
 export function ChatReplies({ children, className }: ChatRepliesProps) {
 	return <div className={cx('flex flex-wrap gap-1.5', className)}>{children}</div>
+}
+
+export interface ChatNoteProps {
+	children: ReactNode
+	className?: string
+}
+
+/** What the Chat did rather than what it said: a Proposal ruled on, a turn
+ * looking something up. Quiet, because it is a record and not a turn. */
+export function ChatNote({ children, className }: ChatNoteProps) {
+	return <p className={cx('text-[0.6875rem] text-faint', className)}>{children}</p>
 }

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -2,6 +2,7 @@ import { type KeyboardEvent, type ReactNode, useState } from 'react'
 
 import { cx } from '../lib/cx'
 import { Button } from './Button'
+import { Notice } from './Notice'
 
 export interface ChatMessageProps {
 	from: 'me' | 'guide'
@@ -82,22 +83,12 @@ export function ChatComposer({
 	}
 
 	return (
-		// Sticky, because the Panel scrolls its own Y and a composer that scrolled
-		// away with the transcript would be the one control on the Panel you
-		// cannot reach. `bg-inherit` carries the Panel's own background under it.
-		// The Panel's bottom padding is inside the scrollport, so a Panel that
-		// scrolls hands that padding to the composer — see `ChatPanel`.
+		// A Panel that scrolls puts this in its `footer` slot, which is what keeps
+		// it reachable — the composer itself only says it is the end of the Panel.
 		<div
-			className={cx(
-				'sticky bottom-0 z-10 mt-auto flex flex-col gap-1.5 border-t border-edge bg-inherit pt-2',
-				className,
-			)}
+			className={cx('mt-auto flex flex-col gap-1.5 border-t border-edge pt-2', className)}
 		>
-			{blocked === null ? null : (
-				<p className="rounded-md border border-accent-edge bg-accent-soft px-2 py-1.5 text-[0.75rem] text-accent-ink">
-					{blocked}
-				</p>
-			)}
+			{blocked === null ? null : <Notice>{blocked}</Notice>}
 			<div className="flex items-center gap-2">
 				{leading}
 				<div className="flex h-9 flex-1 items-center rounded-md border border-edge bg-surface px-2.5 text-[0.8125rem]">

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -45,14 +45,10 @@ export interface ChatComposerProps {
 	leading?: ReactNode
 	/** Sends what the writer typed. A screen with none renders a still frame. */
 	onSend?: (text: string) => void
-	/**
-	 * Why the composer will not send, and null when it will. A parked tool batch
-	 * is the case that matters: Cloudflare's batch-completeness rule has no
-	 * orphan timeout, so a Proposal nobody ruled on stalls the turn — say it here
-	 * rather than letting the composer sit dead (docs/architecture.md §11).
-	 */
+	/** Why the composer will not send, and null when it will. A Proposal nobody
+	 * ruled on is the case worth wording — nothing expires it (§11). */
 	blocked?: string | null
-	/** Held while a turn is in flight, which needs no sentence to explain it. */
+	/** Held while a turn is in flight. */
 	disabled?: boolean
 	className?: string
 }

--- a/src/client/components/Notice.tsx
+++ b/src/client/components/Notice.tsx
@@ -7,14 +7,8 @@ export interface NoticeProps {
 	className?: string
 }
 
-/**
- * One sentence saying a thing did not land: a refused edit, a write the Article
- * Agent rejected, a composer that will not send.
- *
- * Accented, which is the app's one way of asking for the writer's attention —
- * `foundations/Accent.mdx`. It is a component rather than a copied class string
- * so the several places that say it cannot drift apart on their padding.
- */
+/** One sentence saying a thing did not land: a refused edit, a write the Article
+ * Agent rejected, a composer that will not send. */
 export function Notice({ children, className }: NoticeProps) {
 	return (
 		<p

--- a/src/client/components/Notice.tsx
+++ b/src/client/components/Notice.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react'
+
+import { cx } from '../lib/cx'
+
+export interface NoticeProps {
+	children: ReactNode
+	className?: string
+}
+
+/**
+ * One sentence saying a thing did not land: a refused edit, a write the Article
+ * Agent rejected, a composer that will not send.
+ *
+ * Accented, which is the app's one way of asking for the writer's attention —
+ * `foundations/Accent.mdx`. It is a component rather than a copied class string
+ * so the several places that say it cannot drift apart on their padding.
+ */
+export function Notice({ children, className }: NoticeProps) {
+	return (
+		<p
+			className={cx(
+				'rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink',
+				className,
+			)}
+		>
+			{children}
+		</p>
+	)
+}

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -10,10 +10,6 @@ export interface PanelProps {
 	grow?: number
 	divider?: 'left' | 'right' | 'none'
 	padded?: boolean
-	/** Pinned to the bottom while the Panel scrolls past it — the Chat composer.
-	 * The Panel gives up its own bottom padding to it, because that padding is
-	 * inside the scrollport and content scrolls into it. */
-	footer?: ReactNode
 	children?: ReactNode
 	className?: string
 	style?: CSSProperties
@@ -28,9 +24,10 @@ export interface PanelProps {
  * side. It needs a height to bite on: the Frame body gives it one, and a Panel
  * inside a body with no height simply grows as it always did.
  *
- * A control that has to stay reachable while it scrolls goes in `footer`, which
- * owns the padding handoff a sticky element needs. Passing one as a child
- * instead leaves it to scroll away.
+ * Chrome on an edge — a header that stays put, a composer that stays reachable —
+ * goes in an unpadded Panel: `padded={false}`, a `flex-1 p-3.5` body, and a
+ * full-bleed bar that owns its own padding and is `sticky` if it must be.
+ * `LedgerDrawerScreen` and `ChatPanel` are the two that do it.
  */
 export function Panel({
 	variant = 'surface',
@@ -38,7 +35,6 @@ export function Panel({
 	grow = 1,
 	divider = 'none',
 	padded = true,
-	footer,
 	children,
 	className,
 	style,
@@ -51,21 +47,12 @@ export function Panel({
 				variant === 'sunk' ? 'bg-sunk' : 'bg-surface',
 				divider === 'left' && 'border-l border-edge',
 				divider === 'right' && 'border-r border-edge',
-				padded && (footer === undefined ? 'gap-3.5 p-3.5' : 'gap-3.5 p-3.5 pb-0'),
+				padded && 'gap-3.5 p-3.5',
 				className,
 			)}
 			style={{ width, flex: width ? '0 0 auto' : grow, ...style }}
 		>
 			{children}
-			{footer === undefined ? null : (
-				// `bg-inherit` carries the Panel's own background under it, and the
-				// bottom padding is the Panel's, handed over above.
-				<div
-					className={cx('sticky bottom-0 z-10 mt-auto bg-inherit', padded && 'pb-3.5')}
-				>
-					{footer}
-				</div>
-			)}
 		</section>
 	)
 }

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -23,11 +23,6 @@ export interface PanelProps {
  * beside it, which is what lets two Panels of different lengths sit side by
  * side. It needs a height to bite on: the Frame body gives it one, and a Panel
  * inside a body with no height simply grows as it always did.
- *
- * Chrome on an edge — a header that stays put, a composer that stays reachable —
- * goes in an unpadded Panel: `padded={false}`, a `flex-1 p-3.5` body, and a
- * full-bleed bar that owns its own padding and is `sticky` if it must be.
- * `LedgerDrawerScreen` and `ChatPanel` are the two that do it.
  */
 export function Panel({
 	variant = 'surface',

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -10,6 +10,10 @@ export interface PanelProps {
 	grow?: number
 	divider?: 'left' | 'right' | 'none'
 	padded?: boolean
+	/** Pinned to the bottom while the Panel scrolls past it — the Chat composer.
+	 * The Panel gives up its own bottom padding to it, because that padding is
+	 * inside the scrollport and content scrolls into it. */
+	footer?: ReactNode
 	children?: ReactNode
 	className?: string
 	style?: CSSProperties
@@ -23,6 +27,10 @@ export interface PanelProps {
  * beside it, which is what lets two Panels of different lengths sit side by
  * side. It needs a height to bite on: the Frame body gives it one, and a Panel
  * inside a body with no height simply grows as it always did.
+ *
+ * A control that has to stay reachable while it scrolls goes in `footer`, which
+ * owns the padding handoff a sticky element needs. Passing one as a child
+ * instead leaves it to scroll away.
  */
 export function Panel({
 	variant = 'surface',
@@ -30,6 +38,7 @@ export function Panel({
 	grow = 1,
 	divider = 'none',
 	padded = true,
+	footer,
 	children,
 	className,
 	style,
@@ -42,12 +51,21 @@ export function Panel({
 				variant === 'sunk' ? 'bg-sunk' : 'bg-surface',
 				divider === 'left' && 'border-l border-edge',
 				divider === 'right' && 'border-r border-edge',
-				padded && 'gap-3.5 p-3.5',
+				padded && (footer === undefined ? 'gap-3.5 p-3.5' : 'gap-3.5 p-3.5 pb-0'),
 				className,
 			)}
 			style={{ width, flex: width ? '0 0 auto' : grow, ...style }}
 		>
 			{children}
+			{footer === undefined ? null : (
+				// `bg-inherit` carries the Panel's own background under it, and the
+				// bottom padding is the Panel's, handed over above.
+				<div
+					className={cx('sticky bottom-0 z-10 mt-auto bg-inherit', padded && 'pb-3.5')}
+				>
+					{footer}
+				</div>
+			)}
 		</section>
 	)
 }

--- a/src/client/lib/article.ts
+++ b/src/client/lib/article.ts
@@ -9,7 +9,7 @@ import type { PlanConnection } from '../plan/usePlan'
  * builds it; the Panels read it.
  */
 
-/** The Article Agent's three writer-facing `@callable` methods. */
+/** The Article Agent's writer-facing `@callable` methods. */
 export type OfferStore = {
 	listOffers(): Promise<Offer[]>
 	setOfferDisposition(id: string, ruling: Ruling): Promise<Offer>
@@ -18,7 +18,6 @@ export type OfferStore = {
 
 export type Article = {
 	offers: OfferStore
-	/** The Plan, and the one writer every Plan edit goes through. */
 	plan: PlanConnection
 }
 

--- a/src/client/lib/article.ts
+++ b/src/client/lib/article.ts
@@ -4,12 +4,9 @@ import type { Offer, Ruling } from '../../shared/offer'
 import type { PlanConnection } from '../plan/usePlan'
 
 /**
- * The seam one Article Agent arrives through, in two stores because the Plan and
- * the Offers are held apart on the server — §3, rules 1 and 2. Both halves are
- * shaped as `usePlanChannel` and `useAgent`'s stub already return them.
- *
- * One Provider per Article, above every Panel, because one Article Agent means
- * one socket: `useArticleAgent` builds this and the Panels read it.
+ * The seam one Article Agent arrives through, in two stores because the server
+ * holds the Plan and the Offers apart — §3, rules 1 and 2. `useArticleAgent`
+ * builds it; the Panels read it.
  */
 
 /** The Article Agent's three writer-facing `@callable` methods. */

--- a/src/client/lib/article.ts
+++ b/src/client/lib/article.ts
@@ -1,7 +1,6 @@
 import { createContext, useContext } from 'react'
 
 import type { Offer, Ruling } from '../../shared/offer'
-import { emptyPlan, type Plan } from '../../shared/plan'
 import type { PlanConnection } from '../plan/usePlan'
 
 /**
@@ -38,17 +37,3 @@ export function useArticle(): Article {
 
 	return article
 }
-
-/**
- * The Plan on screen, and an empty one while the first state update is still in
- * flight. A list reads the empty Plan as an empty list, which is what a new
- * Article holds anyway — the Panel that must say "Opening the Plan…" rather
- * than draw an empty one reads `plan.plan` and gates on null itself.
- */
-export function useArticlePlan(): Plan {
-	return useArticle().plan.plan ?? opening
-}
-
-/** One instance, so a render while the socket settles is not a new Plan every
- * time. Nothing writes to it: the writer works on a copy. */
-const opening = emptyPlan()

--- a/src/client/lib/article.ts
+++ b/src/client/lib/article.ts
@@ -1,13 +1,16 @@
 import { createContext, useContext } from 'react'
 
 import type { Offer, Ruling } from '../../shared/offer'
-import type { Plan } from '../../shared/plan'
-import type { PlanEdit } from '../plan/writer'
+import { emptyPlan, type Plan } from '../../shared/plan'
+import type { PlanConnection } from '../plan/usePlan'
 
 /**
  * The seam one Article Agent arrives through, in two stores because the Plan and
  * the Offers are held apart on the server — §3, rules 1 and 2. Both halves are
- * shaped as `usePlan` and `useAgent`'s stub already return them.
+ * shaped as `usePlanChannel` and `useAgent`'s stub already return them.
+ *
+ * One Provider per Article, above every Panel, because one Article Agent means
+ * one socket: `useArticleAgent` builds this and the Panels read it.
  */
 
 /** The Article Agent's three writer-facing `@callable` methods. */
@@ -19,9 +22,8 @@ export type OfferStore = {
 
 export type Article = {
 	offers: OfferStore
-	plan: Plan
-	/** The op vocabulary every other Plan write uses. */
-	edit: (edit: PlanEdit) => void
+	/** The Plan, and the one writer every Plan edit goes through. */
+	plan: PlanConnection
 }
 
 const ArticleContext = createContext<Article | null>(null)
@@ -36,3 +38,17 @@ export function useArticle(): Article {
 
 	return article
 }
+
+/**
+ * The Plan on screen, and an empty one while the first state update is still in
+ * flight. A list reads the empty Plan as an empty list, which is what a new
+ * Article holds anyway — the Panel that must say "Opening the Plan…" rather
+ * than draw an empty one reads `plan.plan` and gates on null itself.
+ */
+export function useArticlePlan(): Plan {
+	return useArticle().plan.plan ?? opening
+}
+
+/** One instance, so a render while the socket settles is not a new Plan every
+ * time. Nothing writes to it: the writer works on a copy. */
+const opening = emptyPlan()

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -26,7 +26,11 @@ export type ArticleConnection = {
 }
 
 export function useArticleAgent(articleId: string): ArticleConnection {
-	const channel = usePlanChannel()
+	// One ref, read by both halves: the client is replaced on every reconnect, and
+	// an `OfferStore` or a writer that closed over one generation would keep
+	// sending to a socket that is gone.
+	const socket = useRef<ArticleSocket | null>(null)
+	const channel = usePlanChannel(() => socket.current)
 
 	const agent = useAgent<Plan>({
 		agent: 'article-agent',
@@ -35,24 +39,35 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 		onMessage: channel.onMessage,
 	})
 
-	// Held rather than closed over: the client is replaced on every reconnect,
-	// and an `OfferStore` that changed identity with it would make the Ledger
-	// re-read its rows on every render.
-	const socket = useRef(agent)
 	useEffect(() => {
 		socket.current = agent
-		channel.attach(agent)
 	})
 
+	// `[]`, so the store keeps its identity across reconnects: the Ledger reads
+	// its rows once per store, and a new one on every render would re-read them.
 	const offers = useMemo<OfferStore>(
 		() => ({
-			listOffers: () => socket.current.call<Offer[]>('listOffers'),
+			listOffers: () => call<Offer[]>(socket, 'listOffers'),
 			setOfferDisposition: (id: string, ruling: Ruling) =>
-				socket.current.call<Offer>('setOfferDisposition', [id, ruling]),
-			restoreOffer: (id: string) => socket.current.call<Offer>('restoreOffer', [id]),
+				call<Offer>(socket, 'setOfferDisposition', [id, ruling]),
+			restoreOffer: (id: string) => call<Offer>(socket, 'restoreOffer', [id]),
 		}),
 		[],
 	)
 
 	return { article: { offers, plan: channel.connection }, agent }
+}
+
+/** An RPC on whichever socket is current. The first render has none, and a
+ * caller reaching one that early is a bug rather than a state to render. */
+function call<T>(
+	socket: { current: ArticleSocket | null },
+	method: string,
+	args?: unknown[],
+): Promise<T> {
+	if (socket.current === null) {
+		return Promise.reject(new Error('The Article Agent is not connected yet.'))
+	}
+
+	return socket.current.call<T>(method, args)
 }

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -7,15 +7,10 @@ import { usePlanChannel } from '../plan/usePlan'
 import type { Article, OfferStore } from './article'
 
 /**
- * One Article Agent, one socket, held above the Panels — docs/architecture.md
- * §8. The socket is multiplexed: it carries the Plan blob, the `@callable` RPC
- * the Offers are read over, and the Chat turn, all on one wire. Two Panels
- * opening their own would mean two Plan writers against a blob that may only
- * have one (§3, rule 1).
- *
- * Mounting this and laying the Panels out is issue #29. What it returns is the
- * `ArticleProvider`'s value plus the socket itself, which is what
- * `useAgentChat` takes.
+ * Opens one Article Agent and hands out the three things that ride its one
+ * multiplexed socket: the Plan channel, an Offer store over `@callable` RPC, and
+ * the client itself for `useAgentChat` — §8. A second socket would mean a second
+ * Plan writer, which §3 rule 1 forbids.
  */
 
 export type ArticleSocket = ReturnType<typeof useAgent<Plan>>
@@ -26,9 +21,8 @@ export type ArticleConnection = {
 }
 
 export function useArticleAgent(articleId: string): ArticleConnection {
-	// One ref, read by both halves: the client is replaced on every reconnect, and
-	// an `OfferStore` or a writer that closed over one generation would keep
-	// sending to a socket that is gone.
+	// `useAgent` hands back a new client on each reconnect, so both halves read
+	// this rather than closing over one generation of it.
 	const socket = useRef<ArticleSocket | null>(null)
 	const channel = usePlanChannel(() => socket.current)
 
@@ -43,8 +37,8 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 		socket.current = agent
 	})
 
-	// `[]`, so the store keeps its identity across reconnects: the Ledger reads
-	// its rows once per store, and a new one on every render would re-read them.
+	// `[]` keeps the store's identity: `useOfferLedger` reads its rows once per
+	// store it is given.
 	const offers = useMemo<OfferStore>(
 		() => ({
 			listOffers: () => call<Offer[]>(socket, 'listOffers'),
@@ -58,8 +52,8 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 	return { article: { offers, plan: channel.connection }, agent }
 }
 
-/** An RPC on whichever socket is current. The first render has none, and a
- * caller reaching one that early is a bug rather than a state to render. */
+/** An RPC on whichever socket is current. Rejects on the first render, before
+ * `useAgent` has built one. */
 function call<T>(
 	socket: { current: ArticleSocket | null },
 	method: string,

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -1,0 +1,58 @@
+import { useAgent } from 'agents/react'
+import { useEffect, useMemo, useRef } from 'react'
+
+import type { Offer, Ruling } from '../../shared/offer'
+import type { Plan } from '../../shared/plan'
+import { usePlanChannel } from '../plan/usePlan'
+import type { Article, OfferStore } from './article'
+
+/**
+ * One Article Agent, one socket, held above the Panels — docs/architecture.md
+ * §8. The socket is multiplexed: it carries the Plan blob, the `@callable` RPC
+ * the Offers are read over, and the Chat turn, all on one wire. Two Panels
+ * opening their own would mean two Plan writers against a blob that may only
+ * have one (§3, rule 1).
+ *
+ * Mounting this and laying the Panels out is issue #29. What it returns is the
+ * `ArticleProvider`'s value plus the socket itself, which is what
+ * `useAgentChat` takes.
+ */
+
+export type ArticleSocket = ReturnType<typeof useAgent<Plan>>
+
+export type ArticleConnection = {
+	article: Article
+	agent: ArticleSocket
+}
+
+export function useArticleAgent(articleId: string): ArticleConnection {
+	const channel = usePlanChannel()
+
+	const agent = useAgent<Plan>({
+		agent: 'article-agent',
+		name: articleId,
+		onStateUpdate: channel.onStateUpdate,
+		onMessage: channel.onMessage,
+	})
+
+	// Held rather than closed over: the client is replaced on every reconnect,
+	// and an `OfferStore` that changed identity with it would make the Ledger
+	// re-read its rows on every render.
+	const socket = useRef(agent)
+	useEffect(() => {
+		socket.current = agent
+		channel.attach(agent)
+	})
+
+	const offers = useMemo<OfferStore>(
+		() => ({
+			listOffers: () => socket.current.call<Offer[]>('listOffers'),
+			setOfferDisposition: (id: string, ruling: Ruling) =>
+				socket.current.call<Offer>('setOfferDisposition', [id, ruling]),
+			restoreOffer: (id: string) => socket.current.call<Offer>('restoreOffer', [id]),
+		}),
+		[],
+	)
+
+	return { article: { offers, plan: channel.connection }, agent }
+}

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { offerLedger, type OfferLedger } from '../../shared/ledger'
 import type { Offer } from '../../shared/offer'
@@ -9,6 +9,10 @@ import { useArticle } from './article'
  * The Offer ledger, live. Rows are read once when the Panel opens, because
  * nothing tells a client a row changed — §3. It holds no Plan: Accepting writes
  * one through `edit` and reads nothing back.
+ *
+ * A research turn is the one thing that changes the list without the writer
+ * touching it, and it writes its rows inside the Article Agent. The Chat calls
+ * `reload` when a turn records some, which is the only signal there is.
  */
 
 export type OfferLedgerHandle = {
@@ -20,12 +24,18 @@ export type OfferLedgerHandle = {
 	accept: (offer: Offer) => void
 	decline: (offer: Offer) => void
 	restore: (offer: Offer) => void
+	/** Read the rows again, after a turn recorded some. */
+	reload: () => void
 }
 
 export function useOfferLedger(): OfferLedgerHandle {
-	const { offers: store, edit } = useArticle()
+	const { offers: store, plan } = useArticle()
+	const { edit } = plan
 	const [rows, setRows] = useState<Offer[] | null>(null)
 	const [failure, setFailure] = useState<string | null>(null)
+	const [reads, setReads] = useState(0)
+
+	const reload = useCallback(() => setReads((count) => count + 1), [])
 
 	useEffect(() => {
 		let live = true
@@ -42,7 +52,7 @@ export function useOfferLedger(): OfferLedgerHandle {
 		return () => {
 			live = false
 		}
-	}, [store])
+	}, [store, reads])
 
 	/** In place: a ruling does not change the recorded order. */
 	function replace(ruled: Offer) {
@@ -60,6 +70,7 @@ export function useOfferLedger(): OfferLedgerHandle {
 		ledger: offerLedger(rows ?? []),
 		loading: rows === null,
 		failure,
+		reload,
 
 		// Two writes against two stores, decoupled — §5. The Plan goes first and
 		// lands locally, because the copy is built from what the Offer says and

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -6,13 +6,9 @@ import { acceptOffer } from '../plan/edits'
 import { useArticle } from './article'
 
 /**
- * The Offer ledger, live. Rows are read once when the Panel opens, because
- * nothing tells a client a row changed — §3. It holds no Plan: Accepting writes
- * one through `edit` and reads nothing back.
- *
- * A research turn is the one thing that changes the list without the writer
- * touching it, and it writes its rows inside the Article Agent. The Chat calls
- * `reload` when a turn records some, which is the only signal there is.
+ * The Offer ledger, live. Rows come down once per store, since nothing announces
+ * a row changing — §3. A research turn writes rows behind the client's back, so
+ * the Chat calls `reload` when a turn records some.
  */
 
 export type OfferLedgerHandle = {

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -15,12 +15,11 @@ export type OfferLedgerHandle = {
 	ledger: OfferLedger
 	/** Until the first `listOffers` answers. */
 	loading: boolean
-	/** In one sentence, for the writer to read. */
 	failure: string | null
 	accept: (offer: Offer) => void
 	decline: (offer: Offer) => void
 	restore: (offer: Offer) => void
-	/** Read the rows again, after a turn recorded some. */
+	/** For after a turn records rows this client did not ask for. */
 	reload: () => void
 }
 

--- a/src/client/mock/MockArticle.tsx
+++ b/src/client/mock/MockArticle.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode, useMemo, useState } from 'react'
 
 import { missingOffer, notDeclined, type Offer, type Ruling } from '../../shared/offer'
-import type { Plan, Refusal } from '../../shared/plan'
-import { ArticleProvider, type OfferStore } from '../lib/article'
+import { emptyPlan, type Plan, type Refusal } from '../../shared/plan'
+import { ArticleProvider, type OfferStore, useArticle } from '../lib/article'
 import { createPlanWriter } from '../plan/writer'
 import { offers as seeded, plan as seededPlan } from './content'
 
@@ -43,6 +43,22 @@ export function MockArticle({ children }: { children: ReactNode }) {
 		</ArticleProvider>
 	)
 }
+
+/**
+ * The Plan a story is looking at. `MockArticle` seeds one before it renders, so
+ * this is only ever the seeded Plan — the fallback is what satisfies the type.
+ *
+ * A Panel in the app must not read a Plan this way: it would draw an empty Plan
+ * as a real one while the socket settles, and a Proposal described against it
+ * would name every Section as one the Plan does not carry. `ArticlePlanPanel`
+ * and `ArticleChatPanel` gate on null instead, which is the one production
+ * answer to "the Plan has not arrived".
+ */
+export function useMockPlan(): Plan {
+	return useArticle().plan.plan ?? blank
+}
+
+const blank = emptyPlan()
 
 function memoryOfferStore(seed: readonly Offer[]): OfferStore {
 	const rows = seed.map((offer) => ({ ...offer }))

--- a/src/client/mock/MockArticle.tsx
+++ b/src/client/mock/MockArticle.tsx
@@ -1,22 +1,28 @@
 import { type ReactNode, useMemo, useState } from 'react'
 
 import { missingOffer, notDeclined, type Offer, type Ruling } from '../../shared/offer'
-import type { Plan } from '../../shared/plan'
+import type { Plan, Refusal } from '../../shared/plan'
 import { ArticleProvider, type OfferStore } from '../lib/article'
 import { createPlanWriter } from '../plan/writer'
 import { offers as seeded, plan as seededPlan } from './content'
 
 /**
  * An Article held in memory, so a story runs the real Ledger and the real
- * applier without a Worker. A refusal has nowhere to go here, where `usePlan`
- * surfaces one.
+ * applier without a Worker. It supplies the same two halves the Article Agent
+ * does — the Plan connection and the Offer rows — and the writer behind it is
+ * the real one, with a `send` that goes nowhere.
  */
 export function MockArticle({ children }: { children: ReactNode }) {
 	const [plan, setPlan] = useState<Plan>(seededPlan)
+	const [refusal, setRefusal] = useState<Refusal | null>(null)
 
 	// The real writer, without a socket: only `send` is debounced.
 	const writer = useMemo(() => {
-		const held = createPlanWriter({ send: () => {}, onPlan: setPlan })
+		const held = createPlanWriter({
+			send: () => {},
+			onPlan: setPlan,
+			onRefusal: setRefusal,
+		})
 		held.receive(seededPlan)
 
 		return held
@@ -25,8 +31,14 @@ export function MockArticle({ children }: { children: ReactNode }) {
 	// One store per story: the Ledger reads its rows once.
 	const offers = useMemo(() => memoryOfferStore(seeded), [])
 
+	const edit = (next: Parameters<typeof writer.edit>[0]) => {
+		setRefusal(null)
+
+		return writer.edit(next)
+	}
+
 	return (
-		<ArticleProvider value={{ offers, plan, edit: writer.edit }}>
+		<ArticleProvider value={{ offers, plan: { plan, edit, refusal, rejected: null } }}>
 			{children}
 		</ArticleProvider>
 	)

--- a/src/client/mock/MockArticle.tsx
+++ b/src/client/mock/MockArticle.tsx
@@ -8,15 +8,14 @@ import { offers as seeded, plan as seededPlan } from './content'
 
 /**
  * An Article held in memory, so a story runs the real Ledger and the real
- * applier without a Worker. It supplies the same two halves the Article Agent
- * does — the Plan connection and the Offer rows — and the writer behind it is
- * the real one, with a `send` that goes nowhere.
+ * applier without a Worker. Supplies the same two halves the Article Agent does,
+ * behind the real `createPlanWriter` with a `send` that goes nowhere.
  */
 export function MockArticle({ children }: { children: ReactNode }) {
 	const [plan, setPlan] = useState<Plan>(seededPlan)
 	const [refusal, setRefusal] = useState<Refusal | null>(null)
 
-	// The real writer, without a socket: only `send` is debounced.
+	// `send` goes nowhere, so the debounce is the only part that idles.
 	const writer = useMemo(() => {
 		const held = createPlanWriter({
 			send: () => {},
@@ -28,7 +27,7 @@ export function MockArticle({ children }: { children: ReactNode }) {
 		return held
 	}, [])
 
-	// One store per story: the Ledger reads its rows once.
+	// One store per story, since `useOfferLedger` reads rows once per store.
 	const offers = useMemo(() => memoryOfferStore(seeded), [])
 
 	const edit = (next: Parameters<typeof writer.edit>[0]) => {
@@ -46,13 +45,9 @@ export function MockArticle({ children }: { children: ReactNode }) {
 
 /**
  * The Plan a story is looking at. `MockArticle` seeds one before it renders, so
- * this is only ever the seeded Plan — the fallback is what satisfies the type.
- *
- * A Panel in the app must not read a Plan this way: it would draw an empty Plan
- * as a real one while the socket settles, and a Proposal described against it
- * would name every Section as one the Plan does not carry. `ArticlePlanPanel`
- * and `ArticleChatPanel` gate on null instead, which is the one production
- * answer to "the Plan has not arrived".
+ * the empty fallback only satisfies the type. A Panel in the app gates on null
+ * instead: it would otherwise draw the empty Plan as a real one, and a Proposal
+ * card would name each of its Sections as missing.
  */
 export function useMockPlan(): Plan {
 	return useArticle().plan.plan ?? blank

--- a/src/client/mock/MockChat.ts
+++ b/src/client/mock/MockChat.ts
@@ -70,7 +70,6 @@ export function useMockChat(start: UIMessage[]): MockChat {
 		onDecline: (call) => rule(call, false),
 		onAcceptOffer: ledger.accept,
 		onDeclineOffer: ledger.decline,
-		onRestoreOffer: ledger.restore,
 		onSend: (text) =>
 			setMessages((held) => [
 				...held,

--- a/src/client/mock/MockChat.ts
+++ b/src/client/mock/MockChat.ts
@@ -1,0 +1,93 @@
+import { isToolUIPart, type UIMessage } from 'ai'
+import { useState } from 'react'
+
+import type { ChatPanelProps } from '../chat/ChatPanel'
+import {
+	afterRuling,
+	type ProposalCall,
+	type Refusals,
+	ruleProposal,
+	type ToolAnswer,
+	waitingCalls,
+} from '../chat/proposals'
+import { useArticle } from '../lib/article'
+import { useOfferLedger } from '../lib/useOfferLedger'
+
+/**
+ * A Chat held in memory, so a story runs the real applier and the real Offer
+ * ledger without a Worker. It rules through `ruleProposal`, the same function
+ * `useArticleChat` rules through, and writes the answer onto the tool part the
+ * way the SDK's `addToolOutput` would.
+ *
+ * No model runs here, so a turn the writer sends gets one flat sentence back.
+ */
+
+export type MockChat = Omit<ChatPanelProps, 'plan' | 'className' | 'leading'>
+
+export function useMockChat(start: UIMessage[]): MockChat {
+	const { plan: connection } = useArticle()
+	const ledger = useOfferLedger()
+	const [messages, setMessages] = useState<UIMessage[]>(() => structuredClone(start))
+	const [refusals, setRefusals] = useState<Refusals>({})
+
+	const answer = (toolCallId: string, sent: ToolAnswer) =>
+		setMessages((held) =>
+			held.map((message) => ({
+				...message,
+				parts: message.parts.map((part) => {
+					if (!isToolUIPart(part) || part.toolCallId !== toolCallId) return part
+
+					// `addToolOutput` writes this half in the app. The cast is the price
+					// of standing in for it: a tool part is a union over every state,
+					// and spreading one widens the fields the answered state requires.
+					const answered =
+						'output' in sent
+							? { ...part, state: 'output-available', output: sent.output }
+							: { ...part, state: 'output-error', errorText: sent.errorText }
+
+					return answered as unknown as typeof part
+				}),
+			})),
+		)
+
+	const rule = (call: ProposalCall, accepted: boolean) => {
+		const ruling = ruleProposal({
+			call,
+			accepted,
+			edit: connection.edit,
+			refusal: refusals[call.toolCallId] ?? null,
+		})
+
+		setRefusals((was) => afterRuling(was, call.toolCallId, ruling.refusal))
+		if (ruling.answer !== null) answer(call.toolCallId, ruling.answer)
+	}
+
+	return {
+		messages,
+		busy: false,
+		waiting: waitingCalls(messages),
+		refusals,
+		offers: ledger.ledger.offers,
+		failure: ledger.failure,
+		onAccept: (call) => rule(call, true),
+		onDecline: (call) => rule(call, false),
+		onAcceptOffer: ledger.accept,
+		onDeclineOffer: ledger.decline,
+		onRestoreOffer: ledger.restore,
+		onSend: (text) =>
+			setMessages((held) => [
+				...held,
+				{ id: `said-${held.length}`, role: 'user', parts: [{ type: 'text', text }] },
+				{
+					id: `back-${held.length}`,
+					role: 'assistant',
+					parts: [
+						{
+							type: 'text',
+							text: 'This screen runs the Plan and the Offer ledger for real, and no model. Accept or Decline the Proposal above to see the Plan move.',
+						},
+					],
+				},
+			]),
+	}
+}

--- a/src/client/mock/MockChat.ts
+++ b/src/client/mock/MockChat.ts
@@ -15,11 +15,9 @@ import { useOfferLedger } from '../lib/useOfferLedger'
 
 /**
  * A Chat held in memory, so a story runs the real applier and the real Offer
- * ledger without a Worker. It rules through `ruleProposal`, the same function
- * `useArticleChat` rules through, and writes the answer onto the tool part the
- * way the SDK's `addToolOutput` would.
- *
- * No model runs here, so a turn the writer sends gets one flat sentence back.
+ * ledger without a Worker. Rules through `ruleProposal` and stands in for the
+ * SDK's `addToolOutput`. No model, so a turn the writer sends gets a flat
+ * sentence back.
  */
 
 export type MockChat = Omit<ChatPanelProps, 'plan' | 'className' | 'leading'>
@@ -37,9 +35,8 @@ export function useMockChat(start: UIMessage[]): MockChat {
 				parts: message.parts.map((part) => {
 					if (!isToolUIPart(part) || part.toolCallId !== toolCallId) return part
 
-					// `addToolOutput` writes this half in the app. The cast is the price
-					// of standing in for it: a tool part is a union over every state,
-					// and spreading one widens the fields the answered state requires.
+					// A tool part is a union over its states, so spreading one widens
+					// the fields the answered state needs — hence the cast.
 					const answered =
 						'output' in sent
 							? { ...part, state: 'output-available', output: sent.output }

--- a/src/client/mock/MockChat.ts
+++ b/src/client/mock/MockChat.ts
@@ -8,7 +8,7 @@ import {
 	type Refusals,
 	ruleProposal,
 	type ToolAnswer,
-	waitingCalls,
+	waitingCount,
 } from '../chat/proposals'
 import { useArticle } from '../lib/article'
 import { useOfferLedger } from '../lib/useOfferLedger'
@@ -65,7 +65,7 @@ export function useMockChat(start: UIMessage[]): MockChat {
 	return {
 		messages,
 		busy: false,
-		waiting: waitingCalls(messages),
+		waiting: waitingCount(messages),
 		refusals,
 		offers: ledger.ledger.offers,
 		failure: ledger.failure,

--- a/src/client/mock/transcript.ts
+++ b/src/client/mock/transcript.ts
@@ -1,0 +1,135 @@
+import type { UIMessage } from 'ai'
+
+import { proposePlanChangeTool, recordOffersTool } from '../../shared/chat'
+import { offers } from './content'
+
+/**
+ * Two transcripts for the showcase, in the shape the Agents SDK stores them.
+ *
+ * The tool parts are the point. A Proposal is a suspended call — `input`
+ * present, no output — which is exactly what an `execute`-less tool leaves
+ * behind, and the ops in it apply cleanly against the mock Plan so a story can
+ * run the real applier. The research turn is the other way round: `recordOffers`
+ * resolved server-side and handed back the ids the Offer ledger holds rows for.
+ */
+
+/** The Chat mid-conversation, with a Proposal the writer has not ruled on. */
+export const midChat: UIMessage[] = [
+	{
+		id: 'm-1',
+		role: 'user',
+		parts: [
+			{
+				type: 'text',
+				text: "The process, then — but I want one developer in it so it isn't all spreadsheets.",
+			},
+		],
+	},
+	{
+		id: 'm-2',
+		role: 'assistant',
+		parts: [
+			{
+				type: 'text',
+				text: 'Then the appeal is the part that needs its own Section — the one nobody files is the whole mechanism. It runs long, so the total wants to move with it.',
+			},
+			{
+				type: `tool-${proposePlanChangeTool}`,
+				toolCallId: 'call-appeals',
+				state: 'input-available',
+				input: {
+					ops: [
+						{
+							op: 'createNode',
+							parentId: null,
+							afterId: 'sec-cost',
+							node: {
+								id: 'sec-appeals',
+								title: 'The appeal that nobody files',
+								intent: 'Why the objector pays nothing and the clock resets anyway.',
+								target: 400,
+								children: [],
+							},
+						},
+						{ op: 'setTarget', nodeId: null, expected: 2400, value: 2800 },
+					],
+				},
+			},
+		],
+	},
+]
+
+/**
+ * A Proposal the Plan will refuse. Its `expected` names a title the Plan no
+ * longer carries, which is what staleness is: the gap between generating a
+ * Proposal and applying it, with one writer in one tab.
+ */
+export const staleProposal: UIMessage[] = [
+	{
+		id: 's-1',
+		role: 'user',
+		parts: [{ type: 'text', text: 'Tighten §3 — the title is doing too much work.' }],
+	},
+	{
+		id: 's-2',
+		role: 'assistant',
+		parts: [
+			{ type: 'text', text: 'Shorter, and it keeps the accusation:' },
+			{
+				type: `tool-${proposePlanChangeTool}`,
+				toolCallId: 'call-stale',
+				state: 'input-available',
+				input: {
+					ops: [
+						{
+							op: 'setTitle',
+							nodeId: 'sec-cost',
+							expected: 'Who pays for the delay',
+							value: 'Who pays',
+						},
+					],
+				},
+			},
+		],
+	},
+]
+
+/** A research turn that returned a lot. Every Offer the mock Article holds. */
+export const researchTurn: UIMessage[] = [
+	{
+		id: 'r-1',
+		role: 'user',
+		parts: [
+			{
+				type: 'text',
+				text: "Find me everything on approval times in comparable cities. Cast wide, I'll rule on them.",
+			},
+		],
+	},
+	{
+		id: 'r-2',
+		role: 'assistant',
+		parts: [
+			{
+				type: 'text',
+				text: "Seven worth showing you. Two are from your favourites, and I've ranked those first.",
+			},
+			{
+				type: `tool-${recordOffersTool}`,
+				toolCallId: 'call-research',
+				state: 'output-available',
+				input: { offers: [] },
+				output: offers.map((offer) => ({
+					id: offer.id,
+					name: offer.source?.title ?? offer.text,
+					disposition: offer.disposition,
+					duplicate: false,
+				})),
+			},
+			{
+				type: 'text',
+				text: 'Accepting one copies it into the Plan — the Offer ledger keeps the whole list either way.',
+			},
+		],
+	},
+]

--- a/src/client/mock/transcript.ts
+++ b/src/client/mock/transcript.ts
@@ -4,13 +4,10 @@ import { proposePlanChangeTool, recordOffersTool } from '../../shared/chat'
 import { offers } from './content'
 
 /**
- * Two transcripts for the showcase, in the shape the Agents SDK stores them.
- *
- * The tool parts are the point. A Proposal is a suspended call — `input`
- * present, no output — which is exactly what an `execute`-less tool leaves
- * behind, and the ops in it apply cleanly against the mock Plan so a story can
- * run the real applier. The research turn is the other way round: `recordOffers`
- * resolved server-side and handed back the ids the Offer ledger holds rows for.
+ * Transcripts for the showcase, in the shape the Agents SDK stores them. The
+ * tool parts carry the interesting states: a suspended Proposal has `input` and
+ * no output, where a resolved `recordOffers` has both. The Proposal ops apply
+ * cleanly against the mock Plan, so a story runs the real applier.
  */
 
 /** The Chat mid-conversation, with a Proposal the writer has not ruled on. */
@@ -59,11 +56,8 @@ export const midChat: UIMessage[] = [
 	},
 ]
 
-/**
- * A Proposal the Plan will refuse. Its `expected` names a title the Plan no
- * longer carries, which is what staleness is: the gap between generating a
- * Proposal and applying it, with one writer in one tab.
- */
+/** A Proposal the Plan will refuse: its `expected` names a title the Plan no
+ * longer carries. */
 export const staleProposal: UIMessage[] = [
 	{
 		id: 's-1',
@@ -94,7 +88,7 @@ export const staleProposal: UIMessage[] = [
 	},
 ]
 
-/** A research turn that returned a lot. Every Offer the mock Article holds. */
+/** A research turn that returned a lot — the mock Article's whole Offer list. */
 export const researchTurn: UIMessage[] = [
 	{
 		id: 'r-1',

--- a/src/client/plan/ArticlePlanPanel.tsx
+++ b/src/client/plan/ArticlePlanPanel.tsx
@@ -1,19 +1,18 @@
+import { useArticle } from '../lib/article'
 import { PlanPanel } from './PlanPanel'
-import { usePlan } from './usePlan'
 
 /**
- * The Plan Panel, wired to one Article Agent. Mounting it inside the Article
- * screen is issue #29; everything it needs from the socket is `usePlan`.
+ * The Plan Panel, reading the one Article Agent connection the
+ * `ArticleProvider` holds. Laying it out beside the other three Panels is issue
+ * #29.
  */
 
 export interface ArticlePlanPanelProps {
-	/** The Article Agent's name, which is the Article's id. */
-	articleId: string
 	className?: string
 }
 
-export function ArticlePlanPanel({ articleId, className }: ArticlePlanPanelProps) {
-	const { plan, edit, refusal, rejected } = usePlan(articleId)
+export function ArticlePlanPanel({ className }: ArticlePlanPanelProps) {
+	const { plan, edit, refusal, rejected } = useArticle().plan
 
 	// The socket usually settles in well under a second, so this says what it is
 	// waiting for rather than drawing a skeleton of the Panel.

--- a/src/client/plan/ArticlePlanPanel.tsx
+++ b/src/client/plan/ArticlePlanPanel.tsx
@@ -1,11 +1,7 @@
 import { useArticle } from '../lib/article'
 import { PlanPanel } from './PlanPanel'
 
-/**
- * The Plan Panel, reading the one Article Agent connection the
- * `ArticleProvider` holds. Laying it out beside the other three Panels is issue
- * #29.
- */
+/** Drives `PlanPanel` from the connection the `ArticleProvider` holds. */
 
 export interface ArticlePlanPanelProps {
 	className?: string
@@ -14,8 +10,8 @@ export interface ArticlePlanPanelProps {
 export function ArticlePlanPanel({ className }: ArticlePlanPanelProps) {
 	const { plan, edit, refusal, rejected } = useArticle().plan
 
-	// The socket usually settles in well under a second, so this says what it is
-	// waiting for rather than drawing a skeleton of the Panel.
+	// Says what it waits on rather than drawing a skeleton, since the socket
+	// settles well inside a second.
 	if (plan === null) {
 		return (
 			<div className={className}>

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -11,6 +11,7 @@ import type { SectionAnchor } from './edits'
 import { addSection, setAdjectives, setTarget, setTitle, setVoice } from './edits'
 import { outlineEntries } from './outline'
 import { ReferenceList } from './ReferenceList'
+import { refusalText } from './refusalText'
 import { SectionRow } from './SectionRow'
 import { ToneFields } from './ToneFields'
 import { AllocationNote, TargetField } from './WordCount'
@@ -67,7 +68,7 @@ export function PlanPanel({
 		<Panel className={className} variant="sunk">
 			{refusal === null ? null : (
 				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
-					{refusal.message}
+					{refusalText(plan, refusal)}
 				</p>
 			)}
 			{rejected === null ? null : (

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -5,6 +5,7 @@ import { planAllocation, resolveArticleScope } from '../../shared/plan'
 import { GroupHeading } from '../components/Divider'
 import { EmptySlot, TextField } from '../components/Field'
 import { LengthBar } from '../components/LengthBar'
+import { Notice } from '../components/Notice'
 import { Panel } from '../components/Panel'
 import { AddSection } from './AddSection'
 import type { SectionAnchor } from './edits'
@@ -66,15 +67,9 @@ export function PlanPanel({
 
 	return (
 		<Panel className={className} variant="sunk">
-			{refusal === null ? null : (
-				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
-					{refusalText(plan, refusal)}
-				</p>
-			)}
+			{refusal === null ? null : <Notice>{refusalText(plan, refusal)}</Notice>}
 			{rejected === null ? null : (
-				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
-					The Article Agent refused the write. {rejected}
-				</p>
+				<Notice>The Article Agent refused the write. {rejected}</Notice>
 			)}
 
 			<TextField

--- a/src/client/plan/ReferenceForm.tsx
+++ b/src/client/plan/ReferenceForm.tsx
@@ -9,6 +9,7 @@ import type {
 import { referenceContentSchema } from '../../shared/plan'
 import { Button, ButtonGroup } from '../components/Button'
 import { TextField } from '../components/Field'
+import { Notice } from '../components/Notice'
 
 /**
  * What a Reference says, in fields the writer types or pastes into.
@@ -139,11 +140,7 @@ export function ReferenceForm({
 				/>
 			</div>
 
-			{refused === null ? null : (
-				<p className="rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink">
-					{refused}
-				</p>
-			)}
+			{refused === null ? null : <Notice>{refused}</Notice>}
 
 			<div className="flex items-center gap-1.5">
 				<Button onClick={save} size="sm">

--- a/src/client/plan/names.ts
+++ b/src/client/plan/names.ts
@@ -1,0 +1,79 @@
+import type { Plan, RefusalSubject } from '../../shared/plan'
+import { outlineEntries, sectionLabel } from './outline'
+import { referenceEntries, referenceMark, referenceName } from './references'
+
+/**
+ * What the writer calls one record in the Plan, for the places that name a
+ * record in a sentence: a Proposal card describing an op, a refusal saying which
+ * Section it could not find.
+ *
+ * A Section is numbered the way the Outline numbers it, out of the one walk, so
+ * no two Panels can number a Section differently — §4. Nothing here reads an id
+ * out loud: the writer never saw one.
+ */
+
+export type PlanNames = {
+	/** "§2 Who actually pays", or "§2" where the Section is untitled. */
+	section: (nodeId: string) => string
+	/** The Article for a null Scope — §6. */
+	scope: (nodeId: string | null) => string
+	/** Its passage or its title, the way the References list has it. */
+	reference: (referenceId: string) => string
+	/** Whichever of the three a refusal is about. */
+	subject: (subject: RefusalSubject | null) => string
+	/** The same record named as briefly as it can be — "§2", "quote [3]". For a
+	 * sentence that goes on to quote what the record says, where the fuller name
+	 * would print the same words twice. */
+	label: (subject: RefusalSubject | null) => string
+}
+
+export function planNames(plan: Plan): PlanNames {
+	const numbered = new Map(
+		outlineEntries(plan.outline).map((entry) => [
+			entry.node.id,
+			entry.node.title === ''
+				? sectionLabel(entry)
+				: `${sectionLabel(entry)} ${entry.node.title}`,
+		]),
+	)
+
+	// A refusal is often about the record that has just gone, so "does not carry"
+	// is the ordinary answer here rather than a fallback for a bug.
+	const section = (nodeId: string) =>
+		numbered.get(nodeId) ?? 'a Section the Plan does not carry'
+
+	const reference = (referenceId: string) => {
+		const held = plan.references.find((entry) => entry.id === referenceId)
+
+		return held === undefined
+			? 'a Reference the Plan does not carry'
+			: referenceName(held)
+	}
+
+	const marked = new Map(
+		referenceEntries(plan).map((entry) => [entry.reference.id, referenceMark(entry)]),
+	)
+
+	return {
+		section,
+		reference,
+		scope: (nodeId) => (nodeId === null ? 'the Article' : section(nodeId)),
+		subject: (subject) => {
+			if (subject === null) return 'the Plan'
+			if (subject.of === 'article') return 'the Article'
+
+			return subject.of === 'section' ? section(subject.id) : reference(subject.id)
+		},
+		label: (subject) => {
+			if (subject === null) return 'the Plan'
+			if (subject.of === 'article') return 'the Article'
+			if (subject.of === 'reference') return marked.get(subject.id) ?? 'that Reference'
+
+			const entry = outlineEntries(plan.outline).find(
+				(held) => held.node.id === subject.id,
+			)
+
+			return entry === undefined ? 'that Section' : sectionLabel(entry)
+		},
+	}
+}

--- a/src/client/plan/names.ts
+++ b/src/client/plan/names.ts
@@ -28,19 +28,24 @@ export type PlanNames = {
 }
 
 export function planNames(plan: Plan): PlanNames {
+	// One walk, giving both forms: the number on its own and the number with the
+	// title after it. Reading either out of a second walk would be a second way
+	// to number a Section.
 	const numbered = new Map(
-		outlineEntries(plan.outline).map((entry) => [
-			entry.node.id,
-			entry.node.title === ''
-				? sectionLabel(entry)
-				: `${sectionLabel(entry)} ${entry.node.title}`,
-		]),
+		outlineEntries(plan.outline).map((entry) => {
+			const label = sectionLabel(entry)
+
+			return [
+				entry.node.id,
+				{ label, full: entry.node.title === '' ? label : `${label} ${entry.node.title}` },
+			]
+		}),
 	)
 
 	// A refusal is often about the record that has just gone, so "does not carry"
 	// is the ordinary answer here rather than a fallback for a bug.
 	const section = (nodeId: string) =>
-		numbered.get(nodeId) ?? 'a Section the Plan does not carry'
+		numbered.get(nodeId)?.full ?? 'a Section the Plan does not carry'
 
 	const reference = (referenceId: string) => {
 		const held = plan.references.find((entry) => entry.id === referenceId)
@@ -50,9 +55,16 @@ export function planNames(plan: Plan): PlanNames {
 			: referenceName(held)
 	}
 
-	const marked = new Map(
-		referenceEntries(plan).map((entry) => [entry.reference.id, referenceMark(entry)]),
-	)
+	// Built on the first `label` of a Reference and not before: `describeProposal`
+	// names every record on a card and never asks for a brief one.
+	let marked: Map<string, string> | null = null
+	const mark = (referenceId: string) => {
+		marked ??= new Map(
+			referenceEntries(plan).map((entry) => [entry.reference.id, referenceMark(entry)]),
+		)
+
+		return marked.get(referenceId) ?? 'that Reference'
+	}
 
 	return {
 		section,
@@ -67,13 +79,9 @@ export function planNames(plan: Plan): PlanNames {
 		label: (subject) => {
 			if (subject === null) return 'the Plan'
 			if (subject.of === 'article') return 'the Article'
-			if (subject.of === 'reference') return marked.get(subject.id) ?? 'that Reference'
+			if (subject.of === 'reference') return mark(subject.id)
 
-			const entry = outlineEntries(plan.outline).find(
-				(held) => held.node.id === subject.id,
-			)
-
-			return entry === undefined ? 'that Section' : sectionLabel(entry)
+			return numbered.get(subject.id)?.label ?? 'that Section'
 		},
 	}
 }

--- a/src/client/plan/names.ts
+++ b/src/client/plan/names.ts
@@ -28,9 +28,7 @@ export type PlanNames = {
 }
 
 export function planNames(plan: Plan): PlanNames {
-	// One walk, giving both forms: the number on its own and the number with the
-	// title after it. Reading either out of a second walk would be a second way
-	// to number a Section.
+	// Both forms out of the one walk — §4.
 	const numbered = new Map(
 		outlineEntries(plan.outline).map((entry) => {
 			const label = sectionLabel(entry)
@@ -55,8 +53,7 @@ export function planNames(plan: Plan): PlanNames {
 			: referenceName(held)
 	}
 
-	// Built on the first `label` of a Reference and not before: `describeProposal`
-	// names every record on a card and never asks for a brief one.
+	// `describeProposal` never asks for a brief name, so it never pays for this.
 	let marked: Map<string, string> | null = null
 	const mark = (referenceId: string) => {
 		marked ??= new Map(

--- a/src/client/plan/names.ts
+++ b/src/client/plan/names.ts
@@ -3,13 +3,10 @@ import { outlineEntries, sectionLabel } from './outline'
 import { referenceEntries, referenceMark, referenceName } from './references'
 
 /**
- * What the writer calls one record in the Plan, for the places that name a
- * record in a sentence: a Proposal card describing an op, a refusal saying which
- * Section it could not find.
- *
- * A Section is numbered the way the Outline numbers it, out of the one walk, so
- * no two Panels can number a Section differently — §4. Nothing here reads an id
- * out loud: the writer never saw one.
+ * Names one record in the Plan the way the writer would say it, for the places
+ * that put a record in a sentence — a Proposal card, a refusal. Sections come
+ * out of the same walk the Outline numbers by (§4), and nothing here reads an id
+ * aloud: the writer never saw one.
  */
 
 export type PlanNames = {
@@ -21,9 +18,8 @@ export type PlanNames = {
 	reference: (referenceId: string) => string
 	/** Whichever of the three a refusal is about. */
 	subject: (subject: RefusalSubject | null) => string
-	/** The same record named as briefly as it can be — "§2", "quote [3]". For a
-	 * sentence that goes on to quote what the record says, where the fuller name
-	 * would print the same words twice. */
+	/** The briefest form — "§2", "quote [3]" — for a sentence that goes on to
+	 * quote the record and would otherwise print its title twice. */
 	label: (subject: RefusalSubject | null) => string
 }
 
@@ -40,8 +36,8 @@ export function planNames(plan: Plan): PlanNames {
 		}),
 	)
 
-	// A refusal is often about the record that has just gone, so "does not carry"
-	// is the ordinary answer here rather than a fallback for a bug.
+	// Refusals are often about a record that has just gone, so missing is an
+	// ordinary answer here rather than a sign of a bug.
 	const section = (nodeId: string) =>
 		numbered.get(nodeId)?.full ?? 'a Section the Plan does not carry'
 

--- a/src/client/plan/refusalText.ts
+++ b/src/client/plan/refusalText.ts
@@ -60,7 +60,6 @@ const wording: Record<RefusalReason, Wording> = {
 		'That change would leave a Plan that cannot be saved, so nothing was written.',
 }
 
-/** One sentence, for the writer. */
 export function refusalText(plan: Plan, refusal: Refusal): string {
 	return wording[refusal.reason](refusal, planNames(plan))
 }

--- a/src/client/plan/refusalText.ts
+++ b/src/client/plan/refusalText.ts
@@ -2,23 +2,17 @@ import type { Plan, Refusal, RefusalReason } from '../../shared/plan'
 import { planNames, type PlanNames } from './names'
 
 /**
- * What a refused edit reads as on screen.
- *
- * The applier writes one sentence and it is written for the model — a Declined
- * Proposal sends it back as the reason, so it names the op and the ids and may
- * run long (§6). This is the other reader: a writer, mid-task, who never saw an
- * id and does not know what `setTitle` is. The applier hands over a `reason`
- * code and the records it is about, and the table below is the only place the
- * English lives. Swap the table to swap the language.
- *
- * The table is total over `RefusalReason`, so a new refusal site in the applier
- * stops this file compiling until it says what the new one reads as.
+ * What a refused edit reads as on screen. `refusal.message` is the applier's
+ * sentence for the model and names ops and ids (§6); this is the other reader,
+ * a writer mid-task who has seen neither. The table below is the only English
+ * in the path — swap it to swap the language — and it is total over
+ * `RefusalReason`, so a new refusal site will not compile until it is worded.
  */
 
 type Wording = (refusal: Refusal, name: PlanNames) => string
 
-/** Also what a Proposal card says when the tool call's own payload did not
- * parse, which is the same condition one step earlier. */
+/** Exported because a Proposal card hits the same condition one step earlier,
+ * when the tool call's own payload will not parse. */
 export const unreadableText =
 	'The Chat sent a change that could not be read. Ask it to try again.'
 
@@ -27,9 +21,8 @@ const wording: Record<RefusalReason, Wording> = {
 
 	noPlan: () => 'The Plan has not arrived yet. Give it a moment.',
 
-	// The four below are about a record the Plan does not carry, so there is no
-	// name to give it: naming it would print the fallback and say the same thing
-	// twice. What the writer needs is that it went, not which it was.
+	// The four below concern a record the Plan has lost, so there is no name to
+	// give it — asking for one prints the fallback and says it twice.
 	noSection: () =>
 		'That change is for a Section that is no longer in the Outline. Ask the Chat to look again.',
 
@@ -42,14 +35,12 @@ const wording: Record<RefusalReason, Wording> = {
 	noReference: () =>
 		'That change is for a Reference that is no longer in the list. Ask the Chat to look again.',
 
-	// The bare label, because the sentence goes on to quote the field: the full
-	// name of a Section is its number and its title, and a refused setTitle would
-	// print that title twice.
+	// `label` and not `subject`: this sentence quotes the field, and the fuller
+	// name carries the title, so a refused setTitle would print it twice.
 	stale: (refusal, name) =>
 		`${capitalise(name.label(refusal.subject))} has changed since the Chat proposed this. It now reads ${quote(refusal.found)}, where the change expected ${quote(refusal.expected)}.`,
 
-	// One code for both: the subject already says whether it is a Section or a
-	// Reference, so two would be two rows saying the same thing.
+	// Sections and References share a code: the subject already says which.
 	duplicateId: (refusal, name) =>
 		`That change adds ${name.subject(refusal.subject)}, which the Plan already carries.`,
 
@@ -74,8 +65,8 @@ export function refusalText(plan: Plan, refusal: Refusal): string {
 	return wording[refusal.reason](refusal, planNames(plan))
 }
 
-/** What a field says, as the writer would read it back. An absent one is a
- * phrase rather than `null`, which is a word they never typed. */
+/** A field's value as the writer would read it back — a phrase for an absent
+ * one, since `null` is a word they never typed. */
 function quote(value: unknown): string {
 	if (value === null || value === undefined) return 'nothing'
 	if (Array.isArray(value)) {

--- a/src/client/plan/refusalText.ts
+++ b/src/client/plan/refusalText.ts
@@ -1,0 +1,88 @@
+import type { Plan, Refusal, RefusalReason } from '../../shared/plan'
+import { planNames, type PlanNames } from './names'
+
+/**
+ * What a refused edit reads as on screen.
+ *
+ * The applier writes one sentence and it is written for the model — a Declined
+ * Proposal sends it back as the reason, so it names the op and the ids and may
+ * run long (§6). This is the other reader: a writer, mid-task, who never saw an
+ * id and does not know what `setTitle` is. The applier hands over a `reason`
+ * code and the records it is about, and the table below is the only place the
+ * English lives. Swap the table to swap the language.
+ *
+ * The table is total over `RefusalReason`, so a new refusal site in the applier
+ * stops this file compiling until it says what the new one reads as.
+ */
+
+type Wording = (refusal: Refusal, name: PlanNames) => string
+
+const wording: Record<RefusalReason, Wording> = {
+	unreadable: () => 'The Chat sent a change that could not be read. Ask it to try again.',
+
+	noPlan: () => 'The Plan has not arrived yet. Give it a moment.',
+
+	// The four below are about a record the Plan does not carry, so there is no
+	// name to give it: naming it would print the fallback and say the same thing
+	// twice. What the writer needs is that it went, not which it was.
+	noSection: () =>
+		'That change is for a Section that is no longer in the Outline. Ask the Chat to look again.',
+
+	noParent: () =>
+		'That change puts a Section inside one that is no longer in the Outline.',
+
+	noAnchor: (refusal, name) =>
+		`That change puts a Section next to one that is no longer in ${name.subject(refusal.other)}.`,
+
+	noReference: () =>
+		'That change is for a Reference that is no longer in the list. Ask the Chat to look again.',
+
+	// The bare label, because the sentence goes on to quote the field: the full
+	// name of a Section is its number and its title, and a refused setTitle would
+	// print that title twice.
+	stale: (refusal, name) =>
+		`${capitalise(name.label(refusal.subject))} has changed since the Chat proposed this. It now reads ${quote(refusal.found)}, where the change expected ${quote(refusal.expected)}.`,
+
+	duplicateSectionId: (refusal, name) =>
+		`That change adds ${name.subject(refusal.subject)}, which the Plan already carries.`,
+
+	duplicateReferenceId: (refusal, name) =>
+		`That change adds ${name.subject(refusal.subject)}, which the Plan already carries.`,
+
+	moveUnderOwn: (refusal, name) =>
+		`That change moves ${name.subject(refusal.subject)} inside ${name.subject(refusal.other)}, which sits inside it.`,
+
+	mergeUnderOwn: (refusal, name) =>
+		`That change merges ${name.subject(refusal.subject)} into ${name.subject(refusal.other)}, which sits inside it.`,
+
+	mergeWithItself: (refusal, name) =>
+		`That change merges ${name.subject(refusal.subject)} into itself.`,
+
+	anchorToItself: (refusal, name) =>
+		`That change moves ${name.subject(refusal.subject)} next to itself.`,
+
+	wouldNotParse: () =>
+		'That change would leave a Plan that cannot be saved, so nothing was written.',
+}
+
+/** One sentence, for the writer. */
+export function refusalText(plan: Plan, refusal: Refusal): string {
+	return wording[refusal.reason](refusal, planNames(plan))
+}
+
+/** What a field says, as the writer would read it back. An absent one is a
+ * phrase rather than `null`, which is a word they never typed. */
+function quote(value: unknown): string {
+	if (value === null || value === undefined) return 'nothing'
+	if (Array.isArray(value)) {
+		return value.length === 0 ? 'nothing' : value.map(String).join(', ')
+	}
+	if (typeof value === 'string') return value === '' ? 'nothing' : `“${value}”`
+	if (typeof value === 'number') return String(value)
+
+	return JSON.stringify(value)
+}
+
+function capitalise(text: string): string {
+	return text.charAt(0).toUpperCase() + text.slice(1)
+}

--- a/src/client/plan/refusalText.ts
+++ b/src/client/plan/refusalText.ts
@@ -17,8 +17,13 @@ import { planNames, type PlanNames } from './names'
 
 type Wording = (refusal: Refusal, name: PlanNames) => string
 
+/** Also what a Proposal card says when the tool call's own payload did not
+ * parse, which is the same condition one step earlier. */
+export const unreadableText =
+	'The Chat sent a change that could not be read. Ask it to try again.'
+
 const wording: Record<RefusalReason, Wording> = {
-	unreadable: () => 'The Chat sent a change that could not be read. Ask it to try again.',
+	unreadable: () => unreadableText,
 
 	noPlan: () => 'The Plan has not arrived yet. Give it a moment.',
 
@@ -43,10 +48,9 @@ const wording: Record<RefusalReason, Wording> = {
 	stale: (refusal, name) =>
 		`${capitalise(name.label(refusal.subject))} has changed since the Chat proposed this. It now reads ${quote(refusal.found)}, where the change expected ${quote(refusal.expected)}.`,
 
-	duplicateSectionId: (refusal, name) =>
-		`That change adds ${name.subject(refusal.subject)}, which the Plan already carries.`,
-
-	duplicateReferenceId: (refusal, name) =>
+	// One code for both: the subject already says whether it is a Section or a
+	// Reference, so two would be two rows saying the same thing.
+	duplicateId: (refusal, name) =>
 		`That change adds ${name.subject(refusal.subject)}, which the Plan already carries.`,
 
 	moveUnderOwn: (refusal, name) =>

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -16,14 +16,13 @@ export type PlanConnection = {
 	/** Takes what the builders in edits.ts return, null included, and hands back
 	 * why the edit did not land — a Proposal ruling needs that in the same turn. */
 	edit: (edit: PlanEdit) => Refusal | null
-	/** Why the last edit did not land, cleared by the next one. */
+	/** Cleared by the next edit. */
 	refusal: Refusal | null
 	/** What the Article Agent said when a write did not parse. Reaching this is
 	 * a bug in the applier, and it is shown rather than swallowed. */
 	rejected: string | null
 }
 
-/** All the writer needs of the socket. */
 export type PlanSocket = { setState: (plan: Plan) => void }
 
 export type PlanChannel = {

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -1,4 +1,3 @@
-import { useAgent } from 'agents/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { Plan, Refusal } from '../../shared/plan'
@@ -6,18 +5,26 @@ import { isPlanRefused } from '../../shared/plan'
 import { createPlanWriter, type PlanEdit } from './writer'
 
 /**
- * The Plan Panel's connection to one Article Agent: its state blob in, and
- * every edit back out through `setState` — docs/architecture.md §3, rule 1.
+ * The Plan's half of one Article Agent: its state blob in, and every edit back
+ * out through `setState` — docs/architecture.md §3, rule 1.
  *
- * The socket is multiplexed, so the Chat Panel shares this one and does not
- * open its own — §8.
+ * **It does not open the socket.** The socket is multiplexed and the Chat rides
+ * the same one (§8), so `useArticleAgent` opens it once above both Panels and
+ * hands this channel the two `useAgent` handlers the Plan needs. Opening a
+ * second one would mean two writers, two debounce timers, and a blob whose
+ * whole design is that it has one writer.
  */
 
 export type PlanConnection = {
 	/** The Plan the writer sees, and null until the first state update arrives. */
 	plan: Plan | null
-	/** What the builders in edits.ts return, null included. */
-	edit: (edit: PlanEdit) => void
+	/**
+	 * What the builders in edits.ts return, null included, and it hands back why
+	 * the edit did not land. The Plan Panel reads that off `refusal` below, and a
+	 * caller ruling on a Proposal needs it in the same turn: Declining answers
+	 * the tool call with the reason.
+	 */
+	edit: (edit: PlanEdit) => Refusal | null
 	/** Why the last edit did not land, cleared by the next one. */
 	refusal: Refusal | null
 	/** What the Article Agent said when a write did not parse. Reaching this is
@@ -25,14 +32,28 @@ export type PlanConnection = {
 	rejected: string | null
 }
 
-export function usePlan(articleId: string): PlanConnection {
+/** All the writer needs of the socket. */
+export type PlanSocket = { setState: (plan: Plan) => void }
+
+export type PlanChannel = {
+	connection: PlanConnection
+	/** Hand it the socket. `useAgent` has none to give on the first render and
+	 * replaces it on every reconnect, so the owner calls this in an effect. */
+	attach: (socket: PlanSocket) => void
+	/** The two `useAgent` handlers the Plan needs. Both are stable, because
+	 * `useAgent` reads its options once. */
+	onStateUpdate: (state: Plan, source: 'server' | 'client') => void
+	onMessage: (event: MessageEvent) => void
+}
+
+export function usePlanChannel(): PlanChannel {
 	const [plan, setPlan] = useState<Plan | null>(null)
 	const [refusal, setRefusal] = useState<Refusal | null>(null)
 	const [rejected, setRejected] = useState<string | null>(null)
 
 	// The socket is not built yet when the writer is, and it is replaced on every
 	// reconnect, so the writer sends through a ref rather than holding one.
-	const socket = useRef<{ setState: (plan: Plan) => void } | null>(null)
+	const socket = useRef<PlanSocket | null>(null)
 	const held = useRef<ReturnType<typeof createPlanWriter> | null>(null)
 	held.current ??= createPlanWriter({
 		send: (next) => socket.current?.setState(next),
@@ -41,9 +62,24 @@ export function usePlan(articleId: string): PlanConnection {
 	})
 	const writer = held.current
 
-	const agent = useAgent<Plan>({
-		agent: 'article-agent',
-		name: articleId,
+	// Flushing on the way out is what keeps the last keystroke of a burst.
+	useEffect(() => () => writer.dispose(), [writer])
+
+	const edit = useCallback(
+		(next: PlanEdit) => {
+			setRefusal(null)
+			setRejected(null)
+
+			return writer.edit(next)
+		},
+		[writer],
+	)
+
+	const wiring = useRef<Omit<PlanChannel, 'connection'> | null>(null)
+	wiring.current ??= {
+		attach: (next) => {
+			socket.current = next
+		},
 		onStateUpdate: (state, source) => {
 			// A client update is the echo of a write the writer already holds.
 			if (source === 'server') writer.receive(state)
@@ -52,25 +88,9 @@ export function usePlan(articleId: string): PlanConnection {
 			const frame = parse(event.data)
 			if (isPlanRefused(frame)) setRejected(frame.error)
 		},
-	})
+	}
 
-	useEffect(() => {
-		socket.current = agent
-	})
-
-	// Flushing on the way out is what keeps the last keystroke of a burst.
-	useEffect(() => () => writer.dispose(), [writer])
-
-	const edit = useCallback(
-		(next: PlanEdit) => {
-			setRefusal(null)
-			setRejected(null)
-			writer.edit(next)
-		},
-		[writer],
-	)
-
-	return { plan, edit, refusal, rejected }
+	return { connection: { plan, edit, refusal, rejected }, ...wiring.current }
 }
 
 /** The socket carries frames this Panel does not read, and a binary one is not

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -5,25 +5,16 @@ import { isPlanRefused } from '../../shared/plan'
 import { createPlanWriter, type PlanEdit } from './writer'
 
 /**
- * The Plan's half of one Article Agent: its state blob in, and every edit back
- * out through `setState` — docs/architecture.md §3, rule 1.
- *
- * **It does not open the socket.** The socket is multiplexed and the Chat rides
- * the same one (§8), so `useArticleAgent` opens it once above both Panels and
- * gives this channel a way to reach it. Opening a second one would mean two
- * writers, two debounce timers, and a blob whose whole design is that it has one
- * writer.
+ * The Plan's half of one Article Agent: state blob in, edits back out through
+ * `setState` — §3, rule 1. `useArticleAgent` owns the socket and passes a way to
+ * reach it, so nothing here opens one.
  */
 
 export type PlanConnection = {
 	/** The Plan the writer sees, and null until the first state update arrives. */
 	plan: Plan | null
-	/**
-	 * What the builders in edits.ts return, null included, and it hands back why
-	 * the edit did not land. The Plan Panel reads that off `refusal` below, and a
-	 * caller ruling on a Proposal needs it in the same turn: Declining answers
-	 * the tool call with the reason.
-	 */
+	/** Takes what the builders in edits.ts return, null included, and hands back
+	 * why the edit did not land — a Proposal ruling needs that in the same turn. */
 	edit: (edit: PlanEdit) => Refusal | null
 	/** Why the last edit did not land, cleared by the next one. */
 	refusal: Refusal | null
@@ -42,11 +33,8 @@ export type PlanChannel = {
 	onMessage: (event: MessageEvent) => void
 }
 
-/**
- * `socket` is read rather than held: `useAgent` has none to give on the first
- * render and replaces it on every reconnect, so the owner keeps the ref and this
- * asks it for whichever one is current.
- */
+/** `socket` is a getter, because `useAgent` has none to give on the first render
+ * and swaps it on reconnect. */
 export function usePlanChannel(socket: () => PlanSocket | null): PlanChannel {
 	const [plan, setPlan] = useState<Plan | null>(null)
 	const [refusal, setRefusal] = useState<Refusal | null>(null)

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -10,9 +10,9 @@ import { createPlanWriter, type PlanEdit } from './writer'
  *
  * **It does not open the socket.** The socket is multiplexed and the Chat rides
  * the same one (§8), so `useArticleAgent` opens it once above both Panels and
- * hands this channel the two `useAgent` handlers the Plan needs. Opening a
- * second one would mean two writers, two debounce timers, and a blob whose
- * whole design is that it has one writer.
+ * gives this channel a way to reach it. Opening a second one would mean two
+ * writers, two debounce timers, and a blob whose whole design is that it has one
+ * writer.
  */
 
 export type PlanConnection = {
@@ -37,26 +37,24 @@ export type PlanSocket = { setState: (plan: Plan) => void }
 
 export type PlanChannel = {
 	connection: PlanConnection
-	/** Hand it the socket. `useAgent` has none to give on the first render and
-	 * replaces it on every reconnect, so the owner calls this in an effect. */
-	attach: (socket: PlanSocket) => void
-	/** The two `useAgent` handlers the Plan needs. Both are stable, because
-	 * `useAgent` reads its options once. */
+	/** The two `useAgent` handlers the Plan needs. */
 	onStateUpdate: (state: Plan, source: 'server' | 'client') => void
 	onMessage: (event: MessageEvent) => void
 }
 
-export function usePlanChannel(): PlanChannel {
+/**
+ * `socket` is read rather than held: `useAgent` has none to give on the first
+ * render and replaces it on every reconnect, so the owner keeps the ref and this
+ * asks it for whichever one is current.
+ */
+export function usePlanChannel(socket: () => PlanSocket | null): PlanChannel {
 	const [plan, setPlan] = useState<Plan | null>(null)
 	const [refusal, setRefusal] = useState<Refusal | null>(null)
 	const [rejected, setRejected] = useState<string | null>(null)
 
-	// The socket is not built yet when the writer is, and it is replaced on every
-	// reconnect, so the writer sends through a ref rather than holding one.
-	const socket = useRef<PlanSocket | null>(null)
 	const held = useRef<ReturnType<typeof createPlanWriter> | null>(null)
 	held.current ??= createPlanWriter({
-		send: (next) => socket.current?.setState(next),
+		send: (next) => socket()?.setState(next),
 		onPlan: setPlan,
 		onRefusal: setRefusal,
 	})
@@ -75,22 +73,17 @@ export function usePlanChannel(): PlanChannel {
 		[writer],
 	)
 
-	const wiring = useRef<Omit<PlanChannel, 'connection'> | null>(null)
-	wiring.current ??= {
-		attach: (next) => {
-			socket.current = next
-		},
-		onStateUpdate: (state, source) => {
-			// A client update is the echo of a write the writer already holds.
-			if (source === 'server') writer.receive(state)
-		},
-		onMessage: (event: MessageEvent) => {
-			const frame = parse(event.data)
-			if (isPlanRefused(frame)) setRejected(frame.error)
-		},
+	// A client update is the echo of a write the writer already holds.
+	const onStateUpdate = (state: Plan, source: 'server' | 'client') => {
+		if (source === 'server') writer.receive(state)
 	}
 
-	return { connection: { plan, edit, refusal, rejected }, ...wiring.current }
+	const onMessage = (event: MessageEvent) => {
+		const frame = parse(event.data)
+		if (isPlanRefused(frame)) setRejected(frame.error)
+	}
+
+	return { connection: { plan, edit, refusal, rejected }, onStateUpdate, onMessage }
 }
 
 /** The socket carries frames this Panel does not read, and a binary one is not

--- a/src/client/plan/writer.ts
+++ b/src/client/plan/writer.ts
@@ -133,7 +133,10 @@ export function createPlanWriter(options: PlanWriterOptions): PlanWriter {
  * edit until then, so this is a guard rather than a state the writer meets. */
 const notYet: Refusal = {
 	type: 'missing',
+	reason: 'noPlan',
 	index: null,
 	op: null,
+	subject: null,
+	other: null,
 	message: 'The Plan has not arrived from the Article Agent yet.',
 }

--- a/src/client/screens/article/ChatWithReferencesScreen.tsx
+++ b/src/client/screens/article/ChatWithReferencesScreen.tsx
@@ -1,63 +1,29 @@
+import { ChatPanel } from '../../chat/ChatPanel'
 import { ArticleBar } from '../../components/ArticleBar'
-import { ChatComposer, ChatMessage } from '../../components/Chat'
-import { GroupHeading } from '../../components/Divider'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Panel } from '../../components/Panel'
-import { ReferenceCard } from '../../components/ReferenceCard'
-import { useOfferLedger } from '../../lib/useOfferLedger'
-import { ARTICLE_TITLE } from '../../mock/content'
+import { useArticlePlan } from '../../lib/article'
+import { useMockChat } from '../../mock/MockChat'
+import { researchTurn } from '../../mock/transcript'
 
 /**
- * 2(d) — A turn that returned a lot, with the Chat Panel at full width.
- * Accepting one copies it straight into the Plan; nothing waits in a holding
- * pen. The Offer ledger keeps the whole list either way.
+ * 2(d) — A turn that returned a lot, with the Chat Panel at full width. The
+ * turn recorded its Offers as rows and handed back their ids; the cards are the
+ * Offer ledger's rows, so Accepting one copies it straight into the Plan and
+ * the row keeps the ruling either way.
  */
 export function ChatWithReferencesScreen() {
-	const { ledger, accept, decline } = useOfferLedger()
+	const plan = useArticlePlan()
+	const chat = useMockChat(researchTurn)
 
 	return (
 		<Frame width={700}>
-			<ArticleBar title={ARTICLE_TITLE} open={['chat']} status="research" />
-			<FrameBody>
-				<Panel className="gap-3">
-					<ChatMessage from="me">
-						Find me everything on approval times in comparable cities. Cast wide, I'll
-						rule on them.
-					</ChatMessage>
-					<ChatMessage from="guide">
-						{ledger.counts.all} worth showing you. Two are from your favourites, and I've
-						ranked those first.
-					</ChatMessage>
-
-					<GroupHeading
-						count={`${ledger.counts.all} found`}
-						action={
-							<span className="text-[0.6875rem] text-faint">
-								{ledger.counts.accepted} Accepted · {ledger.counts.declined} Declined ·{' '}
-								{ledger.counts.undecided} Undecided
-							</span>
-						}
-					>
-						Offers
-					</GroupHeading>
-
-					<div className="flex flex-col gap-2">
-						{ledger.offers.map((offer) => (
-							<ReferenceCard
-								key={offer.id}
-								offer={offer}
-								onAccept={() => accept(offer)}
-								onDecline={() => decline(offer)}
-							/>
-						))}
-					</div>
-
-					<p className="text-[0.6875rem] text-faint">
-						Accepting one copies it into the Plan — the Offer ledger keeps the whole list
-						either way.
-					</p>
-					<ChatComposer placeholder="More like the throughput study, but for transit…" />
-				</Panel>
+			<ArticleBar title={plan.title} open={['chat']} status="research" />
+			<FrameBody className="h-[30rem]">
+				<ChatPanel
+					{...chat}
+					placeholder="More like the throughput study, but for transit…"
+					plan={plan}
+				/>
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/ChatWithReferencesScreen.tsx
+++ b/src/client/screens/article/ChatWithReferencesScreen.tsx
@@ -1,7 +1,7 @@
 import { ChatPanel } from '../../chat/ChatPanel'
 import { ArticleBar } from '../../components/ArticleBar'
 import { Frame, FrameBody } from '../../components/Frame'
-import { useArticlePlan } from '../../lib/article'
+import { useMockPlan } from '../../mock/MockArticle'
 import { useMockChat } from '../../mock/MockChat'
 import { researchTurn } from '../../mock/transcript'
 
@@ -12,7 +12,7 @@ import { researchTurn } from '../../mock/transcript'
  * the row keeps the ruling either way.
  */
 export function ChatWithReferencesScreen() {
-	const plan = useArticlePlan()
+	const plan = useMockPlan()
 	const chat = useMockChat(researchTurn)
 
 	return (

--- a/src/client/screens/article/ChatWithReferencesScreen.tsx
+++ b/src/client/screens/article/ChatWithReferencesScreen.tsx
@@ -5,12 +5,8 @@ import { useMockPlan } from '../../mock/MockArticle'
 import { useMockChat } from '../../mock/MockChat'
 import { researchTurn } from '../../mock/transcript'
 
-/**
- * 2(d) — A turn that returned a lot, with the Chat Panel at full width. The
- * turn recorded its Offers as rows and handed back their ids; the cards are the
- * Offer ledger's rows, so Accepting one copies it straight into the Plan and
- * the row keeps the ruling either way.
- */
+/** 2(d) — A turn that returned a lot, Chat Panel at full width. The cards are
+ * Offer ledger rows, so Accepting one copies it into the Plan. */
 export function ChatWithReferencesScreen() {
 	const plan = useMockPlan()
 	const chat = useMockChat(researchTurn)

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -7,7 +7,7 @@ import { EmptySlot } from '../../components/Field'
 import { Frame, FrameBody } from '../../components/Frame'
 import { Panel } from '../../components/Panel'
 import { ReferenceCard } from '../../components/ReferenceCard'
-import { useArticle } from '../../lib/article'
+import { useArticle, useArticlePlan } from '../../lib/article'
 import { useOfferLedger } from '../../lib/useOfferLedger'
 import { ARTICLE_TITLE } from '../../mock/content'
 import { PlanPanel } from '../../plan/PlanPanel'
@@ -29,7 +29,8 @@ const filters: Filter[] = ['all', 'undecided', 'accepted', 'declined']
  * a Reference sits, and which sit nowhere yet, are its own to show.
  */
 export function LedgerDrawerScreen() {
-	const { plan, edit } = useArticle()
+	const { edit } = useArticle().plan
+	const plan = useArticlePlan()
 	const { ledger, loading, failure, accept, decline, restore } = useOfferLedger()
 	const [filter, setFilter] = useState<Filter>('all')
 

--- a/src/client/screens/article/LedgerDrawerScreen.tsx
+++ b/src/client/screens/article/LedgerDrawerScreen.tsx
@@ -7,9 +7,10 @@ import { EmptySlot } from '../../components/Field'
 import { Frame, FrameBody } from '../../components/Frame'
 import { Panel } from '../../components/Panel'
 import { ReferenceCard } from '../../components/ReferenceCard'
-import { useArticle, useArticlePlan } from '../../lib/article'
+import { useArticle } from '../../lib/article'
 import { useOfferLedger } from '../../lib/useOfferLedger'
 import { ARTICLE_TITLE } from '../../mock/content'
+import { useMockPlan } from '../../mock/MockArticle'
 import { PlanPanel } from '../../plan/PlanPanel'
 
 type Filter = 'all' | Disposition
@@ -30,7 +31,7 @@ const filters: Filter[] = ['all', 'undecided', 'accepted', 'declined']
  */
 export function LedgerDrawerScreen() {
 	const { edit } = useArticle().plan
-	const plan = useArticlePlan()
+	const plan = useMockPlan()
 	const { ledger, loading, failure, accept, decline, restore } = useOfferLedger()
 	const [filter, setFilter] = useState<Filter>('all')
 

--- a/src/client/screens/article/MidChatScreen.tsx
+++ b/src/client/screens/article/MidChatScreen.tsx
@@ -7,11 +7,8 @@ import { useMockChat } from '../../mock/MockChat'
 import { midChat } from '../../mock/transcript'
 import { PlanPanel } from '../../plan/PlanPanel'
 
-/**
- * 2(b) — Mid-chat. The Chat has proposed a Section and a new total, and the
- * Proposal waits on the writer. Accepting applies it through the same writer
- * the Plan Panel beside it types into, so the Outline moves as you rule.
- */
+/** 2(b) — Mid-chat, with a live Proposal. Accepting it moves the Outline in the
+ * Plan Panel beside it: both go through the one writer. */
 export function MidChatScreen() {
 	const { edit, refusal } = useArticle().plan
 	const plan = useMockPlan()

--- a/src/client/screens/article/MidChatScreen.tsx
+++ b/src/client/screens/article/MidChatScreen.tsx
@@ -1,56 +1,27 @@
+import { ChatPanel } from '../../chat/ChatPanel'
 import { ArticleBar } from '../../components/ArticleBar'
-import { ChatComposer, ChatMessage } from '../../components/Chat'
 import { Frame, FrameBody } from '../../components/Frame'
-import { Panel } from '../../components/Panel'
-import { ReferenceCard } from '../../components/ReferenceCard'
-import { ARTICLE_TITLE, offers, plan } from '../../mock/content'
-import { PlanBlock, PlanLength, PlanOutline, PlanReferences } from './PlanBlocks'
+import { useArticle, useArticlePlan } from '../../lib/article'
+import { useMockChat } from '../../mock/MockChat'
+import { midChat } from '../../mock/transcript'
+import { PlanPanel } from '../../plan/PlanPanel'
 
 /**
- * 2(b) — Mid-chat. Ticking a reference in the chat sends it straight into
- * References; there is no interstitial approval screen. Meanwhile section 3 is
- * being typed by hand in the plan, which is equally allowed.
+ * 2(b) — Mid-chat. The Chat has proposed a Section and a new total, and the
+ * Proposal waits on the writer. Accepting applies it through the same writer
+ * the Plan Panel beside it types into, so the Outline moves as you rule.
  */
 export function MidChatScreen() {
-	return (
-		<Frame width={800}>
-			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
-			<FrameBody row className="h-[24rem]">
-				<Panel divider="right" className="gap-3">
-					<ChatMessage from="me">
-						The process, then — but I want one developer in it so it isn't all
-						spreadsheets.
-					</ChatMessage>
-					<ChatMessage from="guide">
-						Two that carry the argument, both from your favourites:
-					</ChatMessage>
-					<div className="flex flex-col gap-2">
-						<ReferenceCard offer={offers[0]} variant="ledger" favourite="publication" />
-						<ReferenceCard offer={offers[3]} variant="ledger" compact />
-					</div>
-					<ChatMessage from="guide">
-						The throughput study has a line that would open §2 well. I've pulled it into
-						quotes.
-					</ChatMessage>
-					<ChatComposer />
-				</Panel>
+	const { edit, refusal } = useArticle().plan
+	const plan = useArticlePlan()
+	const chat = useMockChat(midChat)
 
-				<Panel variant="sunk">
-					<PlanLength total={plan.totalTarget} voice={plan.voice} />
-					<PlanBlock title="Outline" meta="3 of ~4">
-						<PlanOutline
-							outline={plan.outline.slice(0, 2)}
-							typing="Who actually pays for the delay"
-							showAdd
-						/>
-					</PlanBlock>
-					<PlanBlock title="References" meta="4">
-						<PlanReferences
-							references={plan.references.slice(0, 3)}
-							justAddedId={plan.references[0].id}
-						/>
-					</PlanBlock>
-				</Panel>
+	return (
+		<Frame width={880}>
+			<ArticleBar title={plan.title} open={['chat', 'plan']} status="planning" />
+			<FrameBody row className="h-[26rem]">
+				<ChatPanel {...chat} className="border-r border-edge" plan={plan} />
+				<PlanPanel edit={edit} plan={plan} refusal={refusal} />
 			</FrameBody>
 		</Frame>
 	)

--- a/src/client/screens/article/MidChatScreen.tsx
+++ b/src/client/screens/article/MidChatScreen.tsx
@@ -1,7 +1,8 @@
 import { ChatPanel } from '../../chat/ChatPanel'
 import { ArticleBar } from '../../components/ArticleBar'
 import { Frame, FrameBody } from '../../components/Frame'
-import { useArticle, useArticlePlan } from '../../lib/article'
+import { useArticle } from '../../lib/article'
+import { useMockPlan } from '../../mock/MockArticle'
 import { useMockChat } from '../../mock/MockChat'
 import { midChat } from '../../mock/transcript'
 import { PlanPanel } from '../../plan/PlanPanel'
@@ -13,7 +14,7 @@ import { PlanPanel } from '../../plan/PlanPanel'
  */
 export function MidChatScreen() {
 	const { edit, refusal } = useArticle().plan
-	const plan = useArticlePlan()
+	const plan = useMockPlan()
 	const chat = useMockChat(midChat)
 
 	return (

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -15,6 +15,7 @@ import { LedgerPopoverScreen } from './LedgerPopoverScreen'
 import { MidChatScreen } from './MidChatScreen'
 import { PlanSheetScreen } from './PlanSheetScreen'
 import { ReadyToDraftScreen } from './ReadyToDraftScreen'
+import { StaleProposalScreen } from './StaleProposalScreen'
 
 const meta = {
 	title: 'Screens/2 Plan an article',
@@ -69,11 +70,13 @@ export const B_MidConversation: Story = {
 	name: '2(b) Mid-chat',
 	render: () => (
 		<div className="flex flex-col">
-			<MidChatScreen />
+			<MockArticle>
+				<MidChatScreen />
+			</MockArticle>
 			<Annotation>
-				Ticking a reference in the chat sends it across into References immediately — the
-				wash on the newly added reference is the only thing marking the change. Section 3
-				is being typed by hand at the same time, which is equally allowed.
+				Wired, and the Proposal is live: Accept it and the Section lands in the Outline
+				beside it and the total moves to 2,800. The Chat proposes and the client applies,
+				so the ops run through the same writer the Plan Panel types into.
 			</Annotation>
 		</div>
 	),
@@ -178,6 +181,23 @@ export const I_PlanPanelWired: Story = {
 				Every field here writes through the same ops the Chat proposes in, so the Panel
 				cannot make a change the applier would refuse. Typing debounces: the Plan is one
 				blob re-broadcast on every write, and a keystroke is not a write.
+			</Annotation>
+		</div>
+	),
+}
+
+export const J_StaleProposal: Story = {
+	name: '2(j) A Proposal the Plan refuses',
+	render: () => (
+		<div className="flex flex-col">
+			<MockArticle>
+				<StaleProposalScreen />
+			</MockArticle>
+			<Annotation>
+				Accept it. Whole-field comparison is conservative and will refuse a Proposal
+				against a field the writer has since touched, so the card says which op failed,
+				what it expected, and what it found — never a greyed-out card with no explanation.
+				It stays open: fix the Plan and Accept again, or Decline and the Chat is told why.
 			</Annotation>
 		</div>
 	),

--- a/src/client/screens/article/StaleProposalScreen.tsx
+++ b/src/client/screens/article/StaleProposalScreen.tsx
@@ -5,13 +5,8 @@ import { useMockPlan } from '../../mock/MockArticle'
 import { useMockChat } from '../../mock/MockChat'
 import { staleProposal } from '../../mock/transcript'
 
-/**
- * 2(j) — A Proposal the Plan refuses. Accept it and the applier compares the
- * op's `expected` whole-field against the title the Plan carries, finds they
- * differ, and refuses the batch. The card says which op failed, what it
- * expected, and what it found, and stays open: the writer can fix the Plan and
- * Accept again, or Decline and send that sentence back to the Chat.
- */
+/** 2(j) — A Proposal the Plan refuses. Accept it: the card says what it expected
+ * against what it found, and stays open. */
 export function StaleProposalScreen() {
 	const plan = useMockPlan()
 	const chat = useMockChat(staleProposal)

--- a/src/client/screens/article/StaleProposalScreen.tsx
+++ b/src/client/screens/article/StaleProposalScreen.tsx
@@ -1,7 +1,7 @@
 import { ChatPanel } from '../../chat/ChatPanel'
 import { ArticleBar } from '../../components/ArticleBar'
 import { Frame, FrameBody } from '../../components/Frame'
-import { useArticlePlan } from '../../lib/article'
+import { useMockPlan } from '../../mock/MockArticle'
 import { useMockChat } from '../../mock/MockChat'
 import { staleProposal } from '../../mock/transcript'
 
@@ -13,7 +13,7 @@ import { staleProposal } from '../../mock/transcript'
  * Accept again, or Decline and send that sentence back to the Chat.
  */
 export function StaleProposalScreen() {
-	const plan = useArticlePlan()
+	const plan = useMockPlan()
 	const chat = useMockChat(staleProposal)
 
 	return (

--- a/src/client/screens/article/StaleProposalScreen.tsx
+++ b/src/client/screens/article/StaleProposalScreen.tsx
@@ -1,0 +1,27 @@
+import { ChatPanel } from '../../chat/ChatPanel'
+import { ArticleBar } from '../../components/ArticleBar'
+import { Frame, FrameBody } from '../../components/Frame'
+import { useArticlePlan } from '../../lib/article'
+import { useMockChat } from '../../mock/MockChat'
+import { staleProposal } from '../../mock/transcript'
+
+/**
+ * 2(j) — A Proposal the Plan refuses. Accept it and the applier compares the
+ * op's `expected` whole-field against the title the Plan carries, finds they
+ * differ, and refuses the batch. The card says which op failed, what it
+ * expected, and what it found, and stays open: the writer can fix the Plan and
+ * Accept again, or Decline and send that sentence back to the Chat.
+ */
+export function StaleProposalScreen() {
+	const plan = useArticlePlan()
+	const chat = useMockChat(staleProposal)
+
+	return (
+		<Frame width={560}>
+			<ArticleBar title={plan.title} open={['chat']} status="planning" />
+			<FrameBody className="h-[18rem]">
+				<ChatPanel {...chat} plan={plan} />
+			</FrameBody>
+		</Frame>
+	)
+}

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -2,7 +2,11 @@ import { getCurrentAgent } from 'agents'
 import { tool, type ToolSet } from 'ai'
 import { z } from 'zod'
 
-import { proposePlanChangeInput, proposePlanChangeTool } from '../../shared/chat'
+import {
+	proposePlanChangeInput,
+	proposePlanChangeTool,
+	recordOffersTool,
+} from '../../shared/chat'
 import { offerBatchSchema } from '../../shared/offer'
 import type { ArticleAgent } from '../article-agent'
 
@@ -81,10 +85,6 @@ const recordOffers = tool({
 		}))
 	},
 })
-
-/** Not in shared/chat.ts, because this tool resolves server-side and no client
- * matches on it. */
-export const recordOffersTool = 'recordOffers'
 
 /** Typed as the whole `ToolSet` rather than inferred: the Proposal tool has no
  * `execute` and so no return type to infer, and the wide type is what lets the

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -5,6 +5,7 @@ import { z } from 'zod'
 import {
 	proposePlanChangeInput,
 	proposePlanChangeTool,
+	recordedOffersOutput,
 	recordOffersTool,
 } from '../../shared/chat'
 import { offerBatchSchema } from '../../shared/offer'
@@ -71,6 +72,9 @@ const recordOffers = tool({
 	].join('\n'),
 	// An object at the top level, like the Proposal tool's input.
 	inputSchema: z.strictObject({ offers: offerBatchSchema }),
+	// The Chat Panel parses this output to find the rows a turn recorded, and
+	// fails soft when it cannot — so bind both ends to the one schema.
+	outputSchema: recordedOffersOutput,
 	execute: async ({ offers }) => {
 		// The module is imported once; the instance is per turn.
 		const { agent } = getCurrentAgent<ArticleAgent>()

--- a/src/shared/chat.ts
+++ b/src/shared/chat.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 
+import { dispositions } from './offer'
 import { chatProposalSchema, planSchema } from './plan'
 
 /**
@@ -29,6 +30,27 @@ export const proposePlanChangeTool = 'proposePlanChange'
  */
 export const proposePlanChangeInput = z.strictObject({ ops: chatProposalSchema })
 export type ProposePlanChangeInput = z.infer<typeof proposePlanChangeInput>
+
+/** The name the research tool is registered and matched under. It resolves
+ * server-side and the client answers nothing, but the Chat Panel reads its
+ * result to show the Offers the turn recorded. */
+export const recordOffersTool = 'recordOffers'
+
+/**
+ * What `recordOffers` hands back: enough for the model to refer to what it
+ * turned up, and the ids the Chat Panel looks the rows up by. The Panel renders
+ * the row rather than this, because the row carries the whole Offer and this
+ * carries a name.
+ */
+export const recordedOffersOutput = z.array(
+	z.object({
+		id: z.string(),
+		name: z.string().optional(),
+		disposition: z.enum(dispositions),
+		duplicate: z.boolean(),
+	}),
+)
+export type RecordedOffers = z.infer<typeof recordedOffersOutput>
 
 /**
  * What the client sends alongside the messages. The Plan rides here because

--- a/src/shared/chat.ts
+++ b/src/shared/chat.ts
@@ -31,17 +31,12 @@ export const proposePlanChangeTool = 'proposePlanChange'
 export const proposePlanChangeInput = z.strictObject({ ops: chatProposalSchema })
 export type ProposePlanChangeInput = z.infer<typeof proposePlanChangeInput>
 
-/** The name the research tool is registered and matched under. It resolves
- * server-side and the client answers nothing, but the Chat Panel reads its
- * result to show the Offers the turn recorded. */
+/** The name the research tool is registered and matched under. The client
+ * answers nothing, but reads the result to show what the turn recorded. */
 export const recordOffersTool = 'recordOffers'
 
-/**
- * What `recordOffers` hands back: enough for the model to refer to what it
- * turned up, and the ids the Chat Panel looks the rows up by. The Panel renders
- * the row rather than this, because the row carries the whole Offer and this
- * carries a name.
- */
+/** What `recordOffers` hands back: enough for the model to refer to what it
+ * turned up, and the ids the Chat Panel looks the rows up by. */
 export const recordedOffersOutput = z.array(
 	z.object({
 		id: z.string(),

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -21,19 +21,79 @@ import { planSchema, referenceContent } from './schema'
  */
 export type RefusalType = 'malformed' | 'missing' | 'stale' | 'invalid'
 
+/**
+ * Exactly what went wrong, as a code rather than a sentence. `RefusalType` sorts
+ * refusals into four kinds and this names the one that happened, which is what a
+ * caller needs to write its own sentence.
+ *
+ * Closed on purpose: adding a refusal site adds a member here, and the client's
+ * table stops compiling until it says what the new one reads as.
+ */
+export type RefusalReason =
+	| 'unreadable'
+	| 'noSection'
+	| 'noParent'
+	| 'noAnchor'
+	| 'noReference'
+	| 'noPlan'
+	| 'stale'
+	| 'duplicateSectionId'
+	| 'duplicateReferenceId'
+	| 'moveUnderOwn'
+	| 'mergeUnderOwn'
+	| 'mergeWithItself'
+	| 'anchorToItself'
+	| 'wouldNotParse'
+
+/** What a refusal is about. The id is the Plan's, so a caller can name the thing
+ * the way the Outline and the References list already name it. */
+export type RefusalSubject =
+	| { of: 'article' }
+	| { of: 'section'; id: string }
+	| { of: 'reference'; id: string }
+
 export type Refusal = {
 	type: RefusalType
+	/** Which of the four went wrong. */
+	reason: RefusalReason
 	/** Which op refused, counting from 0, and null when the refusal is about the
 	 * Proposal as a whole. */
 	index: number | null
 	/** Which op refused, and null when the malformed payload is what hid it. */
 	op: OpName | null
-	/** One sentence, written for the writer to read. */
+	/** What the refusal is about, and null where it is about no one record. */
+	subject: RefusalSubject | null
+	/** The second record a reason names — the Section a merge would go under, the
+	 * Section an anchor was looked for in. Null where the reason names one. */
+	other: RefusalSubject | null
+	/**
+	 * One sentence, **written for the model**. A Declined Proposal sends it back
+	 * as the reason (§6), so it names the op and the ids and may run long. What
+	 * the writer reads is built from `reason` and the fields above, in
+	 * `src/client/plan/refusalText.ts` — one English string here, and one table
+	 * there to swap when a second language arrives.
+	 */
 	message: string
 	/** The value the op named against the value the Plan carries. Both are
 	 * present on a stale field and absent otherwise. */
 	expected?: unknown
 	found?: unknown
+}
+
+const articleSubject: RefusalSubject = { of: 'article' }
+const sectionSubject = (id: string): RefusalSubject => ({ of: 'section', id })
+const referenceSubject = (id: string): RefusalSubject => ({ of: 'reference', id })
+
+/** A content op reads `nodeId: null` as the Article — §6. */
+const scopeSubject = (nodeId: string | null): RefusalSubject =>
+	nodeId === null ? articleSubject : sectionSubject(nodeId)
+
+/** The neighbour a structural op anchored to, which is the one the Plan could
+ * not find. Exactly one of the two is stated — ops.ts. */
+const anchorSubject = (op: Anchor): RefusalSubject | null => {
+	const anchor = op.afterId ?? op.beforeId
+
+	return anchor === undefined || anchor === null ? null : sectionSubject(anchor)
 }
 
 export type ApplyResult = { ok: true; plan: Plan } | { ok: false; refusal: Refusal }
@@ -60,32 +120,53 @@ export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
 }
 
 function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
-	const refuse = (type: RefusalType, message: string): Refusal => ({
-		type,
-		index,
-		op: op.op,
-		message,
-	})
+	const refuse = (
+		type: RefusalType,
+		reason: RefusalReason,
+		subject: RefusalSubject | null,
+		message: string,
+		other: RefusalSubject | null = null,
+	): Refusal => ({ type, reason, index, op: op.op, subject, other, message })
 
-	const stale = (where: string, expected: unknown, found: unknown): Refusal => ({
+	const stale = (
+		subject: RefusalSubject,
+		where: string,
+		expected: unknown,
+		found: unknown,
+	): Refusal => ({
 		...refuse(
 			'stale',
+			'stale',
+			subject,
 			`${op.op} on ${where} expected ${JSON.stringify(expected)} and the Plan carries ${JSON.stringify(found)}.`,
 		),
 		expected,
 		found,
 	})
 
-	const absent = (what: string) =>
-		refuse('missing', `${op.op} names ${what}, which the Plan does not carry.`)
+	const absent = (reason: RefusalReason, subject: RefusalSubject, what: string) =>
+		refuse(
+			'missing',
+			reason,
+			subject,
+			`${op.op} names ${what}, which the Plan does not carry.`,
+		)
 
 	switch (op.op) {
 		case 'createNode': {
 			const siblings = childrenOf(plan, op.parentId)
-			if (siblings === null) return absent(`parent ${op.parentId}`)
+			if (siblings === null)
+				return absent('noParent', scopeSubject(op.parentId), `parent ${op.parentId}`)
 
 			const at = insertionIndex(siblings, op)
-			if (at === null) return refuse('missing', anchorMissing(op))
+			if (at === null)
+				return refuse(
+					'missing',
+					'noAnchor',
+					anchorSubject(op),
+					anchorMissing(op),
+					scopeSubject(op.parentId),
+				)
 
 			// checkIds catches a repeated id at the final parse, but that refusal
 			// cannot say which op carried it. Claiming them here is what does.
@@ -94,6 +175,8 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 				if (taken.has(id)) {
 					return refuse(
 						'invalid',
+						'duplicateSectionId',
+						sectionSubject(id),
 						`${op.op} would leave two Sections carrying the id ${id}.`,
 					)
 				}
@@ -107,20 +190,29 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'moveNode': {
 			const site = locate(plan.outline, op.nodeId)
-			if (site === null) return absent(`node ${op.nodeId}`)
+			if (site === null)
+				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
 
 			const node = site.siblings[site.index]
 			if (op.parentId !== null && subtreeIds(node).includes(op.parentId)) {
 				return refuse(
 					'invalid',
+					'moveUnderOwn',
+					sectionSubject(op.nodeId),
 					`${op.op} would move ${op.nodeId} under a node it contains.`,
+					sectionSubject(op.parentId),
 				)
 			}
 			// Caught here rather than as a missing anchor, which is what it becomes
 			// once the node is out of the Outline, and which would say the Plan does
 			// not carry a node it does.
 			if (op.afterId === op.nodeId || op.beforeId === op.nodeId) {
-				return refuse('invalid', `${op.op} cannot anchor ${op.nodeId} to itself.`)
+				return refuse(
+					'invalid',
+					'anchorToItself',
+					sectionSubject(op.nodeId),
+					`${op.op} cannot anchor ${op.nodeId} to itself.`,
+				)
 			}
 
 			// The node comes out before the destination is known good. That is safe
@@ -129,10 +221,18 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			site.siblings.splice(site.index, 1)
 
 			const siblings = childrenOf(plan, op.parentId)
-			if (siblings === null) return absent(`parent ${op.parentId}`)
+			if (siblings === null)
+				return absent('noParent', scopeSubject(op.parentId), `parent ${op.parentId}`)
 
 			const at = insertionIndex(siblings, op)
-			if (at === null) return refuse('missing', anchorMissing(op))
+			if (at === null)
+				return refuse(
+					'missing',
+					'noAnchor',
+					anchorSubject(op),
+					anchorMissing(op),
+					scopeSubject(op.parentId),
+				)
 
 			siblings.splice(at, 0, node)
 			return null
@@ -140,20 +240,30 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'mergeNodes': {
 			if (op.nodeId === op.intoId) {
-				return refuse('invalid', `${op.op} names ${op.nodeId} on both sides.`)
+				return refuse(
+					'invalid',
+					'mergeWithItself',
+					sectionSubject(op.nodeId),
+					`${op.op} names ${op.nodeId} on both sides.`,
+				)
 			}
 
 			const site = locate(plan.outline, op.nodeId)
-			if (site === null) return absent(`node ${op.nodeId}`)
+			if (site === null)
+				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
 			const intoSite = locate(plan.outline, op.intoId)
-			if (intoSite === null) return absent(`node ${op.intoId}`)
+			if (intoSite === null)
+				return absent('noSection', sectionSubject(op.intoId), `node ${op.intoId}`)
 
 			const node = site.siblings[site.index]
 			const into = intoSite.siblings[intoSite.index]
 			if (subtreeIds(node).includes(op.intoId)) {
 				return refuse(
 					'invalid',
+					'mergeUnderOwn',
+					sectionSubject(op.nodeId),
 					`${op.op} would merge ${op.nodeId} into ${op.intoId}, which it contains.`,
+					sectionSubject(op.intoId),
 				)
 			}
 
@@ -167,7 +277,8 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'deleteNode': {
 			const site = locate(plan.outline, op.nodeId)
-			if (site === null) return absent(`node ${op.nodeId}`)
+			if (site === null)
+				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
 
 			// The unplacing lands in this op or nowhere: the Plan is written whole,
 			// and a Reference naming a node that is gone does not parse — §4.
@@ -182,10 +293,16 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setTitle': {
 			const scope = scopeOf(plan, op.nodeId)
-			if (scope === null) return absent(`node ${op.nodeId}`)
+			if (scope === null)
+				return absent('noSection', scopeSubject(op.nodeId), `node ${op.nodeId}`)
 
 			if (!matches(op.expected, scope.title))
-				return stale(scopeName(op.nodeId), op.expected, scope.title)
+				return stale(
+					scopeSubject(op.nodeId),
+					scopeName(op.nodeId),
+					op.expected,
+					scope.title,
+				)
 
 			scope.title = op.value
 			return null
@@ -193,11 +310,12 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setIntent': {
 			const node = findNode(plan, op.nodeId)
-			if (node === null) return absent(`node ${op.nodeId}`)
+			if (node === null)
+				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
 
 			const found = node.intent ?? null
 			if (!matches(op.expected, found))
-				return stale(scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
 
 			if (op.value === null) delete node.intent
 			else node.intent = op.value
@@ -210,18 +328,19 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			// `totalTarget`, and its Adjectives are required where a node's are not.
 			if (op.nodeId === null) {
 				if (!matches(op.expected, plan.totalTarget)) {
-					return stale(scopeName(null), op.expected, plan.totalTarget)
+					return stale(articleSubject, scopeName(null), op.expected, plan.totalTarget)
 				}
 				plan.totalTarget = op.value
 				return null
 			}
 
 			const node = findNode(plan, op.nodeId)
-			if (node === null) return absent(`node ${op.nodeId}`)
+			if (node === null)
+				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
 
 			const found = node.target ?? null
 			if (!matches(op.expected, found))
-				return stale(scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
 
 			if (op.value === null) delete node.target
 			else node.target = op.value
@@ -230,11 +349,12 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setVoice': {
 			const scope = scopeOf(plan, op.nodeId)
-			if (scope === null) return absent(`node ${op.nodeId}`)
+			if (scope === null)
+				return absent('noSection', scopeSubject(op.nodeId), `node ${op.nodeId}`)
 
 			const found = scope.voice ?? null
 			if (!matches(op.expected, found))
-				return stale(scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
 
 			if (op.value === null) delete scope.voice
 			else scope.voice = op.value
@@ -244,18 +364,19 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		case 'setAdjectives': {
 			if (op.nodeId === null) {
 				if (!matches(op.expected, plan.adjectives)) {
-					return stale(scopeName(null), op.expected, plan.adjectives)
+					return stale(articleSubject, scopeName(null), op.expected, plan.adjectives)
 				}
 				plan.adjectives = op.value
 				return null
 			}
 
 			const node = findNode(plan, op.nodeId)
-			if (node === null) return absent(`node ${op.nodeId}`)
+			if (node === null)
+				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
 
 			const found = node.adjectives ?? []
 			if (!matches(op.expected, found))
-				return stale(scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
 
 			if (op.value.length === 0) delete node.adjectives
 			else node.adjectives = op.value
@@ -264,13 +385,23 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'placeReference': {
 			const reference = plan.references.find((held) => held.id === op.referenceId)
-			if (reference === undefined) return absent(`Reference ${op.referenceId}`)
+			if (reference === undefined)
+				return absent(
+					'noReference',
+					referenceSubject(op.referenceId),
+					`Reference ${op.referenceId}`,
+				)
 
 			if (!matches(op.expected, reference.nodeId)) {
-				return stale(`Reference ${op.referenceId}`, op.expected, reference.nodeId)
+				return stale(
+					referenceSubject(op.referenceId),
+					`Reference ${op.referenceId}`,
+					op.expected,
+					reference.nodeId,
+				)
 			}
 			if (op.value !== null && findNode(plan, op.value) === null)
-				return absent(`node ${op.value}`)
+				return absent('noSection', sectionSubject(op.value), `node ${op.value}`)
 
 			reference.nodeId = op.value
 			return null
@@ -282,11 +413,17 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			if (plan.references.some((held) => held.id === op.reference.id)) {
 				return refuse(
 					'invalid',
+					'duplicateReferenceId',
+					referenceSubject(op.reference.id),
 					`${op.op} would leave two References carrying the id ${op.reference.id}.`,
 				)
 			}
 			if (op.reference.nodeId !== null && findNode(plan, op.reference.nodeId) === null)
-				return absent(`node ${op.reference.nodeId}`)
+				return absent(
+					'noSection',
+					sectionSubject(op.reference.nodeId),
+					`node ${op.reference.nodeId}`,
+				)
 
 			plan.references.push(op.reference)
 			return null
@@ -294,7 +431,12 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'deleteReference': {
 			const at = plan.references.findIndex((held) => held.id === op.referenceId)
-			if (at === -1) return absent(`Reference ${op.referenceId}`)
+			if (at === -1)
+				return absent(
+					'noReference',
+					referenceSubject(op.referenceId),
+					`Reference ${op.referenceId}`,
+				)
 
 			plan.references.splice(at, 1)
 			return null
@@ -302,11 +444,21 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setReference': {
 			const reference = plan.references.find((held) => held.id === op.referenceId)
-			if (reference === undefined) return absent(`Reference ${op.referenceId}`)
+			if (reference === undefined)
+				return absent(
+					'noReference',
+					referenceSubject(op.referenceId),
+					`Reference ${op.referenceId}`,
+				)
 
 			const found = referenceContent(reference)
 			if (!matches(op.expected, found)) {
-				return stale(`Reference ${op.referenceId}`, op.expected, found)
+				return stale(
+					referenceSubject(op.referenceId),
+					`Reference ${op.referenceId}`,
+					op.expected,
+					found,
+				)
 			}
 
 			// The content is replaced whole, so a field the op leaves out is a
@@ -429,8 +581,11 @@ function malformed(error: z.ZodError): Refusal {
 
 	return {
 		type: 'malformed',
+		reason: 'unreadable',
 		index,
 		op: null,
+		subject: null,
+		other: null,
 		message: `An op does not match the vocabulary${at(issue.path.slice(1))}: ${issue.message}`,
 	}
 }
@@ -440,8 +595,11 @@ function invalidPlan(error: z.ZodError): Refusal {
 
 	return {
 		type: 'invalid',
+		reason: 'wouldNotParse',
 		index: null,
 		op: null,
+		subject: null,
+		other: null,
 		message: `The Proposal would leave a Plan the schema refuses${at(issue.path)}: ${issue.message}`,
 	}
 }

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -37,13 +37,30 @@ export type RefusalReason =
 	| 'noReference'
 	| 'noPlan'
 	| 'stale'
-	| 'duplicateSectionId'
-	| 'duplicateReferenceId'
+	| 'duplicateId'
 	| 'moveUnderOwn'
 	| 'mergeUnderOwn'
 	| 'mergeWithItself'
 	| 'anchorToItself'
 	| 'wouldNotParse'
+
+/** Which of the four kinds each reason is. Stated once here rather than passed
+ * beside the reason at every refusal site, where the two could disagree. */
+const kindOf: Record<RefusalReason, RefusalType> = {
+	unreadable: 'malformed',
+	noSection: 'missing',
+	noParent: 'missing',
+	noAnchor: 'missing',
+	noReference: 'missing',
+	noPlan: 'missing',
+	stale: 'stale',
+	duplicateId: 'invalid',
+	moveUnderOwn: 'invalid',
+	mergeUnderOwn: 'invalid',
+	mergeWithItself: 'invalid',
+	anchorToItself: 'invalid',
+	wouldNotParse: 'invalid',
+}
 
 /** What a refusal is about. The id is the Plan's, so a caller can name the thing
  * the way the Outline and the References list already name it. */
@@ -53,8 +70,9 @@ export type RefusalSubject =
 	| { of: 'reference'; id: string }
 
 export type Refusal = {
+	/** Which of the four kinds, derived from `reason`. */
 	type: RefusalType
-	/** Which of the four went wrong. */
+	/** Which check failed. */
 	reason: RefusalReason
 	/** Which op refused, counting from 0, and null when the refusal is about the
 	 * Proposal as a whole. */
@@ -87,6 +105,16 @@ const referenceSubject = (id: string): RefusalSubject => ({ of: 'reference', id 
 /** A content op reads `nodeId: null` as the Article — §6. */
 const scopeSubject = (nodeId: string | null): RefusalSubject =>
 	nodeId === null ? articleSubject : sectionSubject(nodeId)
+
+/** What the model's sentence calls a record: the data model's own words, ids
+ * included, because the model proposes in them. What the writer reads instead is
+ * `src/client/plan/refusalText.ts`. */
+function nameFor(subject: RefusalSubject, reason: RefusalReason): string {
+	if (subject.of === 'article') return 'the Article'
+	if (subject.of === 'reference') return `Reference ${subject.id}`
+
+	return reason === 'noParent' ? `parent ${subject.id}` : `node ${subject.id}`
+}
 
 /** The neighbour a structural op anchored to, which is the one the Plan could
  * not find. Exactly one of the two is stated — ops.ts. */
@@ -121,47 +149,49 @@ export function applyProposal(plan: Plan, proposal: unknown): ApplyResult {
 
 function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 	const refuse = (
-		type: RefusalType,
 		reason: RefusalReason,
 		subject: RefusalSubject | null,
 		message: string,
 		other: RefusalSubject | null = null,
-	): Refusal => ({ type, reason, index, op: op.op, subject, other, message })
+	): Refusal => ({
+		type: kindOf[reason],
+		reason,
+		index,
+		op: op.op,
+		subject,
+		other,
+		message,
+	})
 
 	const stale = (
 		subject: RefusalSubject,
-		where: string,
 		expected: unknown,
 		found: unknown,
 	): Refusal => ({
 		...refuse(
 			'stale',
-			'stale',
 			subject,
-			`${op.op} on ${where} expected ${JSON.stringify(expected)} and the Plan carries ${JSON.stringify(found)}.`,
+			`${op.op} on ${nameFor(subject, 'stale')} expected ${JSON.stringify(expected)} and the Plan carries ${JSON.stringify(found)}.`,
 		),
 		expected,
 		found,
 	})
 
-	const absent = (reason: RefusalReason, subject: RefusalSubject, what: string) =>
+	const absent = (reason: RefusalReason, subject: RefusalSubject) =>
 		refuse(
-			'missing',
 			reason,
 			subject,
-			`${op.op} names ${what}, which the Plan does not carry.`,
+			`${op.op} names ${nameFor(subject, reason)}, which the Plan does not carry.`,
 		)
 
 	switch (op.op) {
 		case 'createNode': {
 			const siblings = childrenOf(plan, op.parentId)
-			if (siblings === null)
-				return absent('noParent', scopeSubject(op.parentId), `parent ${op.parentId}`)
+			if (siblings === null) return absent('noParent', scopeSubject(op.parentId))
 
 			const at = insertionIndex(siblings, op)
 			if (at === null)
 				return refuse(
-					'missing',
 					'noAnchor',
 					anchorSubject(op),
 					anchorMissing(op),
@@ -174,8 +204,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			for (const id of subtreeIds(op.node)) {
 				if (taken.has(id)) {
 					return refuse(
-						'invalid',
-						'duplicateSectionId',
+						'duplicateId',
 						sectionSubject(id),
 						`${op.op} would leave two Sections carrying the id ${id}.`,
 					)
@@ -190,13 +219,11 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'moveNode': {
 			const site = locate(plan.outline, op.nodeId)
-			if (site === null)
-				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
+			if (site === null) return absent('noSection', sectionSubject(op.nodeId))
 
 			const node = site.siblings[site.index]
 			if (op.parentId !== null && subtreeIds(node).includes(op.parentId)) {
 				return refuse(
-					'invalid',
 					'moveUnderOwn',
 					sectionSubject(op.nodeId),
 					`${op.op} would move ${op.nodeId} under a node it contains.`,
@@ -208,7 +235,6 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			// not carry a node it does.
 			if (op.afterId === op.nodeId || op.beforeId === op.nodeId) {
 				return refuse(
-					'invalid',
 					'anchorToItself',
 					sectionSubject(op.nodeId),
 					`${op.op} cannot anchor ${op.nodeId} to itself.`,
@@ -221,13 +247,11 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			site.siblings.splice(site.index, 1)
 
 			const siblings = childrenOf(plan, op.parentId)
-			if (siblings === null)
-				return absent('noParent', scopeSubject(op.parentId), `parent ${op.parentId}`)
+			if (siblings === null) return absent('noParent', scopeSubject(op.parentId))
 
 			const at = insertionIndex(siblings, op)
 			if (at === null)
 				return refuse(
-					'missing',
 					'noAnchor',
 					anchorSubject(op),
 					anchorMissing(op),
@@ -241,7 +265,6 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		case 'mergeNodes': {
 			if (op.nodeId === op.intoId) {
 				return refuse(
-					'invalid',
 					'mergeWithItself',
 					sectionSubject(op.nodeId),
 					`${op.op} names ${op.nodeId} on both sides.`,
@@ -249,17 +272,14 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			}
 
 			const site = locate(plan.outline, op.nodeId)
-			if (site === null)
-				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
+			if (site === null) return absent('noSection', sectionSubject(op.nodeId))
 			const intoSite = locate(plan.outline, op.intoId)
-			if (intoSite === null)
-				return absent('noSection', sectionSubject(op.intoId), `node ${op.intoId}`)
+			if (intoSite === null) return absent('noSection', sectionSubject(op.intoId))
 
 			const node = site.siblings[site.index]
 			const into = intoSite.siblings[intoSite.index]
 			if (subtreeIds(node).includes(op.intoId)) {
 				return refuse(
-					'invalid',
 					'mergeUnderOwn',
 					sectionSubject(op.nodeId),
 					`${op.op} would merge ${op.nodeId} into ${op.intoId}, which it contains.`,
@@ -277,8 +297,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'deleteNode': {
 			const site = locate(plan.outline, op.nodeId)
-			if (site === null)
-				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
+			if (site === null) return absent('noSection', sectionSubject(op.nodeId))
 
 			// The unplacing lands in this op or nowhere: the Plan is written whole,
 			// and a Reference naming a node that is gone does not parse — §4.
@@ -293,16 +312,10 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setTitle': {
 			const scope = scopeOf(plan, op.nodeId)
-			if (scope === null)
-				return absent('noSection', scopeSubject(op.nodeId), `node ${op.nodeId}`)
+			if (scope === null) return absent('noSection', scopeSubject(op.nodeId))
 
 			if (!matches(op.expected, scope.title))
-				return stale(
-					scopeSubject(op.nodeId),
-					scopeName(op.nodeId),
-					op.expected,
-					scope.title,
-				)
+				return stale(scopeSubject(op.nodeId), op.expected, scope.title)
 
 			scope.title = op.value
 			return null
@@ -310,12 +323,11 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setIntent': {
 			const node = findNode(plan, op.nodeId)
-			if (node === null)
-				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
+			if (node === null) return absent('noSection', sectionSubject(op.nodeId))
 
 			const found = node.intent ?? null
 			if (!matches(op.expected, found))
-				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), op.expected, found)
 
 			if (op.value === null) delete node.intent
 			else node.intent = op.value
@@ -328,19 +340,18 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			// `totalTarget`, and its Adjectives are required where a node's are not.
 			if (op.nodeId === null) {
 				if (!matches(op.expected, plan.totalTarget)) {
-					return stale(articleSubject, scopeName(null), op.expected, plan.totalTarget)
+					return stale(articleSubject, op.expected, plan.totalTarget)
 				}
 				plan.totalTarget = op.value
 				return null
 			}
 
 			const node = findNode(plan, op.nodeId)
-			if (node === null)
-				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
+			if (node === null) return absent('noSection', sectionSubject(op.nodeId))
 
 			const found = node.target ?? null
 			if (!matches(op.expected, found))
-				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), op.expected, found)
 
 			if (op.value === null) delete node.target
 			else node.target = op.value
@@ -349,12 +360,11 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'setVoice': {
 			const scope = scopeOf(plan, op.nodeId)
-			if (scope === null)
-				return absent('noSection', scopeSubject(op.nodeId), `node ${op.nodeId}`)
+			if (scope === null) return absent('noSection', scopeSubject(op.nodeId))
 
 			const found = scope.voice ?? null
 			if (!matches(op.expected, found))
-				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), op.expected, found)
 
 			if (op.value === null) delete scope.voice
 			else scope.voice = op.value
@@ -364,19 +374,18 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		case 'setAdjectives': {
 			if (op.nodeId === null) {
 				if (!matches(op.expected, plan.adjectives)) {
-					return stale(articleSubject, scopeName(null), op.expected, plan.adjectives)
+					return stale(articleSubject, op.expected, plan.adjectives)
 				}
 				plan.adjectives = op.value
 				return null
 			}
 
 			const node = findNode(plan, op.nodeId)
-			if (node === null)
-				return absent('noSection', sectionSubject(op.nodeId), `node ${op.nodeId}`)
+			if (node === null) return absent('noSection', sectionSubject(op.nodeId))
 
 			const found = node.adjectives ?? []
 			if (!matches(op.expected, found))
-				return stale(scopeSubject(op.nodeId), scopeName(op.nodeId), op.expected, found)
+				return stale(scopeSubject(op.nodeId), op.expected, found)
 
 			if (op.value.length === 0) delete node.adjectives
 			else node.adjectives = op.value
@@ -386,22 +395,13 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		case 'placeReference': {
 			const reference = plan.references.find((held) => held.id === op.referenceId)
 			if (reference === undefined)
-				return absent(
-					'noReference',
-					referenceSubject(op.referenceId),
-					`Reference ${op.referenceId}`,
-				)
+				return absent('noReference', referenceSubject(op.referenceId))
 
 			if (!matches(op.expected, reference.nodeId)) {
-				return stale(
-					referenceSubject(op.referenceId),
-					`Reference ${op.referenceId}`,
-					op.expected,
-					reference.nodeId,
-				)
+				return stale(referenceSubject(op.referenceId), op.expected, reference.nodeId)
 			}
 			if (op.value !== null && findNode(plan, op.value) === null)
-				return absent('noSection', sectionSubject(op.value), `node ${op.value}`)
+				return absent('noSection', sectionSubject(op.value))
 
 			reference.nodeId = op.value
 			return null
@@ -412,18 +412,13 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			// catches a repeated Section id, and cannot say which op carried it.
 			if (plan.references.some((held) => held.id === op.reference.id)) {
 				return refuse(
-					'invalid',
-					'duplicateReferenceId',
+					'duplicateId',
 					referenceSubject(op.reference.id),
 					`${op.op} would leave two References carrying the id ${op.reference.id}.`,
 				)
 			}
 			if (op.reference.nodeId !== null && findNode(plan, op.reference.nodeId) === null)
-				return absent(
-					'noSection',
-					sectionSubject(op.reference.nodeId),
-					`node ${op.reference.nodeId}`,
-				)
+				return absent('noSection', sectionSubject(op.reference.nodeId))
 
 			plan.references.push(op.reference)
 			return null
@@ -431,12 +426,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 
 		case 'deleteReference': {
 			const at = plan.references.findIndex((held) => held.id === op.referenceId)
-			if (at === -1)
-				return absent(
-					'noReference',
-					referenceSubject(op.referenceId),
-					`Reference ${op.referenceId}`,
-				)
+			if (at === -1) return absent('noReference', referenceSubject(op.referenceId))
 
 			plan.references.splice(at, 1)
 			return null
@@ -445,20 +435,11 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 		case 'setReference': {
 			const reference = plan.references.find((held) => held.id === op.referenceId)
 			if (reference === undefined)
-				return absent(
-					'noReference',
-					referenceSubject(op.referenceId),
-					`Reference ${op.referenceId}`,
-				)
+				return absent('noReference', referenceSubject(op.referenceId))
 
 			const found = referenceContent(reference)
 			if (!matches(op.expected, found)) {
-				return stale(
-					referenceSubject(op.referenceId),
-					`Reference ${op.referenceId}`,
-					op.expected,
-					found,
-				)
+				return stale(referenceSubject(op.referenceId), op.expected, found)
 			}
 
 			// The content is replaced whole, so a field the op leaves out is a
@@ -561,10 +542,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null
 }
 
-function scopeName(nodeId: string | null): string {
-	return nodeId === null ? 'the Article' : `node ${nodeId}`
-}
-
 function anchorMissing(op: Anchor & { op: OpName; parentId: string | null }): string {
 	const anchor =
 		op.afterId !== undefined ? `after ${op.afterId}` : `before ${op.beforeId}`
@@ -580,7 +557,7 @@ function malformed(error: z.ZodError): Refusal {
 	const index = typeof issue.path[0] === 'number' ? issue.path[0] : null
 
 	return {
-		type: 'malformed',
+		type: kindOf.unreadable,
 		reason: 'unreadable',
 		index,
 		op: null,
@@ -594,7 +571,7 @@ function invalidPlan(error: z.ZodError): Refusal {
 	const issue = error.issues[0]
 
 	return {
-		type: 'invalid',
+		type: kindOf.wouldNotParse,
 		reason: 'wouldNotParse',
 		index: null,
 		op: null,

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -41,7 +41,6 @@ export type RefusalReason =
 	| 'anchorToItself'
 	| 'wouldNotParse'
 
-/** Which of the four kinds each reason is. */
 const kindOf: Record<RefusalReason, RefusalType> = {
 	unreadable: 'malformed',
 	noSection: 'missing',
@@ -66,16 +65,15 @@ export type RefusalSubject =
 	| { of: 'reference'; id: string }
 
 export type Refusal = {
-	/** Which of the four kinds, derived from `reason`. */
+	/** Derived from `reason`. */
 	type: RefusalType
-	/** Which check failed. */
 	reason: RefusalReason
 	/** Which op refused, counting from 0, and null when the refusal is about the
 	 * Proposal as a whole. */
 	index: number | null
 	/** Which op refused, and null when the malformed payload is what hid it. */
 	op: OpName | null
-	/** What the refusal is about, and null where it is about no one record. */
+	/** Null where the refusal is about no one record. */
 	subject: RefusalSubject | null
 	/** The second record a reason names — a merge target, the Section an anchor
 	 * was sought in — and null for the reasons that name one. */

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -22,12 +22,9 @@ import { planSchema, referenceContent } from './schema'
 export type RefusalType = 'malformed' | 'missing' | 'stale' | 'invalid'
 
 /**
- * Exactly what went wrong, as a code rather than a sentence. `RefusalType` sorts
- * refusals into four kinds and this names the one that happened, which is what a
- * caller needs to write its own sentence.
- *
- * Closed on purpose: adding a refusal site adds a member here, and the client's
- * table stops compiling until it says what the new one reads as.
+ * Which check failed, as a code a caller can word for itself where
+ * `RefusalType`'s four kinds are too coarse to build a sentence from. Closed, so
+ * a new refusal site stops `refusalText.ts` compiling until it is worded.
  */
 export type RefusalReason =
 	| 'unreadable'
@@ -61,8 +58,8 @@ const kindOf: Record<RefusalReason, RefusalType> = {
 	wouldNotParse: 'invalid',
 }
 
-/** What a refusal is about. The id is the Plan's, so a caller can name the thing
- * the way the Outline and the References list already name it. */
+/** What a refusal is about, by the Plan's own id, so a caller can name it the
+ * way the Outline and the References list do. */
 export type RefusalSubject =
 	| { of: 'article' }
 	| { of: 'section'; id: string }
@@ -80,16 +77,12 @@ export type Refusal = {
 	op: OpName | null
 	/** What the refusal is about, and null where it is about no one record. */
 	subject: RefusalSubject | null
-	/** The second record a reason names — the Section a merge would go under, the
-	 * Section an anchor was looked for in. Null where the reason names one. */
+	/** The second record a reason names — a merge target, the Section an anchor
+	 * was sought in — and null for the reasons that name one. */
 	other: RefusalSubject | null
-	/**
-	 * One sentence, **written for the model**. A Declined Proposal sends it back
-	 * as the reason (§6), so it names the op and the ids and may run long. What
-	 * the writer reads is built from `reason` and the fields above, in
-	 * `src/client/plan/refusalText.ts` — one English string here, and one table
-	 * there to swap when a second language arrives.
-	 */
+	/** One sentence for the model, which a Declined Proposal sends back (§6), so
+	 * it names the op and the ids and may run long. The writer's sentence is
+	 * built from the fields above, in `src/client/plan/refusalText.ts`. */
 	message: string
 	/** The value the op named against the value the Plan carries. Both are
 	 * present on a stale field and absent otherwise. */
@@ -105,9 +98,8 @@ const referenceSubject = (id: string): RefusalSubject => ({ of: 'reference', id 
 const scopeSubject = (nodeId: string | null): RefusalSubject =>
 	nodeId === null ? articleSubject : sectionSubject(nodeId)
 
-/** What the model's sentence calls a record: the data model's own words, ids
- * included, because the model proposes in them. What the writer reads instead is
- * `src/client/plan/refusalText.ts`. */
+/** What the model's sentence calls a record — the data model's own words, ids
+ * included, because the model proposes in them. */
 function nameFor(subject: RefusalSubject, reason: RefusalReason): string {
 	if (subject.of === 'article') return 'the Article'
 	if (subject.of === 'reference') return `Reference ${subject.id}`
@@ -115,8 +107,8 @@ function nameFor(subject: RefusalSubject, reason: RefusalReason): string {
 	return reason === 'noParent' ? `parent ${subject.id}` : `node ${subject.id}`
 }
 
-/** The neighbour a structural op anchored to, which is the one the Plan could
- * not find. Exactly one of the two is stated — ops.ts. */
+/** The neighbour a structural op anchored to, and null where the anchor named
+ * an end rather than a sibling. */
 const anchorSubject = (op: Anchor): RefusalSubject | null => {
 	const anchor = op.afterId ?? op.beforeId
 

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -44,8 +44,7 @@ export type RefusalReason =
 	| 'anchorToItself'
 	| 'wouldNotParse'
 
-/** Which of the four kinds each reason is. Stated once here rather than passed
- * beside the reason at every refusal site, where the two could disagree. */
+/** Which of the four kinds each reason is. */
 const kindOf: Record<RefusalReason, RefusalType> = {
 	unreadable: 'malformed',
 	noSection: 'missing',

--- a/test/client/chat-fixtures.ts
+++ b/test/client/chat-fixtures.ts
@@ -1,11 +1,9 @@
 import type { UIMessage } from 'ai'
 
 /**
- * Building a transcript by hand, for the tests that read one.
- *
- * The cast is the point of sharing this: a tool part is a union over its
- * states, and a fixture states one state's fields against the whole union. One
- * cast in one place is one thing to fix when the SDK moves the union.
+ * Building a transcript by hand. Shared for the cast: a tool part is a union
+ * over its states and a fixture writes one state's fields, so this is the one
+ * place to fix when the SDK moves that union.
  */
 
 export function toolPart(

--- a/test/client/chat-fixtures.ts
+++ b/test/client/chat-fixtures.ts
@@ -1,0 +1,27 @@
+import type { UIMessage } from 'ai'
+
+/**
+ * Building a transcript by hand, for the tests that read one.
+ *
+ * The cast is the point of sharing this: a tool part is a union over its
+ * states, and a fixture states one state's fields against the whole union. One
+ * cast in one place is one thing to fix when the SDK moves the union.
+ */
+
+export function toolPart(
+	toolName: string,
+	state: string,
+	extra: Record<string, unknown> = {},
+): UIMessage['parts'][number] {
+	return {
+		type: `tool-${toolName}`,
+		toolCallId: 'call-1',
+		state,
+		...extra,
+	} as UIMessage['parts'][number]
+}
+
+/** One assistant turn carrying the parts given. */
+export function transcript(...parts: UIMessage['parts']): UIMessage[] {
+	return [{ id: 'm-1', role: 'assistant', parts }]
+}

--- a/test/client/chat-fixtures.ts
+++ b/test/client/chat-fixtures.ts
@@ -19,7 +19,6 @@ export function toolPart(
 	} as UIMessage['parts'][number]
 }
 
-/** One assistant turn carrying the parts given. */
 export function transcript(...parts: UIMessage['parts']): UIMessage[] {
 	return [{ id: 'm-1', role: 'assistant', parts }]
 }

--- a/test/client/chat-offers.test.ts
+++ b/test/client/chat-offers.test.ts
@@ -1,0 +1,79 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import { readRecordedOffers, recordedOfferIds } from '../../src/client/chat/offers'
+import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
+
+/**
+ * A research turn writes Offer rows this client never asked for, and nothing on
+ * the socket announces a row — §3. What the turn hands back is the only signal
+ * the Ledger gets that its list moved.
+ */
+
+function part(state: string, extra: Record<string, unknown> = {}) {
+	return {
+		type: `tool-${recordOffersTool}`,
+		toolCallId: 'call-1',
+		state,
+		input: { offers: [] },
+		...extra,
+	} as UIMessage['parts'][number]
+}
+
+function transcript(...parts: UIMessage['parts']): UIMessage[] {
+	return [{ id: 'm-1', role: 'assistant', parts }]
+}
+
+const recorded = [
+	{ id: 'offer-a', name: 'A study', disposition: 'undecided', duplicate: false },
+	{ id: 'offer-b', name: 'A quote', disposition: 'accepted', duplicate: true },
+]
+
+describe('a research turn', () => {
+	it('hands back the ids the Ledger holds rows for', () => {
+		const found = readRecordedOffers(
+			part('output-available', { output: recorded }) as never,
+		)
+
+		expect(found).toEqual(recorded)
+	})
+
+	it('reads nothing off a call that has not resolved', () => {
+		expect(readRecordedOffers(part('input-available') as never)).toBeNull()
+	})
+
+	it('reads nothing off a Proposal', () => {
+		const proposal = {
+			type: `tool-${proposePlanChangeTool}`,
+			toolCallId: 'call-2',
+			state: 'output-available',
+			input: { ops: [] },
+			output: 'done',
+		} as UIMessage['parts'][number]
+
+		expect(readRecordedOffers(proposal as never)).toBeNull()
+	})
+
+	/** Two turns can offer the same source: the second comes back marked a
+	 * duplicate, naming the row the first one wrote. */
+	it('names each id once, in the order the turns recorded them', () => {
+		const ids = recordedOfferIds([
+			...transcript(part('output-available', { output: recorded })),
+			{
+				id: 'm-2',
+				role: 'assistant',
+				parts: [
+					part('output-available', {
+						toolCallId: 'call-3',
+						output: [
+							{ id: 'offer-b', disposition: 'accepted', duplicate: true },
+							{ id: 'offer-c', disposition: 'undecided', duplicate: false },
+						],
+					}),
+				],
+			},
+		])
+
+		expect(ids).toEqual(['offer-a', 'offer-b', 'offer-c'])
+	})
+})

--- a/test/client/chat-offers.test.ts
+++ b/test/client/chat-offers.test.ts
@@ -4,11 +4,8 @@ import { readRecordedOffers, recordedOfferIds } from '../../src/client/chat/offe
 import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
 import { toolPart, transcript } from './chat-fixtures'
 
-/**
- * A research turn writes Offer rows this client never asked for, and nothing on
- * the socket announces a row — §3. What the turn hands back is the only signal
- * the Ledger gets that its list moved.
- */
+/** Reading a research turn's result, which is the Ledger's only signal that its
+ * list moved — §3. */
 
 const part = (state: string, extra: Record<string, unknown> = {}) =>
 	toolPart(recordOffersTool, state, { input: { offers: [] }, ...extra })

--- a/test/client/chat-offers.test.ts
+++ b/test/client/chat-offers.test.ts
@@ -1,8 +1,8 @@
-import type { UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 
 import { readRecordedOffers, recordedOfferIds } from '../../src/client/chat/offers'
 import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
+import { toolPart, transcript } from './chat-fixtures'
 
 /**
  * A research turn writes Offer rows this client never asked for, and nothing on
@@ -10,19 +10,8 @@ import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
  * the Ledger gets that its list moved.
  */
 
-function part(state: string, extra: Record<string, unknown> = {}) {
-	return {
-		type: `tool-${recordOffersTool}`,
-		toolCallId: 'call-1',
-		state,
-		input: { offers: [] },
-		...extra,
-	} as UIMessage['parts'][number]
-}
-
-function transcript(...parts: UIMessage['parts']): UIMessage[] {
-	return [{ id: 'm-1', role: 'assistant', parts }]
-}
+const part = (state: string, extra: Record<string, unknown> = {}) =>
+	toolPart(recordOffersTool, state, { input: { offers: [] }, ...extra })
 
 const recorded = [
 	{ id: 'offer-a', name: 'A study', disposition: 'undecided', duplicate: false },
@@ -43,13 +32,10 @@ describe('a research turn', () => {
 	})
 
 	it('reads nothing off a Proposal', () => {
-		const proposal = {
-			type: `tool-${proposePlanChangeTool}`,
-			toolCallId: 'call-2',
-			state: 'output-available',
+		const proposal = toolPart(proposePlanChangeTool, 'output-available', {
 			input: { ops: [] },
 			output: 'done',
-		} as UIMessage['parts'][number]
+		})
 
 		expect(readRecordedOffers(proposal as never)).toBeNull()
 	})

--- a/test/client/chat-proposals.test.ts
+++ b/test/client/chat-proposals.test.ts
@@ -1,0 +1,285 @@
+import type { UIMessage } from 'ai'
+import { describe, expect, it } from 'vitest'
+
+import {
+	acceptReason,
+	declineReason,
+	describeProposal,
+	readProposal,
+	ruleProposal,
+	waitingCalls,
+} from '../../src/client/chat/proposals'
+import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
+import { applyProposal, type Plan, type Proposal } from '../../src/shared/plan'
+import { makePlan } from '../shared/plan-fixtures'
+
+/**
+ * Reading Proposals out of a transcript, and ruling on one. No React and no
+ * socket: a Proposal is a suspended tool call, which is a plain object, and the
+ * ruling is the same pure function the Chat Panel and the showcase both run.
+ */
+
+const plan: Plan = makePlan({
+	title: 'Why cities stopped building',
+	totalTarget: 2400,
+	outline: [
+		{ id: 'sec-cranes', title: 'The year the cranes stopped', target: 300, children: [] },
+		{ id: 'sec-cost', title: 'Who actually pays', children: [] },
+	],
+	references: [
+		{
+			id: 'ref-quote',
+			type: 'quote',
+			provenance: { type: 'writer' },
+			text: 'The meter runs on an empty lot.',
+			nodeId: null,
+		},
+	],
+})
+
+function toolPart(state: string, extra: Record<string, unknown> = {}) {
+	return {
+		type: `tool-${proposePlanChangeTool}`,
+		toolCallId: 'call-1',
+		state,
+		...extra,
+	} as UIMessage['parts'][number]
+}
+
+const ops: Proposal = [
+	{
+		op: 'setTitle',
+		nodeId: 'sec-cost',
+		expected: 'Who actually pays',
+		value: 'Who pays',
+	},
+]
+
+function transcript(...parts: UIMessage['parts']): UIMessage[] {
+	return [{ id: 'm-1', role: 'assistant', parts }]
+}
+
+describe('reading a transcript', () => {
+	it('finds a call whose input has arrived and whose output has not', () => {
+		const messages = transcript(toolPart('input-available', { input: { ops } }))
+
+		expect(waitingCalls(messages)).toEqual([
+			{ toolCallId: 'call-1', toolName: proposePlanChangeTool },
+		])
+	})
+
+	it('leaves a Proposal still streaming, and one already ruled on', () => {
+		const messages = transcript(
+			toolPart('input-streaming', { input: {} }),
+			toolPart('output-available', { input: { ops }, output: 'done' }),
+			toolPart('output-error', { input: { ops }, errorText: 'no' }),
+		)
+
+		expect(waitingCalls(messages)).toEqual([])
+	})
+
+	/**
+	 * The batch-completeness rule has no orphan timeout, so this count is what
+	 * stands between the writer and a composer that silently does nothing.
+	 */
+	it('counts every suspended call, not only the Proposals', () => {
+		const waiting = waitingCalls(
+			transcript(toolPart('input-available', { input: { ops } }), {
+				type: `tool-${recordOffersTool}`,
+				toolCallId: 'call-2',
+				state: 'input-available',
+				input: {},
+			} as UIMessage['parts'][number]),
+		)
+
+		expect(waiting.map((call) => call.toolName)).toEqual([
+			proposePlanChangeTool,
+			recordOffersTool,
+		])
+	})
+
+	it('reads the ops off a suspended call', () => {
+		const call = readProposal(toolPart('input-available', { input: { ops } }) as never)
+
+		expect(call.toolCallId).toBe('call-1')
+		expect(call.ops).toEqual(ops)
+		expect(call.unreadable).toBeNull()
+	})
+
+	it('says why a payload could not be read rather than rendering blank', () => {
+		const call = readProposal(
+			toolPart('input-available', { input: { ops: [{ op: 'setTitle' }] } }) as never,
+		)
+
+		expect(call.ops).toBeNull()
+		expect(call.unreadable).toContain('expected')
+	})
+})
+
+describe('ruling on a Proposal', () => {
+	const call = { toolCallId: 'call-1', ops, unreadable: null }
+
+	it('applies the ops and answers the tool call', () => {
+		let written: Plan | null = null
+		const ruling = ruleProposal({
+			call,
+			accepted: true,
+			edit: (applied) => {
+				const result = applyProposal(plan, applied)
+				if (result.ok) written = result.plan
+
+				return result.ok ? null : result.refusal
+			},
+			refusal: null,
+		})
+
+		expect(ruling.refusal).toBeNull()
+		expect(ruling.answer).toEqual({ output: acceptReason(ops) })
+		expect(written).not.toBeNull()
+		expect(written!.outline[1].title).toBe('Who pays')
+	})
+
+	/**
+	 * The card says why and stays open. Whole-field comparison is conservative
+	 * and refuses against a field the writer has since touched, so the writer may
+	 * fix the Plan and Accept again.
+	 */
+	it('answers nothing when the Plan refuses, and hands back the reason', () => {
+		const stale = makePlan({
+			outline: [{ id: 'sec-cost', title: 'Who bears it', children: [] }],
+		})
+
+		const ruling = ruleProposal({
+			call,
+			accepted: true,
+			edit: (applied) => {
+				const result = applyProposal(stale, applied)
+
+				return result.ok ? null : result.refusal
+			},
+			refusal: null,
+		})
+
+		expect(ruling.answer).toBeNull()
+		expect(ruling.refusal?.type).toBe('stale')
+		expect(ruling.refusal?.message).toContain('Who bears it')
+	})
+
+	it('declines with is_error and the refusal the Accept produced', () => {
+		const refusal = {
+			type: 'stale' as const,
+			index: 0,
+			op: 'setTitle' as const,
+			message: 'setTitle on the Article expected "a" and the Plan carries "b".',
+		}
+
+		const ruling = ruleProposal({
+			call,
+			accepted: false,
+			edit: () => null,
+			refusal,
+		})
+
+		expect(ruling.answer).toEqual({ errorText: declineReason(call, refusal) })
+		expect(ruling.answer).toEqual({
+			errorText: expect.stringContaining('the Plan carries "b"'),
+		})
+	})
+
+	it('declines a Proposal it never applied without inventing a reason', () => {
+		const ruling = ruleProposal({
+			call,
+			accepted: false,
+			edit: () => null,
+			refusal: null,
+		})
+
+		expect(ruling.answer).toEqual({ errorText: 'The writer Declined this Proposal.' })
+	})
+
+	it('declines an unreadable Proposal rather than applying nothing quietly', () => {
+		const unreadable = {
+			toolCallId: 'call-1',
+			ops: null,
+			unreadable: 'ops: expected array',
+		}
+		const ruling = ruleProposal({
+			call: unreadable,
+			accepted: true,
+			edit: () => {
+				throw new Error('An unreadable Proposal must not reach the writer.')
+			},
+			refusal: null,
+		})
+
+		expect(ruling.answer).toEqual({
+			errorText: expect.stringContaining('ops: expected array'),
+		})
+	})
+})
+
+describe('what a card says', () => {
+	it('names a Section the way the Outline numbers it', () => {
+		const said = describeProposal(plan, [
+			{ op: 'setTarget', nodeId: 'sec-cost', expected: null, value: 700 },
+		])
+
+		expect(said).toEqual(['Set the length of §2 Who actually pays to 700 words.'])
+	})
+
+	it('reads a null Scope as the Article', () => {
+		const said = describeProposal(plan, [
+			{ op: 'setVoice', nodeId: null, expected: null, value: 'Explainer' },
+		])
+
+		expect(said).toEqual(['Set the Voice of the Article to Explainer.'])
+	})
+
+	it('says which neighbour a new Section anchors to', () => {
+		const said = describeProposal(plan, [
+			{
+				op: 'createNode',
+				parentId: null,
+				afterId: 'sec-cranes',
+				node: { id: 'sec-new', title: 'The appeal nobody files', children: [] },
+			},
+		])
+
+		expect(said).toEqual([
+			'Add a Section, “The appeal nobody files”, after §1 The year the cranes stopped.',
+		])
+	})
+
+	it('states the consequence a delete carries', () => {
+		const said = describeProposal(plan, [{ op: 'deleteNode', nodeId: 'sec-cranes' }])
+
+		expect(said[0]).toContain('unplace the References sitting there')
+	})
+
+	it('names a Reference by what it says', () => {
+		const said = describeProposal(plan, [
+			{
+				op: 'placeReference',
+				referenceId: 'ref-quote',
+				expected: null,
+				value: 'sec-cost',
+			},
+		])
+
+		expect(said).toEqual([
+			'Place “The meter runs on an empty lot.” at §2 Who actually pays.',
+		])
+	})
+
+	it('describes one op per op, in order', () => {
+		const said = describeProposal(plan, [
+			{ op: 'setTitle', nodeId: null, expected: plan.title, value: 'Stalled' },
+			{ op: 'setTarget', nodeId: null, expected: 2400, value: 2800 },
+		])
+
+		expect(said).toEqual([
+			'Retitle the Article “Stalled”.',
+			'Set the length of the Article to 2800 words.',
+		])
+	})
+})

--- a/test/client/chat-proposals.test.ts
+++ b/test/client/chat-proposals.test.ts
@@ -18,11 +18,7 @@ import {
 import { makePlan } from '../shared/plan-fixtures'
 import { toolPart, transcript } from './chat-fixtures'
 
-/**
- * Reading Proposals out of a transcript, and ruling on one. No React and no
- * socket: a Proposal is a suspended tool call, which is a plain object, and the
- * ruling is the same pure function the Chat Panel and the showcase both run.
- */
+/** Reading Proposals out of a transcript, and ruling on one. */
 
 const plan: Plan = makePlan({
 	title: 'Why cities stopped building',
@@ -76,10 +72,8 @@ describe('reading a transcript', () => {
 		expect(waitingCount(messages)).toBe(0)
 	})
 
-	/**
-	 * The batch-completeness rule has no orphan timeout, so this count is what
-	 * stands between the writer and a composer that silently does nothing.
-	 */
+	/** No orphan timeout, so this count is all that stands between the writer and
+	 * a composer that silently does nothing — §11. */
 	it('counts every suspended call, not only the Proposals', () => {
 		const messages = transcript(
 			toolPart(proposePlanChangeTool, 'input-available', { input: { ops } }),
@@ -137,11 +131,7 @@ describe('ruling on a Proposal', () => {
 		expect(written!.outline[1].title).toBe('Who pays')
 	})
 
-	/**
-	 * The card says why and stays open. Whole-field comparison is conservative
-	 * and refuses against a field the writer has since touched, so the writer may
-	 * fix the Plan and Accept again.
-	 */
+	/** The card stays open, so the writer can fix the Plan and Accept again. */
 	it('answers nothing when the Plan refuses, and hands back the reason', () => {
 		const stale = makePlan({
 			outline: [{ id: 'sec-cost', title: 'Who bears it', children: [] }],

--- a/test/client/chat-proposals.test.ts
+++ b/test/client/chat-proposals.test.ts
@@ -10,7 +10,12 @@ import {
 	waitingCalls,
 } from '../../src/client/chat/proposals'
 import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
-import { applyProposal, type Plan, type Proposal } from '../../src/shared/plan'
+import {
+	applyProposal,
+	type Plan,
+	type Proposal,
+	type Refusal,
+} from '../../src/shared/plan'
 import { makePlan } from '../shared/plan-fixtures'
 
 /**
@@ -166,10 +171,13 @@ describe('ruling on a Proposal', () => {
 	})
 
 	it('declines with is_error and the refusal the Accept produced', () => {
-		const refusal = {
-			type: 'stale' as const,
+		const refusal: Refusal = {
+			type: 'stale',
+			reason: 'stale',
 			index: 0,
-			op: 'setTitle' as const,
+			op: 'setTitle',
+			subject: { of: 'article' },
+			other: null,
 			message: 'setTitle on the Article expected "a" and the Plan carries "b".',
 		}
 

--- a/test/client/chat-proposals.test.ts
+++ b/test/client/chat-proposals.test.ts
@@ -1,4 +1,3 @@
-import type { UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -7,7 +6,7 @@ import {
 	describeProposal,
 	readProposal,
 	ruleProposal,
-	waitingCalls,
+	waitingCount,
 } from '../../src/client/chat/proposals'
 import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
 import {
@@ -17,6 +16,7 @@ import {
 	type Refusal,
 } from '../../src/shared/plan'
 import { makePlan } from '../shared/plan-fixtures'
+import { toolPart, transcript } from './chat-fixtures'
 
 /**
  * Reading Proposals out of a transcript, and ruling on one. No React and no
@@ -42,15 +42,6 @@ const plan: Plan = makePlan({
 	],
 })
 
-function toolPart(state: string, extra: Record<string, unknown> = {}) {
-	return {
-		type: `tool-${proposePlanChangeTool}`,
-		toolCallId: 'call-1',
-		state,
-		...extra,
-	} as UIMessage['parts'][number]
-}
-
 const ops: Proposal = [
 	{
 		op: 'setTitle',
@@ -60,27 +51,29 @@ const ops: Proposal = [
 	},
 ]
 
-function transcript(...parts: UIMessage['parts']): UIMessage[] {
-	return [{ id: 'm-1', role: 'assistant', parts }]
-}
-
 describe('reading a transcript', () => {
-	it('finds a call whose input has arrived and whose output has not', () => {
-		const messages = transcript(toolPart('input-available', { input: { ops } }))
+	it('counts a call whose input has arrived and whose output has not', () => {
+		const messages = transcript(
+			toolPart(proposePlanChangeTool, 'input-available', { input: { ops } }),
+		)
 
-		expect(waitingCalls(messages)).toEqual([
-			{ toolCallId: 'call-1', toolName: proposePlanChangeTool },
-		])
+		expect(waitingCount(messages)).toBe(1)
 	})
 
 	it('leaves a Proposal still streaming, and one already ruled on', () => {
 		const messages = transcript(
-			toolPart('input-streaming', { input: {} }),
-			toolPart('output-available', { input: { ops }, output: 'done' }),
-			toolPart('output-error', { input: { ops }, errorText: 'no' }),
+			toolPart(proposePlanChangeTool, 'input-streaming', { input: {} }),
+			toolPart(proposePlanChangeTool, 'output-available', {
+				input: { ops },
+				output: 'done',
+			}),
+			toolPart(proposePlanChangeTool, 'output-error', {
+				input: { ops },
+				errorText: 'no',
+			}),
 		)
 
-		expect(waitingCalls(messages)).toEqual([])
+		expect(waitingCount(messages)).toBe(0)
 	})
 
 	/**
@@ -88,23 +81,21 @@ describe('reading a transcript', () => {
 	 * stands between the writer and a composer that silently does nothing.
 	 */
 	it('counts every suspended call, not only the Proposals', () => {
-		const waiting = waitingCalls(
-			transcript(toolPart('input-available', { input: { ops } }), {
-				type: `tool-${recordOffersTool}`,
+		const messages = transcript(
+			toolPart(proposePlanChangeTool, 'input-available', { input: { ops } }),
+			toolPart(recordOffersTool, 'input-available', {
 				toolCallId: 'call-2',
-				state: 'input-available',
 				input: {},
-			} as UIMessage['parts'][number]),
+			}),
 		)
 
-		expect(waiting.map((call) => call.toolName)).toEqual([
-			proposePlanChangeTool,
-			recordOffersTool,
-		])
+		expect(waitingCount(messages)).toBe(2)
 	})
 
 	it('reads the ops off a suspended call', () => {
-		const call = readProposal(toolPart('input-available', { input: { ops } }) as never)
+		const call = readProposal(
+			toolPart(proposePlanChangeTool, 'input-available', { input: { ops } }) as never,
+		)
 
 		expect(call.toolCallId).toBe('call-1')
 		expect(call.ops).toEqual(ops)
@@ -113,7 +104,9 @@ describe('reading a transcript', () => {
 
 	it('says why a payload could not be read rather than rendering blank', () => {
 		const call = readProposal(
-			toolPart('input-available', { input: { ops: [{ op: 'setTitle' }] } }) as never,
+			toolPart(proposePlanChangeTool, 'input-available', {
+				input: { ops: [{ op: 'setTitle' }] },
+			}) as never,
 		)
 
 		expect(call.ops).toBeNull()

--- a/test/client/plan-refusal-text.test.ts
+++ b/test/client/plan-refusal-text.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from 'vitest'
+
+import { refusalText } from '../../src/client/plan/refusalText'
+import { applyProposal, type Plan, type ProposalInput } from '../../src/shared/plan'
+import { makePlan } from '../shared/plan-fixtures'
+
+/**
+ * What a refused edit reads as on screen, against what the same refusal says to
+ * the model. Every case runs the real applier rather than a hand-built
+ * `Refusal`, so a reason code that stops being produced takes its test with it.
+ *
+ * The rule these hold: nothing the writer reads names an op, an id, or a node.
+ * Those are the model's, and they stay on `refusal.message`.
+ */
+
+const plan: Plan = makePlan({
+	title: 'Why cities stopped building',
+	totalTarget: 2400,
+	outline: [
+		{ id: 'sec-cranes', title: 'The year the cranes stopped', children: [] },
+		{
+			id: 'sec-cost',
+			title: 'Who actually pays for the delay',
+			target: 900,
+			children: [{ id: 'sec-sub', title: 'The carrying cost', children: [] }],
+		},
+	],
+	references: [
+		{
+			id: 'ref-meter',
+			type: 'quote',
+			provenance: { type: 'writer' },
+			text: 'The meter runs on an empty lot.',
+			nodeId: null,
+		},
+	],
+})
+
+/** The refusal the applier produces, which is the one the Panel renders. */
+function refuse(ops: ProposalInput, against: Plan = plan) {
+	const result = applyProposal(against, ops)
+	if (result.ok) throw new Error('These ops were meant to be refused.')
+
+	return result.refusal
+}
+
+function reads(ops: ProposalInput, against: Plan = plan): string {
+	return refusalText(against, refuse(ops, against))
+}
+
+describe('what the writer reads', () => {
+	it('names the Section the way the Outline numbers it, and quotes both values', () => {
+		expect(
+			reads([
+				{ op: 'setTitle', nodeId: 'sec-cost', expected: 'Who pays', value: 'Who pays' },
+			]),
+		).toBe(
+			'§2 has changed since the Chat proposed this. It now reads “Who actually pays for the delay”, where the change expected “Who pays”.',
+		)
+	})
+
+	/** The full name of a Section is its number and its title, so a refused
+	 * setTitle would otherwise print that title twice. */
+	it('uses the bare number where the sentence goes on to quote the title', () => {
+		const said = reads([
+			{ op: 'setTitle', nodeId: 'sec-cost', expected: 'Who pays', value: 'x' },
+		])
+
+		expect(said.split('Who actually pays for the delay')).toHaveLength(2)
+	})
+
+	it('reads a null Scope as the Article', () => {
+		expect(reads([{ op: 'setTarget', nodeId: null, expected: 100, value: 2000 }])).toBe(
+			'The Article has changed since the Chat proposed this. It now reads 2400, where the change expected 100.',
+		)
+	})
+
+	it('says "nothing" for a field the Plan does not carry, never "null"', () => {
+		expect(
+			reads([{ op: 'setVoice', nodeId: null, expected: 'Explainer', value: 'Wry' }]),
+		).toContain('It now reads nothing, where the change expected “Explainer”.')
+	})
+
+	it('says an empty Adjectives list is nothing', () => {
+		expect(
+			reads([{ op: 'setAdjectives', nodeId: 'sec-cost', expected: ['wry'], value: [] }]),
+		).toContain('It now reads nothing, where the change expected wry.')
+	})
+
+	/** There is no name to give a Section the Plan does not carry, so the
+	 * sentence says it went rather than naming the fallback twice. */
+	it('does not try to name a Section that is gone', () => {
+		expect(reads([{ op: 'deleteNode', nodeId: 'sec-gone' }])).toBe(
+			'That change is for a Section that is no longer in the Outline. Ask the Chat to look again.',
+		)
+	})
+
+	it('names the Section an anchor was looked for in, which does exist', () => {
+		expect(
+			reads([
+				{
+					op: 'createNode',
+					parentId: 'sec-cost',
+					afterId: 'sec-gone',
+					node: { id: 'sec-new', title: 'New', children: [] },
+				},
+			]),
+		).toBe(
+			'That change puts a Section next to one that is no longer in §2 Who actually pays for the delay.',
+		)
+	})
+
+	it('does not try to name a Reference that is gone', () => {
+		expect(reads([{ op: 'deleteReference', referenceId: 'ref-gone' }])).toContain(
+			'no longer in the list',
+		)
+	})
+
+	it('names a Section that is in the way of a move', () => {
+		expect(
+			reads([
+				{ op: 'moveNode', nodeId: 'sec-cost', parentId: 'sec-sub', beforeId: null },
+			]),
+		).toBe(
+			'That change moves §2 Who actually pays for the delay inside §2.1 The carrying cost, which sits inside it.',
+		)
+	})
+
+	it('names the Section a duplicate id would collide with', () => {
+		expect(
+			reads([
+				{
+					op: 'createNode',
+					parentId: null,
+					beforeId: null,
+					node: { id: 'sec-cranes', title: 'Again', children: [] },
+				},
+			]),
+		).toBe(
+			'That change adds §1 The year the cranes stopped, which the Plan already carries.',
+		)
+	})
+
+	it('says a merge with itself plainly', () => {
+		expect(reads([{ op: 'mergeNodes', nodeId: 'sec-cost', intoId: 'sec-cost' }])).toBe(
+			'That change merges §2 Who actually pays for the delay into itself.',
+		)
+	})
+
+	it('says an unreadable payload without repeating the schema at the writer', () => {
+		expect(reads([{ op: 'setTitle' } as never])).toBe(
+			'The Chat sent a change that could not be read. Ask it to try again.',
+		)
+	})
+})
+
+/**
+ * The other reader. `message` is what a Declined Proposal sends back, so it
+ * keeps the op name and the ids the model proposed with — and that is exactly
+ * why it is not what the writer sees.
+ */
+describe('what the model reads', () => {
+	it('keeps the op name and the id the writer never saw', () => {
+		const refusal = refuse([
+			{ op: 'setTitle', nodeId: 'sec-cost', expected: 'Who pays', value: 'x' },
+		])
+
+		expect(refusal.message).toContain('setTitle')
+		expect(refusal.message).toContain('sec-cost')
+	})
+
+	it('leaves both out of what the writer reads', () => {
+		const said = reads([
+			{ op: 'setTitle', nodeId: 'sec-cost', expected: 'Who pays', value: 'x' },
+		])
+
+		expect(said).not.toContain('setTitle')
+		expect(said).not.toContain('sec-cost')
+	})
+
+	/** The word is the Plan's data model, not the writer's — context.md fixes
+	 * Section and Subsection. It may stay in the model's sentence. */
+	it('never says "node" to the writer', () => {
+		const everything = [
+			reads([{ op: 'deleteNode', nodeId: 'sec-gone' }]),
+			reads([{ op: 'setIntent', nodeId: 'sec-gone', expected: null, value: 'x' }]),
+			reads([
+				{ op: 'placeReference', referenceId: 'ref-gone', expected: null, value: null },
+			]),
+			reads([
+				{ op: 'moveNode', nodeId: 'sec-cost', parentId: 'sec-sub', beforeId: null },
+			]),
+		]
+
+		for (const said of everything) expect(said).not.toMatch(/node/i)
+	})
+})

--- a/test/client/plan-refusal-text.test.ts
+++ b/test/client/plan-refusal-text.test.ts
@@ -6,11 +6,8 @@ import { makePlan } from '../shared/plan-fixtures'
 
 /**
  * What a refused edit reads as on screen, against what the same refusal says to
- * the model. Every case runs the real applier rather than a hand-built
- * `Refusal`, so a reason code that stops being produced takes its test with it.
- *
- * The rule these hold: nothing the writer reads names an op, an id, or a node.
- * Those are the model's, and they stay on `refusal.message`.
+ * the model. Cases run the real applier rather than a hand-built `Refusal`, so a
+ * reason code that stops being produced takes its test with it.
  */
 
 const plan: Plan = makePlan({
@@ -154,11 +151,8 @@ describe('what the writer reads', () => {
 	})
 })
 
-/**
- * The other reader. `message` is what a Declined Proposal sends back, so it
- * keeps the op name and the ids the model proposed with — and that is exactly
- * why it is not what the writer sees.
- */
+/** The other reader: a Declined Proposal sends `message` back, so it keeps the
+ * op name and the ids the model proposed with. */
 describe('what the model reads', () => {
 	it('keeps the op name and the id the writer never saw', () => {
 		const refusal = refuse([
@@ -178,8 +172,8 @@ describe('what the model reads', () => {
 		expect(said).not.toContain('sec-cost')
 	})
 
-	/** The word is the Plan's data model, not the writer's — context.md fixes
-	 * Section and Subsection. It may stay in the model's sentence. */
+	/** context.md fixes Section and Subsection for the writer; "node" belongs to
+	 * the data model and may stay in the model's sentence. */
 	it('never says "node" to the writer', () => {
 		const everything = [
 			reads([{ op: 'deleteNode', nodeId: 'sec-gone' }]),

--- a/test/worker/chat-tools.test.ts
+++ b/test/worker/chat-tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { chatTools, recordOffersTool } from '../../src/server/llm/tools'
-import { proposePlanChangeTool } from '../../src/shared/chat'
+import { chatTools } from '../../src/server/llm/tools'
+import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
 import { chatOpNames } from '../../src/shared/plan'
 
 /**


### PR DESCRIPTION
Closes #26.

The Chat Panel was the last unwired surface in 1a. `src/client/screens/` held it as a static composition against mock data; this builds it — the transcript, the composer, and the two rulings the writer makes on what a turn returns.

Eight commits, and the first two are the ones to read. Everything after is cleanup, and each says what it took out and why.

---

## 1. Wire the Chat Panel — `7941d29`

**The surface and the wiring are split**, the same way #43 split `PlanPanel` from `ArticlePlanPanel`. `ChatPanel` takes a transcript and the rulings; `useArticleChat` is the `useAgentChat` half; `ArticleChatPanel` joins them. A story drives the surface from a fixture and the app drives it from the Article Agent.

**One connection per Article, held above the Panels** — `src/client/lib/useArticleAgent.ts`.

This is the part to look at hardest, because it changes a shape other things read. `usePlan` opened the socket inside `ArticlePlanPanel`, so a second Panel had nowhere to share it from. The Chat is that second Panel, and `useAgentChat` consumes the client `useAgent` returns — so without the hoist it opens a second socket, with a second `createPlanWriter` and a second debounce timer, against a blob whose whole design is that it has one writer (§3, rule 1).

`useArticleAgent` makes the one `useAgent` call and hands out three things: the Plan channel, the Offer store built on the same socket's RPC, and the client itself. `Article` becomes `{ offers, plan: PlanConnection }` — the shape written up on #29, which is also where the route that mounts these Panels lives. #26 hits the constraint first, so it hoists. `usePlan` accordingly becomes `usePlanChannel`, taking a way to reach the socket rather than opening one.

**Ruling on a Proposal.** A Proposal is an `execute`-less tool call that suspends with its input available and no output (§6). Accepting runs `edit(ops)` — the same call every Plan edit makes, so the writer's debounce and its held Plan still apply. Declining answers the tool call with the reason. The rule is `ruleProposal` in `src/client/chat/proposals.ts`, a pure function with no React and no socket, which the app and the showcase both run.

The four API details from #26, and where each landed:

- `addToolOutput`, never `addToolResult`, and **not awaited** — awaiting deadlocks.
- A rejection is `state: 'output-error'` with the reason in `errorText`, which `convertToModelMessages` turns into `{ type: 'error-text' }` — the `is_error: true` the ticket names.
- `addToolApprovalResponse` is **not used**. §6 rules out approval entirely: `needsApproval` and `toolApproval` gate a server-side `execute` this product does not have.
- The socket is multiplexed and the SDK's own client handles the `cf_agent_*` frames, so the Chat rides the one connection above.

**A refused Accept answers nothing and leaves the card open.** Whole-field `expected` comparison is conservative and will refuse against a field the writer has since touched, so they can fix the Plan and Accept again — or Decline, which sends the refusal back so the model learns the Plan moved rather than that the writer said no.

**A parked turn says so.** Cloudflare's batch-completeness rule has no orphan timeout (§11), so `waitingCount` counts every suspended call and the composer names what it is waiting on.

## 2. Split a refusal into the model's sentence and the writer's — `42d2774`

`refusal.message` read `setTitle on node sec-cost expected …` — an op name, a raw id, and a word from the data model, none of which the writer has ever seen. Renaming "node" to "Section" in the applier would have made it worse: that same string is what a Declined Proposal sends back, and the model wants the op and the id, because that is what it re-proposes with.

So the applier keeps writing one sentence, for the model, and says separately what happened:

- **`reason`** — a closed code naming exactly which check failed, where `RefusalType` only sorts refusals into four kinds. `type` is derived from it through one table.
- **`subject` and `other`** — the records the reason is about, as `{ of, id }` rather than baked into prose.

`src/client/plan/refusalText.ts` turns those into the writer's sentence. It holds the Plan, so it names a Section the way the Outline numbers it — "§3", not `sec-cost`. The naming helpers it shares with the Proposal card are lifted out of `describeProposal` into `src/client/plan/names.ts`.

Both readers, same refusal, from 2(j):

> **Writer:** §3 has changed since the Chat proposed this. It now reads “Who actually pays for the delay”, where the change expected “Who pays for the delay”.
>
> **Model, on Decline:** `setTitle on node sec-cost expected "Who pays for the delay" and the Plan carries "Who actually pays for the delay".`

Two things follow, and both are why the seam is here rather than a second prose field on the `Refusal`. **One English string lives in `src/shared`**, aimed at a reader with no eyes, and it never needs translating — `llm/tools.ts` teaches the model in English already. And **the writer's half is a table over a closed union**, so a second language is a second table rather than a sweep through the applier. `refusalText.ts` is total over `RefusalReason`: a new refusal site stops it compiling until it says what the new one reads as.

**`message` is unchanged, byte for byte**, so every assertion in `plan-apply.test.ts` stands.

## 3–8. Cleanup

- **`f59e749`** — `/simplify` pass. Two of its findings were defects: the Panel was rendering `part.errorText` to the writer, which is the model's sentence and undoes the commit above; and opening an Article read the Offers twice, because the persisted transcript's ids looked like a turn that had just recorded some. The rest is tidying — `waitingCalls` became `waitingCount` since only `.length` was read, `planNames` walks the Outline once, a `Notice` component replaced six copied accent paragraphs, and the `useCallback`s came out of `useArticleChat` since nothing under `src/client` is memoised.
- **`bad2b73`** — the composer had gone into a `Panel` `footer` slot with a padding handoff. Checking it against the Offer ledger's sticky header showed the app already had one shape for chrome on a Panel edge, used three times: `padded={false}`, a `flex-1 p-3.5` body, and a full-bleed bar. The slot was a fourth way, and an inset one. Deleted; `ChatPanel` takes the established shape and `Panel`'s API is smaller than it started.
- **`511294b`, `fb2af90`, `88dcbe7`** — three comment passes. Out went ticket references that read as TODOs, restatements of the arch doc, other functions' internals, CSS narration, and about twenty one-liners the name and type already gave. What stayed is the surprises: `useAgent` swapping its client on reconnect, awaiting `addToolOutput` deadlocking, a tool part being a union its states cannot be spread across.
- **`507b2c1`** — the review's findings, below.

---

## What changed outside `src/client/chat/`

The new directory is self-contained; these are the files that are not, and the ones worth a closer read:

| File | What moved |
| --- | --- |
| `src/shared/plan/apply.ts` | `Refusal` gains `reason`, `subject`, `other`; `type` derives from `reason`. `message` untouched. |
| `src/shared/chat.ts` | `recordOffersTool` moves here from `llm/tools.ts`, with `recordedOffersOutput` — a client matches on both now. |
| `src/server/llm/tools.ts` | The research tool declares `outputSchema`, so both ends of that shape are bound. |
| `src/client/lib/article.ts` | `Article` is `{ offers, plan: PlanConnection }`. |
| `src/client/plan/usePlan.ts` | `usePlanChannel`: builds the writer, opens no socket. `PlanConnection.edit` returns the refusal, which a ruling needs in the same turn. |
| `src/client/lib/useOfferLedger.ts` | Adds `reload`. A research turn writes rows nothing announces (§3), so the Chat calls it when a turn records some. |
| `src/client/components/Chat.tsx` | `ChatComposer` becomes interactive — `onSend`, `blocked`, `disabled`. |
| `src/client/components/Panel.tsx` | Unchanged from main, after `bad2b73` reverted the slot. |
| `src/client/components/ReferenceCard.tsx` | Unchanged from main. My version was superseded by #45 and dropped in the rebase. |
| `src/client/mock/MockArticle.tsx` | Gains `useMockPlan`, which the story screens read. A Panel in the app gates on null instead. |
| `docs/architecture.md` | §6 gains the Chat Panel, the ruling, and the two readers; §8 gains the one connection; §11's orphan carry now says it is surfaced. |

## Rebased onto main after #45 and #47

This branch was written before those landed and was rebased onto `00233d1` rather than merged. What that cost:

- **#45 narrowed the Ledger to the ruling**, so `stranded` and `addToPlan` are gone. About 30 lines of threading came out of `ChatPanel`, and a stranded-Offer fix I had written was dropped — #45 fixes the same silent failure better, by writing the Plan copy first so the failure does not outlive the click.
- **`ReferenceCard` and both Ledger screens** took main's version whole.
- **#47's browser test** found a real bug: with `Panel` now `overflow-y-auto`, the composer scrolled away with the transcript. Three of these stories now run in Chromium and are held to the layout invariants for free.

## Review

[One review](https://github.com/mhsnook/journo-harness/pull/49#issuecomment-5225893303) raised four things. Three are fixed in `507b2c1`: the research tool declared no `outputSchema` so its shape agreed with `recordedOffersOutput` only by hand; `send` checked the text was non-empty and left the composer as the only thing that knew a parked turn cannot go; and `ChatPanel` threaded `onRestoreOffer` to a card variant with no Restore button.

Two of its points are stale against the rebase — `variant="offer"` gained its `ruled` gating in #45, and `Refusal.reason`'s contradictory comment went in the comment pass.

One is skipped and worth stating. `setTitle` and `setVoice` pass `scopeSubject` with reason `'noSection'`, which could pair an Article subject with a Section reason. It is unreachable — `scopeOf` returns null only for a stated id — and every exact fix costs either a non-null assertion or a duplicated branch of the body `scopeOf` exists to share. The change that makes it reachable is the House Scope at 1b, when `scopeOf` becomes genuinely fallible; that is the point to constrain `absent`'s subject by its reason.

## Verified

- `pnpm test` — 258 tests, 24 files, including the `stories` project in a real browser. Green in CI.
- Lint, `format:check`, and `typecheck` clean.
- Driven by hand in Chromium against the built Storybook: Accepting the live Proposal on 2(b) lands §4 in the Outline beside it and moves the total to 2,800; 2(j) refuses, says why, stays open, and its Decline carries the reason into the transcript; 2(d) Accepting an Offer copies it into the Plan.

## Not in this PR

- **The route that mounts these Panels** — #29. Nothing imports `useArticleAgent` or `ArticleChatPanel` yet, the same way `ArticlePlanPanel` waited before this.
- **The composer is a single-line `<input>`**, so a pasted multi-line quote flattens, and its shift-Enter branch cannot fire. Left deliberately for a later UX pass.
- **Screens 2(a), 2(c), 2(e)** are still wireframes. 2(b), 2(d), and the new 2(j) run the real Chat Panel, the real applier, and the real Offer ledger against a fixture transcript.