### PR TITLE
Make ChatComposer a textarea with auto-grow and Ctrl+Enter send

### DIFF
--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -1,4 +1,11 @@
-import { type KeyboardEvent, type ReactNode, useEffect, useState } from 'react'
+import {
+	type KeyboardEvent,
+	type ReactNode,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react'
 
 import { cx } from '../lib/cx'
 import { Button } from './Button'
@@ -56,9 +63,36 @@ export interface ChatComposerProps {
 }
 
 /**
+ * How far the field grows before it scrolls inside itself, in lines. Eight lines
+ * of this type is about 183px with the box's padding, and the Chat Panel on
+ * `MidChatScreen` is 26rem — so a composer at full height takes about half the
+ * Panel and leaves the writer the rest of the transcript to write against.
+ */
+const maxLines = 8
+
+/**
+ * Sets the field's height to the height of what is in it, up to `maxLines`.
+ *
+ * The `auto` is not decoration: `scrollHeight` reads back the height the field
+ * already has whenever the field is taller than its text, so without the reset
+ * a field that grew to six lines would never shrink to three again.
+ */
+function grow(field: HTMLTextAreaElement) {
+	const lineHeight = Number.parseFloat(getComputedStyle(field).lineHeight)
+	const ceiling = Number.isNaN(lineHeight) ? Infinity : lineHeight * maxLines
+
+	field.style.height = 'auto'
+	field.style.height = `${Math.min(field.scrollHeight, ceiling)}px`
+}
+
+/**
  * **The field is never disabled while a turn runs.** Disabling it blurs it, so a
  * thought typed while the guide answers is lost at the first keystroke. The
  * button beside it changes instead.
+ *
+ * The field is a `textarea` because writers compose paragraphs and paste
+ * passages in. Enter sends and shift-Enter breaks the line, which is the pair
+ * a chat composer is expected to have.
  */
 export function ChatComposer({
 	placeholder = 'Ask, argue, or paste something in…',
@@ -70,9 +104,17 @@ export function ChatComposer({
 	className,
 }: ChatComposerProps) {
 	const [said, setSaid] = useState('')
+	const field = useRef<HTMLTextAreaElement>(null)
 	const stopping = busy && onStop !== undefined
 	const cannotSend =
 		blocked !== null || busy || onSend === undefined || said.trim() === ''
+
+	// Resizing on the value rather than on the change event covers the two cases
+	// a change handler misses: the first paint, and sending, which empties the
+	// field without anyone typing in it.
+	useLayoutEffect(() => {
+		if (field.current !== null) grow(field.current)
+	}, [said])
 
 	const send = () => {
 		if (cannotSend || onSend === undefined) return
@@ -81,7 +123,7 @@ export function ChatComposer({
 		setSaid('')
 	}
 
-	const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+	const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
 		if (event.key !== 'Enter' || event.shiftKey) return
 
 		event.preventDefault()
@@ -89,19 +131,25 @@ export function ChatComposer({
 	}
 
 	return (
-		<div className={cx('mt-auto flex flex-col gap-1.5 pt-1', className)}>
+		<div
+			// The browser story test finds the composer by this attribute rather than
+			// by a class, so renaming a Tailwind class cannot quietly empty the test.
+			data-composer=""
+			className={cx('mt-auto flex flex-col gap-1.5 pt-1', className)}
+		>
 			{blocked === null ? null : <Notice>{blocked}</Notice>}
-			<div className="flex items-center gap-2">
+			<div className="flex items-end gap-2">
 				{leading}
-				<div className="flex h-9 flex-1 items-center rounded-md border border-edge bg-surface px-2.5 text-[0.8125rem]">
-					<input
+				<div className="flex flex-1 items-center rounded-md border border-edge bg-surface px-2.5 py-1.5">
+					<textarea
+						ref={field}
 						aria-label="Message the guide"
-						className="min-w-0 flex-1 bg-transparent text-ink outline-none placeholder:text-faint"
+						className="min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-[0.8125rem] leading-relaxed text-ink outline-none placeholder:text-faint"
 						disabled={onSend === undefined}
 						onChange={(event) => setSaid(event.target.value)}
 						onKeyDown={onKeyDown}
 						placeholder={placeholder}
-						type="text"
+						rows={1}
 						value={said}
 					/>
 				</div>

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -63,26 +63,17 @@ export interface ChatComposerProps {
 }
 
 /**
- * How far the field grows before it scrolls inside itself, in lines. Eight lines
- * of this type is about 183px with the box's padding, and the Chat Panel on
- * `MidChatScreen` is 26rem — so a composer at full height takes about half the
- * Panel and leaves the writer the rest of the transcript to write against.
- */
-const maxLines = 8
-
-/**
- * Sets the field's height to the height of what is in it, up to `maxLines`.
+ * Sets the field's height to the height of what is in it. The ceiling is
+ * `max-h-[8lh]` on the field itself, so the browser clamps this and the field
+ * scrolls from there — no line height to measure here.
  *
  * The `auto` is not decoration: `scrollHeight` reads back the height the field
  * already has whenever the field is taller than its text, so without the reset
  * a field that grew to six lines would never shrink to three again.
  */
 function grow(field: HTMLTextAreaElement) {
-	const lineHeight = Number.parseFloat(getComputedStyle(field).lineHeight)
-	const ceiling = Number.isNaN(lineHeight) ? Infinity : lineHeight * maxLines
-
 	field.style.height = 'auto'
-	field.style.height = `${Math.min(field.scrollHeight, ceiling)}px`
+	field.style.height = `${field.scrollHeight}px`
 }
 
 /**
@@ -145,10 +136,16 @@ export function ChatComposer({
 			<div className="flex items-end gap-2">
 				{leading}
 				<div className="flex flex-1 items-center rounded-md border border-edge bg-surface px-2.5 py-1.5">
+					{/* `max-h-[8lh]` is the ceiling: eight lines of this type, which is
+					    where the composer stops growing and starts scrolling. Eight was
+					    picked against `MidChatScreen`, whose Chat Panel is 26rem — a
+					    full-height field takes under half of it and leaves the writer
+					    the transcript to write against. A shorter Panel gives the same
+					    eight lines a larger share. */}
 					<textarea
 						ref={field}
 						aria-label="Message the guide"
-						className="min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-[0.8125rem] leading-relaxed text-ink outline-none placeholder:text-faint"
+						className="max-h-[8lh] min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-[0.8125rem] leading-relaxed text-ink outline-none placeholder:text-faint"
 						disabled={onSend === undefined}
 						onChange={(event) => setSaid(event.target.value)}
 						onKeyDown={onKeyDown}

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -91,8 +91,10 @@ function grow(field: HTMLTextAreaElement) {
  * button beside it changes instead.
  *
  * The field is a `textarea` because writers compose paragraphs and paste
- * passages in. Enter sends and shift-Enter breaks the line, which is the pair
- * a chat composer is expected to have.
+ * passages in. **Enter breaks the line and control-Enter sends**, which is the
+ * way round a composer wants when a paragraph is the ordinary message: the
+ * newline is the keystroke you make constantly, and sending is the deliberate
+ * one you make once.
  */
 export function ChatComposer({
 	placeholder = 'Ask, argue, or paste something in…',
@@ -123,8 +125,10 @@ export function ChatComposer({
 		setSaid('')
 	}
 
+	// `metaKey` is the same chord on a Mac, where control-Enter is not what a
+	// hand reaches for.
 	const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-		if (event.key !== 'Enter' || event.shiftKey) return
+		if (event.key !== 'Enter' || !(event.ctrlKey || event.metaKey)) return
 
 		event.preventDefault()
 		send()

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -62,15 +62,9 @@ export interface ChatComposerProps {
 	className?: string
 }
 
-/**
- * Sets the field's height to the height of what is in it. The ceiling is
- * `max-h-[8lh]` on the field itself, so the browser clamps this and the field
- * scrolls from there — no line height to measure here.
- *
- * The `auto` is not decoration: `scrollHeight` reads back the height the field
- * already has whenever the field is taller than its text, so without the reset
- * a field that grew to six lines would never shrink to three again.
- */
+/** Height of the content, clamped by the field's own `max-h`. The `auto` is
+ * load-bearing: `scrollHeight` reads back the height the field already has, so
+ * without the reset the field could grow but never shrink. */
 function grow(field: HTMLTextAreaElement) {
 	field.style.height = 'auto'
 	field.style.height = `${field.scrollHeight}px`
@@ -81,11 +75,8 @@ function grow(field: HTMLTextAreaElement) {
  * thought typed while the guide answers is lost at the first keystroke. The
  * button beside it changes instead.
  *
- * The field is a `textarea` because writers compose paragraphs and paste
- * passages in. **Enter breaks the line and control-Enter sends**, which is the
- * way round a composer wants when a paragraph is the ordinary message: the
- * newline is the keystroke you make constantly, and sending is the deliberate
- * one you make once.
+ * **Enter breaks the line and control-Enter sends** — the reverse of the chat
+ * convention, because the ordinary message here is a paragraph.
  */
 export function ChatComposer({
 	placeholder = 'Ask, argue, or paste something in…',
@@ -102,9 +93,8 @@ export function ChatComposer({
 	const cannotSend =
 		blocked !== null || busy || onSend === undefined || said.trim() === ''
 
-	// Resizing on the value rather than on the change event covers the two cases
-	// a change handler misses: the first paint, and sending, which empties the
-	// field without anyone typing in it.
+	// On the value, not the change event: a change handler misses the first paint
+	// and the reset after sending.
 	useLayoutEffect(() => {
 		if (field.current !== null) grow(field.current)
 	}, [said])
@@ -116,8 +106,6 @@ export function ChatComposer({
 		setSaid('')
 	}
 
-	// `metaKey` is the same chord on a Mac, where control-Enter is not what a
-	// hand reaches for.
 	const onKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
 		if (event.key !== 'Enter' || !(event.ctrlKey || event.metaKey)) return
 
@@ -126,22 +114,14 @@ export function ChatComposer({
 	}
 
 	return (
-		<div
-			// The browser story test finds the composer by this attribute rather than
-			// by a class, so renaming a Tailwind class cannot quietly empty the test.
-			data-composer=""
-			className={cx('mt-auto flex flex-col gap-1.5 pt-1', className)}
-		>
+		<div data-composer="" className={cx('mt-auto flex flex-col gap-1.5 pt-1', className)}>
 			{blocked === null ? null : <Notice>{blocked}</Notice>}
 			<div className="flex items-end gap-2">
 				{leading}
 				<div className="flex flex-1 items-center rounded-md border border-edge bg-surface px-2.5 py-1.5">
-					{/* `max-h-[8lh]` is the ceiling: eight lines of this type, which is
-					    where the composer stops growing and starts scrolling. Eight was
-					    picked against `MidChatScreen`, whose Chat Panel is 26rem — a
-					    full-height field takes under half of it and leaves the writer
-					    the transcript to write against. A shorter Panel gives the same
-					    eight lines a larger share. */}
+					{/* Eight lines, picked against `MidChatScreen`'s 26rem Chat Panel,
+					    where a full-height field takes under half. A shorter Panel gives
+					    the same eight lines a larger share. */}
 					<textarea
 						ref={field}
 						aria-label="Message the guide"

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -70,14 +70,8 @@ function grow(field: HTMLTextAreaElement) {
 	field.style.height = `${field.scrollHeight}px`
 }
 
-/**
- * **The field is never disabled while a turn runs.** Disabling it blurs it, so a
- * thought typed while the guide answers is lost at the first keystroke. The
- * button beside it changes instead.
- *
- * **Enter breaks the line and control-Enter sends** — the reverse of the chat
- * convention, because the ordinary message here is a paragraph.
- */
+/** A chat message input that grows as you type; Enter adds a new line and
+ * control-Enter sends. */
 export function ChatComposer({
 	placeholder = 'Ask, argue, or paste something in…',
 	leading,
@@ -93,8 +87,7 @@ export function ChatComposer({
 	const cannotSend =
 		blocked !== null || busy || onSend === undefined || said.trim() === ''
 
-	// On the value, not the change event: a change handler misses the first paint
-	// and the reset after sending.
+	// An `onChange` would miss the first paint & the clear after sending
 	useLayoutEffect(() => {
 		if (field.current !== null) grow(field.current)
 	}, [said])

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -121,19 +121,16 @@ export const Composer: Story = {
 
 		const sent = within(canvas.getByLabelText('Sent'))
 
-		// Enter breaks the line and sends nothing.
 		await userEvent.click(field)
 		await userEvent.keyboard('one{Enter}two')
 		await expect(field.value).toBe('one\ntwo')
 		await expect(sent.queryAllByRole('listitem')).toHaveLength(0)
 
-		// Control-Enter sends what is in the field, newline and all, and empties it
-		// back to one line.
 		await userEvent.keyboard('{Control>}{Enter}{/Control}')
 		await expect(field.value).toBe('')
 		await expect(sent.getAllByRole('listitem')[0]).toHaveTextContent('one two')
 
-		// Command-Enter is the same chord on a Mac.
+		// `{Meta>}` is command, which sends on a Mac.
 		await userEvent.keyboard('again{Meta>}{Enter}{/Meta}')
 		await expect(field.value).toBe('')
 		await expect(sent.getAllByRole('listitem')).toHaveLength(2)

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
+import { expect, userEvent, within } from 'storybook/test'
 
 import { offers, plan, sectionState } from '../mock/content'
 import { Button } from './Button'
+import { ChatComposer } from './Chat'
 import { Check } from './Check'
 import { Chip } from './Chip'
 import { Divider } from './Divider'
@@ -85,6 +87,51 @@ export const PanelToggle: Story = {
 				</p>
 			</div>
 		)
+	},
+}
+
+export const Composer: Story = {
+	render: function ComposerStory() {
+		const [sent, setSent] = useState<string[]>([])
+
+		return (
+			<div className="flex w-[26rem] flex-col gap-4">
+				<Row label="Chat composer — Enter sends, shift-Enter breaks the line">
+					<ChatComposer
+						onSend={(text) => setSent((held) => [...held, text])}
+						className="w-full"
+					/>
+				</Row>
+				<ul aria-label="Sent" className="flex flex-col gap-1">
+					{sent.map((text, index) => (
+						<li
+							key={index}
+							className="rounded-md bg-hush px-3 py-2 text-[0.8125rem] leading-relaxed whitespace-pre-wrap text-ink"
+						>
+							{text}
+						</li>
+					))}
+				</ul>
+			</div>
+		)
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+		const field = canvas.getByLabelText('Message the guide') as HTMLTextAreaElement
+
+		// Shift-Enter breaks the line and sends nothing.
+		await userEvent.click(field)
+		await userEvent.keyboard('one{Shift>}{Enter}{/Shift}two')
+		await expect(field.value).toBe('one\ntwo')
+		await expect(
+			within(canvas.getByLabelText('Sent')).queryAllByRole('listitem'),
+		).toHaveLength(0)
+
+		// Enter sends what is in the field, newline and all, and empties it back to
+		// one line.
+		await userEvent.keyboard('{Enter}')
+		await expect(field.value).toBe('')
+		await expect(canvas.getByRole('listitem')).toHaveTextContent('one two')
 	},
 }
 

--- a/src/client/components/Primitives.stories.tsx
+++ b/src/client/components/Primitives.stories.tsx
@@ -96,7 +96,7 @@ export const Composer: Story = {
 
 		return (
 			<div className="flex w-[26rem] flex-col gap-4">
-				<Row label="Chat composer — Enter sends, shift-Enter breaks the line">
+				<Row label="Chat composer — Enter breaks the line, control-Enter sends">
 					<ChatComposer
 						onSend={(text) => setSent((held) => [...held, text])}
 						className="w-full"
@@ -119,19 +119,24 @@ export const Composer: Story = {
 		const canvas = within(canvasElement)
 		const field = canvas.getByLabelText('Message the guide') as HTMLTextAreaElement
 
-		// Shift-Enter breaks the line and sends nothing.
-		await userEvent.click(field)
-		await userEvent.keyboard('one{Shift>}{Enter}{/Shift}two')
-		await expect(field.value).toBe('one\ntwo')
-		await expect(
-			within(canvas.getByLabelText('Sent')).queryAllByRole('listitem'),
-		).toHaveLength(0)
+		const sent = within(canvas.getByLabelText('Sent'))
 
-		// Enter sends what is in the field, newline and all, and empties it back to
-		// one line.
-		await userEvent.keyboard('{Enter}')
+		// Enter breaks the line and sends nothing.
+		await userEvent.click(field)
+		await userEvent.keyboard('one{Enter}two')
+		await expect(field.value).toBe('one\ntwo')
+		await expect(sent.queryAllByRole('listitem')).toHaveLength(0)
+
+		// Control-Enter sends what is in the field, newline and all, and empties it
+		// back to one line.
+		await userEvent.keyboard('{Control>}{Enter}{/Control}')
 		await expect(field.value).toBe('')
-		await expect(canvas.getByRole('listitem')).toHaveTextContent('one two')
+		await expect(sent.getAllByRole('listitem')[0]).toHaveTextContent('one two')
+
+		// Command-Enter is the same chord on a Mac.
+		await userEvent.keyboard('again{Meta>}{Enter}{/Meta}')
+		await expect(field.value).toBe('')
+		await expect(sent.getAllByRole('listitem')).toHaveLength(2)
 	},
 }
 

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -98,7 +98,7 @@ export const B2_ComposerGrows: Story = {
 				The composer grows with what the writer types or pastes, up to eight lines. Past
 				that it scrolls inside itself, so the transcript above it never falls below about
 				half the Panel — this screen is the one the ceiling was picked against. Enter
-				sends; shift-Enter breaks the line.
+				breaks the line; control-Enter sends.
 			</Annotation>
 		</div>
 	),
@@ -111,10 +111,10 @@ export const B2_ComposerGrows: Story = {
 
 		const empty = field.clientHeight
 
-		// Shift-Enter breaks the line. Enter is the send key, and this screen is
+		// Enter breaks the line. Control-Enter is the send key, and this screen is
 		// parked on a Proposal, so `Primitives/Overview` covers what it sends.
 		await userEvent.click(field)
-		await userEvent.keyboard('one{Shift>}{Enter}{/Shift}two')
+		await userEvent.keyboard('one{Enter}two')
 		await expect(field.value).toBe('one\ntwo')
 		await userEvent.clear(field)
 

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
+import { expect, userEvent, within } from 'storybook/test'
 
 import type { Plan, ProposalInput, Refusal } from '../../../shared/plan'
 import { applyProposal, emptyPlan } from '../../../shared/plan'
@@ -80,6 +81,71 @@ export const B_MidConversation: Story = {
 			</Annotation>
 		</div>
 	),
+}
+
+/** One paragraph of a draft message, which is the ordinary thing to paste in. */
+const paragraph =
+	'The appeal is the part nobody files, and that is the whole mechanism: the objector pays nothing, the clock resets, and the scheme sits another eleven weeks. I want that in its own section rather than folded into the cost one.'
+
+export const B2_ComposerGrows: Story = {
+	name: '2(b·i) A paragraph in the composer',
+	render: () => (
+		<div className="flex flex-col">
+			<MockArticle>
+				<MidChatScreen />
+			</MockArticle>
+			<Annotation>
+				The composer grows with what the writer types or pastes, up to eight lines. Past
+				that it scrolls inside itself, so the transcript above it never falls below about
+				half the Panel — this screen is the one the ceiling was picked against. Enter
+				sends; shift-Enter breaks the line.
+			</Annotation>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+		const field = canvas.getByLabelText('Message the guide') as HTMLTextAreaElement
+		const panel = canvasElement.querySelector('[data-panel]')!
+		const composer = canvasElement.querySelector('[data-composer]')!
+		const opening = canvas.getByText(/one developer in it/)
+
+		const empty = field.clientHeight
+
+		// Shift-Enter breaks the line. Enter is the send key, and this screen is
+		// parked on a Proposal, so `Primitives/Overview` covers what it sends.
+		await userEvent.click(field)
+		await userEvent.keyboard('one{Shift>}{Enter}{/Shift}two')
+		await expect(field.value).toBe('one\ntwo')
+		await userEvent.clear(field)
+
+		// Grows with what is in it.
+		await userEvent.paste(paragraph)
+		await expect(field.clientHeight).toBeGreaterThan(empty)
+
+		// And stops. Two more paragraphs are past any sane ceiling, so a third
+		// changing nothing is the ceiling holding rather than the text fitting.
+		await userEvent.paste(paragraph)
+		await userEvent.paste(paragraph)
+		const ceiling = field.clientHeight
+		await userEvent.paste(paragraph)
+		await expect(field.clientHeight).toBe(ceiling)
+
+		// Past the ceiling the field scrolls rather than the composer growing.
+		await expect(field.scrollHeight).toBeGreaterThan(ceiling)
+
+		// Which is what leaves the writer a transcript to write against. The field
+		// at full height takes at most half the Panel — this screen is parked on a
+		// Proposal, so its Notice sits above the field on top of that, and that is
+		// a state the writer is being asked to leave rather than a resting size.
+		const panelBox = panel.getBoundingClientRect()
+		const composerBox = composer.getBoundingClientRect()
+		await expect(field.clientHeight).toBeLessThanOrEqual(panelBox.height / 2)
+
+		// The first turn is still on screen, above the composer and inside the Panel.
+		const openingBox = opening.getBoundingClientRect()
+		await expect(openingBox.top).toBeGreaterThanOrEqual(panelBox.top)
+		await expect(openingBox.bottom).toBeLessThanOrEqual(composerBox.top)
+	},
 }
 
 export const C_ReadyToDraft: Story = {

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -111,21 +111,15 @@ export const B2_ComposerGrows: Story = {
 
 		const empty = field.clientHeight
 
-		// Enter breaks the line. Control-Enter is the send key, and this screen is
-		// parked on a Proposal, so `Primitives/Overview` covers what it sends.
+		// Grows with what is in it. The keys are `Primitives/Overview`'s to check:
+		// this screen is parked on a Proposal, so it cannot send.
 		await userEvent.click(field)
-		await userEvent.keyboard('one{Enter}two')
-		await expect(field.value).toBe('one\ntwo')
-		await userEvent.clear(field)
-
-		// Grows with what is in it.
 		await userEvent.paste(paragraph)
 		await expect(field.clientHeight).toBeGreaterThan(empty)
 
-		// And stops. Two more paragraphs are past any sane ceiling, so a third
+		// And stops. Two more paragraphs are past any sane ceiling, so a fourth
 		// changing nothing is the ceiling holding rather than the text fitting.
-		await userEvent.paste(paragraph)
-		await userEvent.paste(paragraph)
+		await userEvent.paste(paragraph.repeat(2))
 		const ceiling = field.clientHeight
 		await userEvent.paste(paragraph)
 		await expect(field.clientHeight).toBe(ceiling)

--- a/src/client/screens/article/PlanAnArticle.stories.tsx
+++ b/src/client/screens/article/PlanAnArticle.stories.tsx
@@ -83,7 +83,6 @@ export const B_MidConversation: Story = {
 	),
 }
 
-/** One paragraph of a draft message, which is the ordinary thing to paste in. */
 const paragraph =
 	'The appeal is the part nobody files, and that is the whole mechanism: the objector pays nothing, the clock resets, and the scheme sits another eleven weeks. I want that in its own section rather than folded into the cost one.'
 
@@ -111,31 +110,26 @@ export const B2_ComposerGrows: Story = {
 
 		const empty = field.clientHeight
 
-		// Grows with what is in it. The keys are `Primitives/Overview`'s to check:
-		// this screen is parked on a Proposal, so it cannot send.
+		// This screen is parked on a Proposal and cannot send, so the keys are
+		// `Primitives/Overview`'s to check.
 		await userEvent.click(field)
 		await userEvent.paste(paragraph)
 		await expect(field.clientHeight).toBeGreaterThan(empty)
 
-		// And stops. Two more paragraphs are past any sane ceiling, so a fourth
-		// changing nothing is the ceiling holding rather than the text fitting.
+		// Two more paragraphs are past any ceiling, so a fourth changing nothing is
+		// the ceiling holding rather than the text happening to fit.
 		await userEvent.paste(paragraph.repeat(2))
 		const ceiling = field.clientHeight
 		await userEvent.paste(paragraph)
 		await expect(field.clientHeight).toBe(ceiling)
-
-		// Past the ceiling the field scrolls rather than the composer growing.
 		await expect(field.scrollHeight).toBeGreaterThan(ceiling)
 
-		// Which is what leaves the writer a transcript to write against. The field
-		// at full height takes at most half the Panel — this screen is parked on a
-		// Proposal, so its Notice sits above the field on top of that, and that is
-		// a state the writer is being asked to leave rather than a resting size.
+		// Measured on the field, not the whole composer: the parked Proposal's
+		// Notice sits above it, and that is a state the writer is asked to leave.
 		const panelBox = panel.getBoundingClientRect()
 		const composerBox = composer.getBoundingClientRect()
 		await expect(field.clientHeight).toBeLessThanOrEqual(panelBox.height / 2)
 
-		// The first turn is still on screen, above the composer and inside the Panel.
 		const openingBox = opening.getBoundingClientRect()
 		await expect(openingBox.top).toBeGreaterThanOrEqual(panelBox.top)
 		await expect(openingBox.bottom).toBeLessThanOrEqual(composerBox.top)


### PR DESCRIPTION
Replace the single-line input field in ChatComposer with a textarea that grows as the user types, up to a maximum of eight lines, then scrolls internally. Change the send keybinding from Shift+Enter to Ctrl+Enter (or Cmd+Enter on Mac), making Enter the default line-break key.

**Changes:**

- Convert ChatComposer's input to a textarea with `max-h-[8lh]` and `overflow-y-auto` to cap growth while allowing scrolling
- Add `grow()` function that resets height to `auto` then reads `scrollHeight` to size the field to its content
- Use `useLayoutEffect` to call `grow()` whenever the message text changes, ensuring the field expands and shrinks with edits
- Invert the keyboard logic: send on Ctrl+Enter (or Meta+Enter on Mac) instead of Shift+Enter; plain Enter now breaks the line
- Update the container to use `items-end` instead of `items-center` so the button aligns with the textarea baseline
- Add `data-composer` attribute for test selection
- Add story tests in both Primitives and PlanAnArticle to verify textarea growth behavior and keybinding

This makes the composer feel more like a paragraph editor, where multi-line input is the default and sending requires an explicit modifier key.

https://claude.ai/code/session_01UijK5nTvV3pgtKbA9v2GLj