### PR TITLE
Place Plan after tool results, not before them

### DIFF
--- a/src/server/llm/prompt.ts
+++ b/src/server/llm/prompt.ts
@@ -76,8 +76,8 @@ function planMessage(plan: Plan): ModelMessage {
 }
 
 /**
- * The conversation with the Plan in it — after every turn but the last, so the
- * writer's own words are the last thing the model reads.
+ * The conversation with the Plan in it — in front of the writer's last message,
+ * so the writer's own words are the last thing the model reads.
  *
  * Two orderings are defensible and neither has met a real model yet. Appending
  * the Plan after everything is one message cheaper to cache, and it makes a
@@ -93,8 +93,26 @@ export function chatPackMessages(
 	conversation: ModelMessage[],
 	plan: Plan,
 ): ModelMessage[] {
-	const last = conversation.length - 1
-	if (last < 0) return [planMessage(plan)]
+	const at = planSlot(conversation)
 
-	return [...conversation.slice(0, last), planMessage(plan), conversation[last]]
+	return [...conversation.slice(0, at), planMessage(plan), ...conversation.slice(at)]
+}
+
+/**
+ * Where the Plan goes: in front of the last message where that message is the
+ * writer's, and after the whole conversation otherwise.
+ *
+ * **A tool result may not be separated from the call it answers.** A tool
+ * message answers the assistant message before it, and the AI SDK throws
+ * `MissingToolResultsError` at a user message that arrives with a call still
+ * unanswered — so the turn that resumes after the writer rules on a Proposal
+ * ends in a tool result, and the Plan has to follow it rather than split the
+ * pair. That turn wants the Plan last in any case: the ruling has just changed
+ * it, and what the model reads is then the Plan the Accept produced.
+ */
+function planSlot(conversation: ModelMessage[]): number {
+	const last = conversation.length - 1
+	if (last < 0) return 0
+
+	return conversation[last].role === 'user' ? last : conversation.length
 }

