### PR TITLE
Make the Offer ledger a real drawer, and say when the transcript has more below

### DIFF
--- a/.storybook/mock/MockChat.ts
+++ b/.storybook/mock/MockChat.ts
@@ -27,8 +27,8 @@ export type MockChat = Omit<
 	ChatPanelProps,
 	'plan' | 'className' | 'leading' | 'drawer'
 > & {
-	/** The same handle the transcript's Offer cards rule through, so a screen
-	 * that also draws the Ledger drawer rules through one ledger and not two. */
+	/** The handle the transcript's Offer cards rule through. A screen drawing
+	 * the Ledger drawer as well passes it this one. */
 	ledger: OfferLedgerHandle
 }
 

--- a/.storybook/mock/MockChat.ts
+++ b/.storybook/mock/MockChat.ts
@@ -11,7 +11,10 @@ import {
 	waitingCount,
 } from '../../src/client/chat/proposals'
 import { useArticle } from '../../src/client/lib/article'
-import { useOfferLedger } from '../../src/client/lib/useOfferLedger'
+import {
+	type OfferLedgerHandle,
+	useOfferLedger,
+} from '../../src/client/lib/useOfferLedger'
 
 /**
  * A Chat held in memory, so a story runs the real applier and the real Offer
@@ -20,7 +23,14 @@ import { useOfferLedger } from '../../src/client/lib/useOfferLedger'
  * sentence back.
  */
 
-export type MockChat = Omit<ChatPanelProps, 'plan' | 'className' | 'leading'>
+export type MockChat = Omit<
+	ChatPanelProps,
+	'plan' | 'className' | 'leading' | 'drawer'
+> & {
+	/** The same handle the transcript's Offer cards rule through, so a screen
+	 * that also draws the Ledger drawer rules through one ledger and not two. */
+	ledger: OfferLedgerHandle
+}
 
 export function useMockChat(start: UIMessage[]): MockChat {
 	const { plan: connection } = useArticle()
@@ -60,6 +70,7 @@ export function useMockChat(start: UIMessage[]): MockChat {
 	}
 
 	return {
+		ledger,
 		messages,
 		busy: false,
 		waiting: waitingCount(messages),

--- a/.storybook/screens/article/ChatWithReferencesScreen.tsx
+++ b/.storybook/screens/article/ChatWithReferencesScreen.tsx
@@ -9,7 +9,7 @@ import { researchTurn } from '../../mock/transcript'
  * Offer ledger rows, so Accepting one copies it into the Plan. */
 export function ChatWithReferencesScreen() {
 	const plan = useMockPlan()
-	const chat = useMockChat(researchTurn)
+	const { ledger: _ledger, ...chat } = useMockChat(researchTurn)
 
 	return (
 		<Frame width={700}>

--- a/.storybook/screens/article/LedgerDrawerScreen.tsx
+++ b/.storybook/screens/article/LedgerDrawerScreen.tsx
@@ -1,27 +1,59 @@
-import { OfferLedgerPanel } from '../../../src/client/chat/OfferLedgerPanel'
+import { ListTodo } from 'lucide-react'
+import { useRef, useState } from 'react'
+
+import { ChatPanel } from '../../../src/client/chat/ChatPanel'
+import { OfferLedgerDrawer } from '../../../src/client/chat/OfferLedgerDrawer'
 import { ArticleBar } from '../../../src/client/components/ArticleBar'
+import { Button } from '../../../src/client/components/Button'
 import { Frame, FrameBody } from '../../../src/client/components/Frame'
 import { useArticle } from '../../../src/client/lib/article'
-import { useOfferLedger } from '../../../src/client/lib/useOfferLedger'
 import { PlanPanel } from '../../../src/client/plan/PlanPanel'
 import { ARTICLE_TITLE } from '../../mock/content'
 import { useMockPlan } from '../../mock/MockArticle'
+import { useMockChat } from '../../mock/MockChat'
+import { midChat } from '../../mock/transcript'
 
 /**
- * Storybook fixture 2(f): `OfferLedgerPanel` open beside a Plan Panel, in a
- * fixed-width Frame. Filtering and ruling work; `close ×` is inert, since
- * there is no Chat here to go back to.
+ * Storybook fixture 2(f): the Offer ledger open over the Chat Panel's
+ * transcript, beside a Plan Panel. The drawer, the toggle, and the rulings are
+ * the ones the app runs, so the toggle closes what it opened and Escape
+ * dismisses.
  */
 export function LedgerDrawerScreen() {
 	const { edit } = useArticle().plan
 	const plan = useMockPlan()
-	const ledger = useOfferLedger()
+	const { ledger, ...chat } = useMockChat(midChat)
+	const [open, setOpen] = useState(true)
+	const toggle = useRef<HTMLButtonElement>(null)
+
+	const close = () => {
+		setOpen(false)
+		toggle.current?.focus()
+	}
 
 	return (
 		<Frame width={820}>
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="ledger" />
 			<FrameBody row className="h-[22rem]">
-				<OfferLedgerPanel divider="right" ledger={ledger} onClose={() => {}} />
+				<ChatPanel
+					{...chat}
+					divider="right"
+					drawer={<OfferLedgerDrawer ledger={ledger} onClose={close} open={open} />}
+					leading={
+						<Button
+							aria-expanded={open}
+							aria-label="Offer ledger"
+							onClick={() => (open ? close() : setOpen(true))}
+							pressed={open}
+							ref={toggle}
+							size="sm"
+							variant="quiet"
+						>
+							<ListTodo aria-hidden className="size-3.5" />
+						</Button>
+					}
+					plan={plan}
+				/>
 				<PlanPanel plan={plan} edit={edit} />
 			</FrameBody>
 		</Frame>

--- a/.storybook/screens/article/LedgerDrawerScreen.tsx
+++ b/.storybook/screens/article/LedgerDrawerScreen.tsx
@@ -16,8 +16,7 @@ import { midChat } from '../../mock/transcript'
 /**
  * Storybook fixture 2(f): the Offer ledger open over the Chat Panel's
  * transcript, beside a Plan Panel. The drawer, the toggle, and the rulings are
- * the ones the app runs, so the toggle closes what it opened and Escape
- * dismisses.
+ * the app's own rather than stand-ins, so all of them work here.
  */
 export function LedgerDrawerScreen() {
 	const { edit } = useArticle().plan

--- a/.storybook/screens/article/MidChatScreen.tsx
+++ b/.storybook/screens/article/MidChatScreen.tsx
@@ -12,7 +12,7 @@ import { midChat } from '../../mock/transcript'
 export function MidChatScreen() {
 	const { edit, refusal } = useArticle().plan
 	const plan = useMockPlan()
-	const chat = useMockChat(midChat)
+	const { ledger: _ledger, ...chat } = useMockChat(midChat)
 
 	return (
 		<Frame width={880}>

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -142,8 +142,7 @@ export const B2_ComposerGrows: Story = {
 		const transcript = canvasElement.querySelector('[data-scroller]')!
 		await expect(canvas.queryByLabelText('Scroll to the latest')).toBeNull()
 
-		// Scrolled up, the way back appears. The transcript otherwise stops
-		// mid-sentence against the composer with nothing saying there is more.
+		// Scrolled up, the way back appears.
 		transcript.scrollTop = 0
 		const back = await canvas.findByLabelText('Scroll to the latest')
 
@@ -231,16 +230,15 @@ export const F_LedgerDrawer: Story = {
 		// wrapper's edge rather than at the field.
 		const foot = () => transcript.getBoundingClientRect().bottom
 
-		// Open, the drawer covers the transcript and leaves the composer alone,
-		// which is what keeps the toggle in place for the second click.
+		// The drawer covers the transcript and leaves the composer alone, which is
+		// what keeps the toggle in place for the second click.
 		await expect(toggle.getAttribute('aria-expanded')).toBe('true')
 		await expect(drawer.getBoundingClientRect().top).toBeLessThan(foot())
 		await expect(drawer.getBoundingClientRect().bottom).toBeLessThanOrEqual(
 			composer.getBoundingClientRect().top,
 		)
 
-		// One control, both directions: no traverse to a close button elsewhere.
-		// The geometry waits, because closing is a 200ms slide.
+		// One control, both directions. The geometry waits on the 200ms slide.
 		await userEvent.click(toggle)
 		await expect(toggle.getAttribute('aria-expanded')).toBe('false')
 		await waitFor(() =>
@@ -248,8 +246,8 @@ export const F_LedgerDrawer: Story = {
 		)
 
 		// Opening moves the drawer and nothing else. Focus lands on it while it is
-		// still out of view, and a browser answers that by scrolling whatever box
-		// is clipping it — which drags the transcript up by a drawer's height.
+		// still out of view, and a browser reveals such an element by scrolling the
+		// box clipping it, which would carry the transcript with it.
 		const still = transcript.getBoundingClientRect().top
 		await userEvent.click(toggle)
 		await expect(toggle.getAttribute('aria-expanded')).toBe('true')

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -136,6 +136,26 @@ export const B2_ComposerGrows: Story = {
 		const latestBox = latest.getBoundingClientRect()
 		await expect(latestBox.top).toBeGreaterThanOrEqual(panelBox.top)
 		await expect(latestBox.bottom).toBeLessThanOrEqual(composerBox.top)
+
+		// Pinned to the foot, so there is nothing below and nothing offering to
+		// take you there.
+		const transcript = canvasElement.querySelector('[data-scroller]')!
+		await expect(canvas.queryByLabelText('Scroll to the latest')).toBeNull()
+
+		// Scrolled up, the way back appears. The transcript otherwise stops
+		// mid-sentence against the composer with nothing saying there is more.
+		transcript.scrollTop = 0
+		const back = await canvas.findByLabelText('Scroll to the latest')
+
+		await userEvent.click(back)
+		await waitFor(() =>
+			expect(
+				transcript.scrollHeight - transcript.scrollTop - transcript.clientHeight,
+			).toBeLessThanOrEqual(24),
+		)
+		await waitFor(() =>
+			expect(canvas.queryByLabelText('Scroll to the latest')).toBeNull(),
+		)
 	},
 }
 

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { useState } from 'react'
-import { expect, userEvent, within } from 'storybook/test'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 
 import { Annotation } from '../../../src/client/components/Annotation'
 import { Frame, FrameBody } from '../../../src/client/components/Frame'
@@ -191,13 +191,50 @@ export const F_LedgerDrawer: Story = {
 				<LedgerDrawerScreen />
 			</MockArticle>
 			<Annotation>
-				The same list at every stage — early on most rows read Undecided, later most are
-				placed. That is precisely why there is no separate triage screen. Accepting a row
-				on the left copies it into the Plan on the right: the row keeps what was turned
-				up, and the copy is the writer's to edit.
+				A drawer over the transcript, not a screen the Chat swaps to: the composer stays
+				uncovered, so the control that opened it closes it, and Escape does too. The same
+				list at every stage — early on most rows read Undecided, later most are placed,
+				which is why there is no separate triage screen. Accepting a row copies it into
+				the Plan on the right: the row keeps what was turned up, and the copy is the
+				writer's to edit.
 			</Annotation>
 		</div>
 	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+		const toggle = canvas.getByRole('button', { name: /Offer ledger/ })
+		const drawer = canvasElement.querySelector('[aria-label="Offer ledger"]')!
+		const transcript = canvasElement.querySelector('[data-scroller]')!
+		const composer = canvasElement.querySelector('[data-composer]')!
+		// Measured against the transcript's foot, not the composer's own box: the
+		// composer sits inside a padded wrapper, and the drawer stops at the
+		// wrapper's edge rather than at the field.
+		const foot = () => transcript.getBoundingClientRect().bottom
+
+		// Open, the drawer covers the transcript and leaves the composer alone,
+		// which is what keeps the toggle in place for the second click.
+		await expect(toggle.getAttribute('aria-expanded')).toBe('true')
+		await expect(drawer.getBoundingClientRect().top).toBeLessThan(foot())
+		await expect(drawer.getBoundingClientRect().bottom).toBeLessThanOrEqual(
+			composer.getBoundingClientRect().top,
+		)
+
+		// One control, both directions: no traverse to a close button elsewhere.
+		// The geometry waits, because closing is a 200ms slide.
+		await userEvent.click(toggle)
+		await expect(toggle.getAttribute('aria-expanded')).toBe('false')
+		await waitFor(() =>
+			expect(drawer.getBoundingClientRect().top).toBeGreaterThanOrEqual(foot() - 1),
+		)
+
+		// Escape dismisses, and focus lands back on the toggle rather than in the
+		// transcript behind it.
+		await userEvent.click(toggle)
+		await expect(toggle.getAttribute('aria-expanded')).toBe('true')
+		await userEvent.keyboard('{Escape}')
+		await expect(toggle.getAttribute('aria-expanded')).toBe('false')
+		await expect(document.activeElement).toBe(toggle)
+	},
 }
 
 export const G_LedgerPopover: Story = {

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -247,13 +247,21 @@ export const F_LedgerDrawer: Story = {
 			expect(drawer.getBoundingClientRect().top).toBeGreaterThanOrEqual(foot() - 1),
 		)
 
-		// Escape dismisses, and focus lands back on the toggle rather than in the
-		// transcript behind it.
+		// Opening moves the drawer and nothing else. Focus lands on it while it is
+		// still out of view, and a browser answers that by scrolling whatever box
+		// is clipping it — which drags the transcript up by a drawer's height.
+		const still = transcript.getBoundingClientRect().top
 		await userEvent.click(toggle)
 		await expect(toggle.getAttribute('aria-expanded')).toBe('true')
+		await expect(transcript.getBoundingClientRect().top).toBe(still)
+		await expect(drawer.parentElement!.scrollTop).toBe(0)
+
+		// Escape dismisses, and focus lands back on the toggle rather than in the
+		// transcript behind it.
 		await userEvent.keyboard('{Escape}')
 		await expect(toggle.getAttribute('aria-expanded')).toBe('false')
 		await expect(document.activeElement).toBe(toggle)
+		await expect(transcript.getBoundingClientRect().top).toBe(still)
 	},
 }
 

--- a/.storybook/screens/article/StaleProposalScreen.tsx
+++ b/.storybook/screens/article/StaleProposalScreen.tsx
@@ -9,7 +9,7 @@ import { staleProposal } from '../../mock/transcript'
  * against what it found, and stays open. */
 export function StaleProposalScreen() {
 	const plan = useMockPlan()
-	const chat = useMockChat(staleProposal)
+	const { ledger: _ledger, ...chat } = useMockChat(staleProposal)
 
 	return (
 		<Frame width={560}>

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -85,19 +85,27 @@ function checkLayout(canvasElement: HTMLElement) {
 		// Each Panel scrolls its own Y: reading down the Plan leaves the Chat
 		// beside it where it was. A Panel with nothing to scroll says nothing
 		// either way, so it is skipped rather than counted as a pass.
+		//
+		// A Panel that keeps something fixed at its foot scrolls an inner element
+		// marked `data-scroller` instead of scrolling itself. Finding it here is
+		// what stops that Panel dropping out of this check by growing one.
 		const panels = [...body.querySelectorAll<HTMLElement>(':scope > [data-panel]')]
 		if (panels.length < 2) continue
 
-		for (const panel of panels) {
-			if (panel.scrollHeight <= panel.clientHeight + TOLERANCE) continue
+		const scrollers = panels.map(
+			(panel) => panel.querySelector<HTMLElement>('[data-scroller]') ?? panel,
+		)
 
-			panel.scrollTop = panel.scrollHeight
+		for (const scroller of scrollers) {
+			if (scroller.scrollHeight <= scroller.clientHeight + TOLERANCE) continue
+
+			scroller.scrollTop = scroller.scrollHeight
 			expect
-				.soft(panel.scrollTop, `Panel did not scroll — ${describe(panel)}`)
+				.soft(scroller.scrollTop, `Panel did not scroll — ${describe(scroller)}`)
 				.toBeGreaterThan(0)
 
-			for (const neighbour of panels) {
-				if (neighbour === panel) continue
+			for (const neighbour of scrollers) {
+				if (neighbour === scroller) continue
 				expect
 					.soft(
 						neighbour.scrollTop,
@@ -106,7 +114,7 @@ function checkLayout(canvasElement: HTMLElement) {
 					.toBe(0)
 			}
 
-			panel.scrollTop = 0
+			scroller.scrollTop = 0
 		}
 	}
 }

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -87,8 +87,8 @@ function checkLayout(canvasElement: HTMLElement) {
 		// either way, so it is skipped rather than counted as a pass.
 		//
 		// A Panel that keeps something fixed at its foot scrolls an inner element
-		// marked `data-scroller` instead of scrolling itself. Finding it here is
-		// what stops that Panel dropping out of this check by growing one.
+		// marked `data-scroller` instead of scrolling itself, so that is what gets
+		// scrolled here.
 		const panels = [...body.querySelectorAll<HTMLElement>(':scope > [data-panel]')]
 		if (panels.length < 2) continue
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -169,9 +169,11 @@ The Chat turns up Offers — Links and Quotes — as SQLite rows in the Article 
 
 **The Ledger belongs to the Chat Panel and doesn't read the Plan.** Its data model and its
 visual representation should both be understood to relate to the Chat Panel itself. It
-opens from the control left of the composer as a drawer over the Chat Panel, taking whatever
-width that Panel has rather than being a fifth Panel of its own — `close ×` is on the Ledger
-because the Chat is what it covers.
+opens from the control left of the composer as a drawer over that Panel's transcript, taking
+whatever width the Panel has rather than being a fifth Panel of its own. **It covers the
+transcript and not the composer**, so the control that opened it is still there to close it,
+and the writer can go on typing with the record open. Escape closes it too, and focus makes
+the same round trip.
 It shows one flat list with a chip per disposition to filter it, and `all` first, so the
 Undecided pile can be read on its own without losing the record. When the writer Accepts an
 Offer, it sends the Reference over to the Plan Panel; then it belongs to the Plan, where it

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -1,12 +1,12 @@
 import { ListTodo } from 'lucide-react'
-import { Activity, useState } from 'react'
+import { useRef, useState, type RefObject } from 'react'
 
 import { Button } from '../components/Button'
 import { Panel } from '../components/Panel'
 import { useArticle } from '../lib/article'
 import type { ArticleSocket } from '../lib/useArticleAgent'
 import { ChatPanel, type ChatPanelProps } from './ChatPanel'
-import { OfferLedgerPanel } from './OfferLedgerPanel'
+import { OfferLedgerDrawer } from './OfferLedgerDrawer'
 import { useArticleChat } from './useArticleChat'
 
 /** Drives `ChatPanel` from one Article Agent. Takes the socket rather than
@@ -29,6 +29,7 @@ export function ArticleChatPanel({
 	const chat = useArticleChat(agent)
 	const { ledger } = chat
 	const [showLedger, setShowLedger] = useState(false)
+	const toggle = useRef<HTMLButtonElement>(null)
 
 	// A Proposal card names Sections out of the Plan, so there is nothing to draw
 	// until one arrives.
@@ -40,58 +41,66 @@ export function ArticleChatPanel({
 		)
 	}
 
-	// Hidden rather than swapped out, so a half-typed message survives a look at
-	// the Ledger.
+	const close = () => {
+		setShowLedger(false)
+		toggle.current?.focus()
+	}
+
 	return (
-		<>
-			<Activity mode={showLedger ? 'hidden' : 'visible'}>
-				<ChatPanel
-					busy={chat.busy}
-					className={className}
-					divider={divider}
-					failure={chat.failure ?? ledger.failure}
-					leading={
-						<LedgerToggle
-							onOpen={() => setShowLedger(true)}
-							undecided={ledger.ledger.counts.undecided}
-						/>
-					}
-					messages={chat.messages}
-					offers={ledger.ledger.offers}
-					onAccept={chat.accept}
-					onAcceptOffer={ledger.accept}
-					onDecline={chat.decline}
-					onDeclineOffer={ledger.decline}
-					onSend={chat.send}
-					onStop={chat.stop}
-					placeholder={placeholder}
-					plan={plan}
-					refusals={chat.refusals}
-					waiting={chat.waiting}
+		<ChatPanel
+			busy={chat.busy}
+			className={className}
+			divider={divider}
+			drawer={<OfferLedgerDrawer ledger={ledger} onClose={close} open={showLedger} />}
+			failure={chat.failure ?? ledger.failure}
+			leading={
+				<LedgerToggle
+					onToggle={() => (showLedger ? close() : setShowLedger(true))}
+					open={showLedger}
+					ref={toggle}
+					undecided={ledger.ledger.counts.undecided}
 				/>
-			</Activity>
-			<Activity mode={showLedger ? 'visible' : 'hidden'}>
-				<OfferLedgerPanel
-					className={className}
-					divider={divider}
-					ledger={ledger}
-					onClose={() => setShowLedger(false)}
-				/>
-			</Activity>
-		</>
+			}
+			messages={chat.messages}
+			offers={ledger.ledger.offers}
+			onAccept={chat.accept}
+			onAcceptOffer={ledger.accept}
+			onDecline={chat.decline}
+			onDeclineOffer={ledger.decline}
+			onSend={chat.send}
+			onStop={chat.stop}
+			placeholder={placeholder}
+			plan={plan}
+			refusals={chat.refusals}
+			waiting={chat.waiting}
+		/>
 	)
 }
 
-/** Opens the Offer ledger. Sits left of the composer. */
-function LedgerToggle({ onOpen, undecided }: { onOpen: () => void; undecided: number }) {
+/** Opens and closes the Offer ledger. Sits left of the composer, which the
+ * drawer leaves uncovered, so it is in one place for both. */
+function LedgerToggle({
+	onToggle,
+	open,
+	ref,
+	undecided,
+}: {
+	onToggle: () => void
+	open: boolean
+	ref: RefObject<HTMLButtonElement | null>
+	undecided: number
+}) {
 	return (
 		<Button
+			aria-expanded={open}
 			aria-label={
 				undecided === 0
 					? 'Offer ledger'
 					: `Offer ledger, ${undecided} Offers still Undecided`
 			}
-			onClick={onOpen}
+			onClick={onToggle}
+			pressed={open}
+			ref={ref}
 			size="sm"
 			variant="quiet"
 		>

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -1,9 +1,11 @@
 import { getToolName, isTextUIPart, isToolUIPart, type UIMessage } from 'ai'
-import { useEffect, useLayoutEffect, useRef, type ReactNode } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 
 import { proposePlanChangeTool, recordOffersTool } from '../../shared/chat'
 import type { Offer } from '../../shared/offer'
 import type { Plan } from '../../shared/plan'
+import { Button } from '../components/Button'
 import { ChatComposer, ChatMessage, ChatNote, ChatWorking } from '../components/Chat'
 import { Notice } from '../components/Notice'
 import { Panel, type PanelProps } from '../components/Panel'
@@ -108,6 +110,27 @@ export function ChatPanel({
 					{busy ? <ChatWorking>The guide is answering…</ChatWorking> : null}
 					{failure === null ? null : <Notice>{failure}</Notice>}
 				</div>
+				{transcript.atFoot ? null : (
+					<>
+						{/* The transcript otherwise stops mid-sentence against the composer,
+						    which reads as the end of it rather than as more below. */}
+						<div
+							aria-hidden
+							className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-surface to-transparent"
+						/>
+						{/* No width or padding of its own: `sizeClass` owns both, and a
+						    utility fighting it resolves by stylesheet order rather than by
+						    the order it is written in. */}
+						<Button
+							aria-label="Scroll to the latest"
+							className="absolute right-3 bottom-3 shadow-frame"
+							onClick={transcript.toFoot}
+							size="sm"
+						>
+							<ChevronDown aria-hidden className="size-3.5" />
+						</Button>
+					</>
+				)}
 				{drawer}
 			</div>
 
@@ -130,13 +153,32 @@ const AT_THE_FOOT = 24
 
 /**
  * Keeps the Chat pinned to the bottom as messages stream in. Releases when the
- * writer scrolls up more than 24px, and re-takes when they scroll back down.
+ * writer scrolls up, and re-takes within 24px of the foot.
  *
- * Returns the ref for the scrolling element and the `onScroll` that tracks it.
+ * **Only scrolling up releases the pin, rather than the distance alone.** The
+ * composer growing shortens the transcript under it, and the browser reports
+ * that as a scroll before the observer gets to re-pin — measuring the distance
+ * at that moment reads the writer's own paste as them scrolling away from it.
+ *
+ * Returns the ref for the scrolling element, the `onScroll` that tracks it,
+ * whether it is at the foot, and a way back down.
  */
 function useFootOfTranscript() {
 	const panel = useRef<HTMLDivElement>(null)
 	const pinned = useRef(true)
+	const wasAt = useRef(0)
+	// The ref drives the pin, which has to be current inside a scroll handler and
+	// an observer. This mirrors it for the controls that have to be drawn, and
+	// only on the crossing, so a scroll gesture costs one render rather than one
+	// per event.
+	const [atFoot, setAtFoot] = useState(true)
+
+	const settle = (next: boolean) => {
+		if (pinned.current === next) return
+
+		pinned.current = next
+		setAtFoot(next)
+	}
 
 	const foot = () => {
 		if (panel.current !== null && pinned.current) {
@@ -163,12 +205,24 @@ function useFootOfTranscript() {
 
 	return {
 		ref: panel,
+		atFoot,
 		onScroll: () => {
 			const scroller = panel.current
 			if (scroller === null) return
 
-			pinned.current =
-				scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <= AT_THE_FOOT
+			const off = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+			if (off <= AT_THE_FOOT) settle(true)
+			else if (scroller.scrollTop < wasAt.current) settle(false)
+
+			wasAt.current = scroller.scrollTop
+		},
+		toFoot: () => {
+			const scroller = panel.current
+			if (scroller === null) return
+
+			settle(true)
+			wasAt.current = scroller.scrollHeight
+			scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
 		},
 	}
 }

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -112,15 +112,11 @@ export function ChatPanel({
 				</div>
 				{transcript.atFoot ? null : (
 					<>
-						{/* The transcript otherwise stops mid-sentence against the composer,
-						    which reads as the end of it rather than as more below. */}
+						{/* Says the transcript carries on under the composer. */}
 						<div
 							aria-hidden
 							className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-surface to-transparent"
 						/>
-						{/* No width or padding of its own: `sizeClass` owns both, and a
-						    utility fighting it resolves by stylesheet order rather than by
-						    the order it is written in. */}
 						<Button
 							aria-label="Scroll to the latest"
 							className="absolute right-3 bottom-3 shadow-frame"
@@ -155,10 +151,10 @@ const AT_THE_FOOT = 24
  * Keeps the Chat pinned to the bottom as messages stream in. Releases when the
  * writer scrolls up, and re-takes within 24px of the foot.
  *
- * **Only scrolling up releases the pin, rather than the distance alone.** The
- * composer growing shortens the transcript under it, and the browser reports
- * that as a scroll before the observer gets to re-pin — measuring the distance
- * at that moment reads the writer's own paste as them scrolling away from it.
+ * Only an upward scroll releases it. The composer growing shortens the
+ * transcript under it, and the browser reports that as a scroll of its own
+ * before the observer can re-pin, so distance from the foot cannot tell the
+ * writer's paste apart from the writer scrolling away.
  *
  * Returns the ref for the scrolling element, the `onScroll` that tracks it,
  * whether it is at the foot, and a way back down.

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -43,6 +43,9 @@ export interface ChatPanelProps {
 	placeholder?: string
 	/** Left of send — the Offer ledger toggle. */
 	leading?: ReactNode
+	/** A layer over the transcript, stopping at the top of the composer. The
+	 * Offer ledger is the one of these. */
+	drawer?: ReactNode
 	className?: string
 }
 
@@ -63,45 +66,52 @@ export function ChatPanel({
 	divider,
 	placeholder,
 	leading,
+	drawer,
 	className,
 }: ChatPanelProps) {
 	const rows = new Map(offers.map((offer) => [offer.id, offer]))
 	const transcript = useFootOfTranscript()
 
 	return (
-		<Panel
-			className={className}
-			divider={divider}
-			onScroll={transcript.onScroll}
-			padded={false}
-			ref={transcript.ref}
-		>
-			<div className="flex flex-1 flex-col gap-3.5 p-3.5">
-				{messages.map((message) => (
-					<Turn
-						key={message.id}
-						message={message}
-						onAccept={onAccept}
-						onAcceptOffer={onAcceptOffer}
-						onDecline={onDecline}
-						onDeclineOffer={onDeclineOffer}
-						plan={plan}
-						refusals={refusals}
-						rows={rows}
-					/>
-				))}
+		<Panel className={className} divider={divider} padded={false}>
+			{/* The transcript and the drawer share this box, so the drawer covers
+			    what the writer is reading and stops at the composer. `overflow-hidden`
+			    is what makes the drawer slide out of sight behind it. */}
+			<div className="relative flex min-h-0 flex-1 overflow-hidden">
+				<div
+					data-scroller=""
+					className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto p-3.5"
+					onScroll={transcript.onScroll}
+					ref={transcript.ref}
+				>
+					{messages.map((message) => (
+						<Turn
+							key={message.id}
+							message={message}
+							onAccept={onAccept}
+							onAcceptOffer={onAcceptOffer}
+							onDecline={onDecline}
+							onDeclineOffer={onDeclineOffer}
+							plan={plan}
+							refusals={refusals}
+							rows={rows}
+						/>
+					))}
 
-				{messages.length === 0 ? (
-					<ChatNote>
-						Say what the piece is about. The Plan fills in beside you as you agree on it.
-					</ChatNote>
-				) : null}
+					{messages.length === 0 ? (
+						<ChatNote>
+							Say what the piece is about. The Plan fills in beside you as you agree on
+							it.
+						</ChatNote>
+					) : null}
 
-				{busy ? <ChatWorking>The guide is answering…</ChatWorking> : null}
-				{failure === null ? null : <Notice>{failure}</Notice>}
+					{busy ? <ChatWorking>The guide is answering…</ChatWorking> : null}
+					{failure === null ? null : <Notice>{failure}</Notice>}
+				</div>
+				{drawer}
 			</div>
 
-			<div className="sticky bottom-0 z-10 border-t border-edge bg-surface px-3.5 py-2.5">
+			<div className="shrink-0 border-t border-edge bg-surface px-3.5 py-2.5">
 				<ChatComposer
 					blocked={parked(waiting)}
 					busy={busy}
@@ -125,7 +135,7 @@ const AT_THE_FOOT = 24
  * Returns the ref for the scrolling element and the `onScroll` that tracks it.
  */
 function useFootOfTranscript() {
-	const panel = useRef<HTMLElement>(null)
+	const panel = useRef<HTMLDivElement>(null)
 	const pinned = useRef(true)
 
 	const foot = () => {
@@ -141,8 +151,8 @@ function useFootOfTranscript() {
 		const scroller = panel.current
 		if (scroller === null) return
 
-		// The children grow as the transcript and the composer do; the scroller
-		// itself changes height when the window does.
+		// The children grow as turns arrive; the scroller itself changes height
+		// when the window does, or when the composer grows under it.
 		const watch = new ResizeObserver(foot)
 		watch.observe(scroller)
 		for (const child of scroller.children) watch.observe(child)

--- a/src/client/chat/OfferLedgerDrawer.tsx
+++ b/src/client/chat/OfferLedgerDrawer.tsx
@@ -48,10 +48,9 @@ export function OfferLedgerDrawer({
 	// Focus moves in on open, so Escape has an owner and the writer's next Tab
 	// starts inside the drawer rather than back in the transcript behind it.
 	//
-	// **`preventScroll` is what keeps the Chat still.** At the moment focus
-	// lands, the drawer is still translated out of view, and the browser's reply
-	// to that is to scroll the box clipping it — dragging the transcript up by a
-	// drawer's height and easing it back as the drawer rises.
+	// `preventScroll`, because focus lands while the drawer is still translated
+	// out of view, and a browser reveals such an element by scrolling the box
+	// clipping it — here the transcript.
 	useEffect(() => {
 		if (open) panel.current?.focus({ preventScroll: true })
 	}, [open])

--- a/src/client/chat/OfferLedgerDrawer.tsx
+++ b/src/client/chat/OfferLedgerDrawer.tsx
@@ -1,20 +1,25 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { dispositions, type Disposition } from '../../shared/offer'
 import { Chip } from '../components/Chip'
 import { EmptySlot } from '../components/Field'
 import { Notice } from '../components/Notice'
-import { Panel, PanelHeader, type PanelProps } from '../components/Panel'
+import { PanelHeader } from '../components/Panel'
 import { ReferenceCard } from '../components/ReferenceCard'
+import { cx } from '../lib/cx'
 import type { OfferLedgerHandle } from '../lib/useOfferLedger'
 
 /**
- * A drawer that opens over the Chat Panel, listing this Article's Offers and
- * letting the writer Accept or Decline each one.
+ * A drawer over the Chat Panel's transcript, listing this Article's Offers and
+ * letting the writer Accept or Decline each one. The composer stays uncovered,
+ * so the control that opened the drawer is the control that closes it.
  *
  * It takes an `OfferLedgerHandle` from its parent: it neither reads nor tracks
  * the Offers itself, it renders the handle's rows and calls the handle's
  * rulings.
+ *
+ * Closed, it stays mounted and sits translated out of sight — the filter it was
+ * on and the rows it had are still there when it comes back.
  */
 
 type Filter = 'all' | Disposition
@@ -22,27 +27,51 @@ type Filter = 'all' | Disposition
 // The order `offerLedger` keys its counts in.
 const filters: Filter[] = ['all', ...dispositions]
 
-export interface OfferLedgerPanelProps {
+export interface OfferLedgerDrawerProps {
 	ledger: OfferLedgerHandle
+	open: boolean
+	/** Escape and `close ×` both route here. */
 	onClose: () => void
-	divider?: PanelProps['divider']
 	className?: string
 }
 
-export function OfferLedgerPanel({
+export function OfferLedgerDrawer({
 	ledger,
+	open,
 	onClose,
-	divider,
 	className,
-}: OfferLedgerPanelProps) {
+}: OfferLedgerDrawerProps) {
 	const { ledger: rows, loading, failure, accept, decline, restore } = ledger
 	const [filter, setFilter] = useState<Filter>('all')
+	const panel = useRef<HTMLDivElement>(null)
+
+	// Focus moves in on open, so Escape has an owner and the writer's next Tab
+	// starts inside the drawer rather than back in the transcript behind it.
+	useEffect(() => {
+		if (open) panel.current?.focus()
+	}, [open])
 
 	const shown = filter === 'all' ? rows.offers : rows.byDisposition[filter]
 
 	return (
-		<Panel className={className} divider={divider} padded={false}>
-			{/* Sticky: the Panel scrolls under it, and `close ×` has to stay reachable. */}
+		<div
+			ref={panel}
+			aria-label="Offer ledger"
+			className={cx(
+				'absolute inset-x-0 bottom-0 flex max-h-[85%] flex-col rounded-t-frame border-t border-edge bg-surface shadow-drawer outline-none',
+				'transition-transform duration-200 ease-out motion-reduce:transition-none',
+				open ? 'translate-y-0' : 'translate-y-full',
+				className,
+			)}
+			// Not modal: the composer below stays live, so the writer can go on
+			// typing with the record open.
+			inert={!open}
+			onKeyDown={(event) => {
+				if (event.key === 'Escape') onClose()
+			}}
+			role="group"
+			tabIndex={-1}
+		>
 			<PanelHeader
 				actions={
 					<button
@@ -53,11 +82,11 @@ export function OfferLedgerPanel({
 						close ×
 					</button>
 				}
-				className="sticky top-0 z-10 border-b border-edge bg-sunk px-3.5 py-2.5"
+				className="shrink-0 rounded-t-frame border-b border-edge bg-sunk px-3.5 py-2.5"
 				meta={`${rows.counts.all} · ${rows.counts.accepted} Accepted`}
 				title="Offer ledger"
 			/>
-			<div className="flex flex-col gap-2.5 p-3.5">
+			<div className="flex min-h-0 flex-col gap-2.5 overflow-y-auto p-3.5">
 				<div className="flex flex-wrap gap-1.5">
 					{filters.map((name) => (
 						<Chip
@@ -87,6 +116,6 @@ export function OfferLedgerPanel({
 					<EmptySlot>Nothing {filter === 'all' ? 'offered yet' : filter}</EmptySlot>
 				) : null}
 			</div>
-		</Panel>
+		</div>
 	)
 }

--- a/src/client/chat/OfferLedgerDrawer.tsx
+++ b/src/client/chat/OfferLedgerDrawer.tsx
@@ -47,8 +47,13 @@ export function OfferLedgerDrawer({
 
 	// Focus moves in on open, so Escape has an owner and the writer's next Tab
 	// starts inside the drawer rather than back in the transcript behind it.
+	//
+	// **`preventScroll` is what keeps the Chat still.** At the moment focus
+	// lands, the drawer is still translated out of view, and the browser's reply
+	// to that is to scroll the box clipping it — dragging the transcript up by a
+	// drawer's height and easing it back as the drawer rises.
 	useEffect(() => {
-		if (open) panel.current?.focus()
+		if (open) panel.current?.focus({ preventScroll: true })
 	}, [open])
 
 	const shown = filter === 'all' ? rows.offers : rows.byDisposition[filter]

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode, Ref } from 'react'
 
 import { cx } from '../lib/cx'
 
@@ -18,6 +18,9 @@ export interface ButtonProps extends Omit<
 	/** "You are here" — the chosen one of a set. State rather than a call to
 	 * action, so it takes ink rather than the accent, the way a solid Chip does. */
 	pressed?: boolean
+	/** For a caller that puts focus back on this Button after closing what it
+	 * opened. */
+	ref?: Ref<HTMLButtonElement>
 	children?: ReactNode
 }
 
@@ -60,6 +63,7 @@ export function Button({
 	variant = 'default',
 	size = 'md',
 	pressed,
+	ref,
 	className,
 	children,
 	type = 'button',
@@ -67,6 +71,7 @@ export function Button({
 }: ButtonProps) {
 	return (
 		<button
+			ref={ref}
 			type={type}
 			aria-pressed={pressed}
 			className={buttonClass({ variant, size, pressed, className })}

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -1,12 +1,8 @@
-import type { CSSProperties, ReactNode, Ref, UIEventHandler } from 'react'
+import type { CSSProperties, ReactNode } from 'react'
 
 import { cx } from '../lib/cx'
 
 export interface PanelProps {
-	/** The scrolling element itself, for a Panel that drives its own scroll
-	 * position. */
-	ref?: Ref<HTMLElement>
-	onScroll?: UIEventHandler<HTMLElement>
 	/** `surface` is the writing surface; `sunk` is everything that supports it. */
 	variant?: 'surface' | 'sunk'
 	/** Fixed width in px, or a flex ratio when omitted. */
@@ -27,10 +23,11 @@ export interface PanelProps {
  * beside it, which is what lets two Panels of different lengths sit side by
  * side. It needs a height to bite on: the Frame body gives it one, and a Panel
  * inside a body with no height simply grows as it always did.
+ *
+ * A Panel that keeps something fixed at its foot scrolls an inner element
+ * instead, marked `data-scroller`. One Panel, one scroller, either way.
  */
 export function Panel({
-	ref,
-	onScroll,
 	variant = 'surface',
 	width,
 	grow = 1,
@@ -42,8 +39,6 @@ export function Panel({
 }: PanelProps) {
 	return (
 		<section
-			ref={ref}
-			onScroll={onScroll}
 			data-panel=""
 			className={cx(
 				'flex min-h-0 min-w-0 flex-col overflow-y-auto',

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -44,8 +44,12 @@
 
 	--radius-frame: 0.625rem;
 
-	/* One elevation, used only on the outermost frame */
+	/* One elevation, in the two directions something lifts: the outermost frame
+	   casts down, and a drawer rising from the foot of a Panel casts up. Same
+	   depth, mirrored — a second depth would be a second elevation. */
 	--shadow-frame: 0 1px 2px rgb(27 26 23 / 0.05), 0 8px 24px -16px rgb(27 26 23 / 0.25);
+	--shadow-drawer:
+		0 -1px 2px rgb(27 26 23 / 0.05), 0 -8px 24px -16px rgb(27 26 23 / 0.25);
 }
 
 @layer base {

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -44,9 +44,8 @@
 
 	--radius-frame: 0.625rem;
 
-	/* One elevation, in the two directions something lifts: the outermost frame
-	   casts down, and a drawer rising from the foot of a Panel casts up. Same
-	   depth, mirrored — a second depth would be a second elevation. */
+	/* One depth, cast in whichever direction the thing lifts: the outermost
+	   frame downwards, a drawer rising from a Panel's foot upwards. */
 	--shadow-frame: 0 1px 2px rgb(27 26 23 / 0.05), 0 8px 24px -16px rgb(27 26 23 / 0.25);
 	--shadow-drawer:
 		0 -1px 2px rgb(27 26 23 / 0.05), 0 -8px 24px -16px rgb(27 26 23 / 0.25);


### PR DESCRIPTION
Two commits, from using the app after #55.

## The Ledger was a screen swap, not a drawer

It was two Panels trading places, which is why it had nothing to slide, no top edge to round, and two controls half a screen apart — the open control at the bottom left, the close at the top right. **The close button existed only because the open button vanished with the composer.**

The drawer now covers the transcript and stops at the composer, and the rest follows from that:

- The toggle stays on screen and takes `pressed`, so one control does both directions. `close ×` stays as a second way out.
- Escape closes it. Focus moves into the drawer on open and back to the toggle on close, so the keyboard round trip is as short as the mouse one.
- It rises on a 200ms slide with rounded top corners and an upward shadow, and honours `prefers-reduced-motion`.
- The composer stays live underneath, so the writer can keep typing with the record open. A half-typed message survives a look at the Ledger.

`--shadow-drawer` mirrors `--shadow-frame` rather than adding a depth: the frame casts down, a drawer rising from a Panel's foot casts up, and reusing the frame's shadow verbatim would have put it under the bottom edge where the composer hides it. Same elevation, two directions.

The drawer stays mounted and translated out of sight rather than using `Activity`, so the filter it was on survives and the slide has something to animate. The Panel rail already wraps the whole Chat Panel in one `Activity`, so nothing is lost.

## The transcript stopped dead against the composer

A turn cut mid-sentence read as the end of it. A gradient over the last 32px says there is more, and a chevron above it goes back to the latest. Both draw only when the transcript is off its foot.

Writing that exposed a drift bug in the scroll pin. It was released by measuring the distance to the foot on every scroll event, but the composer growing shortens the transcript beneath it, and the browser reports that as a scroll *before* the `ResizeObserver` re-pins. Pasting four paragraphs left the transcript 63px adrift with the last turn under the field — the exact case the observer was added for, invisible until a control started appearing when it should not have. Releasing the pin now takes the writer scrolling **up**, which layout changes never do.

## Structural notes for review

- **The composer moved out of the scrolling element** so the drawer had something to stop at. The Chat Panel now scrolls an inner `data-scroller` rather than scrolling itself.
- **The story layout invariant follows it.** It found scrollers by `[data-panel]`, so an inner scroller would have dropped the Chat out of that check silently. It now finds each Panel's scroller, defaulting to the Panel. One Panel, one scroller, either way.
- `Panel` gives back the `ref` and `onScroll` it was widened with in #55, since the scroller is internal now. `Button` takes a `ref` for the focus return.
- The 2(f) fixture was calling `useOfferLedger()` separately from the one inside `useMockChat`, so ruling in the drawer would not have updated the Offer cards in the transcript. `useMockChat` returns its handle and the fixture uses that one.

## Checks

`pnpm test` — 309 tests across 27 files, 38 of them stories in a real Chromium. Lint, formatting, and typecheck clean.

Two new play functions cover the affordances directly: the drawer's geometry against the composer, the toggle round trip, and the Escape focus return; then no chevron at the foot, a chevron after scrolling up, and the return trip.

Behaviour was also driven in a browser against the dev server — the slide, the draft surviving a round trip, and the computed shadow and radius, since a class name that resolves to nothing looks identical to one that works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GU36U26yfybv44XC8KtM7k

---
_Generated by [Claude Code](https://claude.ai/code/session_01GU36U26yfybv44XC8KtM7k)_