--- a/src/server/llm/prompt.ts
+++ b/src/server/llm/prompt.ts
@@ -102,13 +102,10 @@ export function chatPackMessages(
  * Where the Plan goes: in front of the last message where that message is the
  * writer's, and after the whole conversation otherwise.
  *
- * **A tool result may not be separated from the call it answers.** A tool
- * message answers the assistant message before it, and the AI SDK throws
- * `MissingToolResultsError` at a user message that arrives with a call still
- * unanswered — so the turn that resumes after the writer rules on a Proposal
- * ends in a tool result, and the Plan has to follow it rather than split the
- * pair. That turn wants the Plan last in any case: the ruling has just changed
- * it, and what the model reads is then the Plan the Accept produced.
+ * The Plan is a user message, and the AI SDK refuses a prompt that carries a
+ * user message between an assistant's tool call and the tool result answering
+ * it. A transcript ends in a tool result on the turn that resumes after the
+ * writer rules on a Proposal, so that is the turn this keeps legal.
  */
 function planSlot(conversation: ModelMessage[]): number {
 	const last = conversation.length - 1

--- a/src/server/llm/prompt.ts
+++ b/src/server/llm/prompt.ts
@@ -99,13 +99,13 @@ export function chatPackMessages(
 }
 
 /**
- * Where the Plan goes: in front of the last message where that message is the
- * writer's, and after the whole conversation otherwise.
+ * Calculates where the Plan goes: in front of the last message, or at the end
+ * of the conversation.
  *
- * The Plan is a user message, and the AI SDK refuses a prompt that carries a
- * user message between an assistant's tool call and the tool result answering
- * it. A transcript ends in a tool result on the turn that resumes after the
- * writer rules on a Proposal, so that is the turn this keeps legal.
+ * The AI SDK refuses a prompt that places a user message between a tool call
+ * and its tool result. The Plan is a user message, so it goes in front of the
+ * last message only where that message is the writer's, and at the end
+ * otherwise.
  */
 function planSlot(conversation: ModelMessage[]): number {
 	const last = conversation.length - 1

--- a/test/worker/chat-turn.test.ts
+++ b/test/worker/chat-turn.test.ts
@@ -1,7 +1,9 @@
+import type { UIMessage } from 'ai'
 import { MockLanguageModelV3, simulateReadableStream } from 'ai/test'
 import { env, runInDurableObject } from 'cloudflare:test'
 import { describe, expect, it } from 'vitest'
 
+import { chatTurn } from '../../src/server/llm/chat-turn'
 import type { ProposalInput } from '../../src/shared/plan'
 import { makeNode, makePlan } from '../shared/plan-fixtures'
 import { type Frame, openAgentSocket } from './agent-socket'
@@ -195,6 +197,57 @@ describe('a Chat turn', () => {
 		expect(planBlock).toContain('Open on one refused permit.')
 
 		expect(JSON.stringify(conversation.at(-1))).toContain('What is the opening for?')
+	})
+
+	// A tool result answers the assistant message before it, and the Plan is a
+	// user message, so packing it in front of the last message would split the
+	// pair — which the AI SDK refuses with MissingToolResultsError before the
+	// model is called at all. The turn that resumes after the writer rules on a
+	// Proposal is exactly that transcript.
+	//
+	// `chatTurn` directly rather than through the socket: the harness sends one
+	// user message, and this case needs a transcript with a settled tool part
+	// already in it.
+	it('packs the Plan after a tool result rather than in front of it', async () => {
+		const model = speaks('Noted.')
+		const ruled = [
+			{
+				id: 'm1',
+				role: 'user',
+				parts: [{ type: 'text', text: 'Give the opening a word count.' }],
+			},
+			{
+				id: 'm2',
+				role: 'assistant',
+				parts: [
+					{
+						type: 'tool-proposePlanChange',
+						toolCallId: 'call-1',
+						state: 'output-available',
+						input: { ops: proposal },
+						output: 'The writer Accepted this Proposal.',
+					},
+				],
+			},
+		] as unknown as UIMessage[]
+
+		const response = await chatTurn({
+			model,
+			plan,
+			messages: ruled,
+			onFinish: async () => {},
+		})
+
+		// The stream carries the turn rather than an error, and the model was
+		// reached — the pack is refused before the first call, so a turn that
+		// never happened is what the defect looks like.
+		expect(await response.text()).not.toContain('Tool result is missing')
+		expect(model.doStreamCalls).toHaveLength(1)
+
+		// The Plan is last here, after the tool result that ends the transcript.
+		const [call] = model.doStreamCalls
+		expect(JSON.stringify(call.prompt.at(-1))).toContain('The permit queue')
+		expect(call.prompt.at(-2)?.role).toBe('tool')
 	})
 
 	it('offers both tools to the model', async () => {


### PR DESCRIPTION
## Summary

Fix message ordering in chat turns that resume after a writer rules on a proposal. The Plan message was being inserted in front of tool results, which violates the AI SDK's requirement that tool results stay adjacent to their corresponding assistant calls.

## Changes

- **`src/server/llm/prompt.ts`**: Refactored `chatPackMessages` to use a new `planSlot` function that determines where to insert the Plan message. The Plan now goes after tool results (at the end of the conversation) instead of in front of the writer's last message when that message is a tool result.

- **`test/worker/chat-turn.test.ts`**: Added a test case that verifies the Plan is correctly placed after a tool result in a transcript where the writer has ruled on a proposal. This test directly calls `chatTurn` with a pre-constructed message history containing a settled tool call, ensuring the model is reached without a `MissingToolResultsError`.

## Implementation Details

The `planSlot` function implements the correct placement logic:
- If the conversation is empty, the Plan goes at position 0
- If the last message is from the user (the writer), the Plan goes before it
- Otherwise (when the last message is a tool result), the Plan goes at the end

This ensures tool result–assistant call pairs remain adjacent, which the AI SDK validates before calling the model.

https://claude.ai/code/session_01DWfXqeidEbL1zT5iLzsoX3