### PR TITLE
Show proposal details in transcript when accepted or declined

### DIFF
--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -11,6 +11,7 @@ import { ReferenceCard } from '../components/ReferenceCard'
 import { readRecordedOffers } from './offers'
 import { ProposalCard } from './ProposalCard'
 import { readProposal, type ProposalCall, type Refusals } from './proposals'
+import { RuledProposal } from './RuledProposal'
 
 /**
  * The Chat Panel takes a transcript & rulings; `ArticleChatPanel` drives it from
@@ -233,9 +234,23 @@ function Turn({
 							)
 						}
 						case 'output-available':
-							return <ChatNote key={key}>Proposal Accepted.</ChatNote>
+							return (
+								<RuledProposal
+									key={key}
+									call={readProposal(part)}
+									plan={plan}
+									ruling="accepted"
+								/>
+							)
 						case 'output-error':
-							return <ChatNote key={key}>Proposal Declined.</ChatNote>
+							return (
+								<RuledProposal
+									key={key}
+									call={readProposal(part)}
+									plan={plan}
+									ruling="declined"
+								/>
+							)
 						default:
 							return null
 					}

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -2,7 +2,8 @@ import type { Plan, Refusal } from '../../shared/plan'
 import { Button } from '../components/Button'
 import { Notice } from '../components/Notice'
 import { cx } from '../lib/cx'
-import { refusalText, unreadableText } from '../plan/refusalText'
+import { refusalText } from '../plan/refusalText'
+import { changeCount, ProposalChanges } from './ProposalChanges'
 import { describeProposal, type ProposalCall } from './proposals'
 
 /** One suspended Proposal to Accept or Decline — §6. Renders its ops as
@@ -34,21 +35,9 @@ export function ProposalCard({
 				className,
 			)}
 		>
-			<h4 className="label-meta text-muted">
-				Proposal · {changes.length === 1 ? '1 change' : `${changes.length} changes`}
-			</h4>
+			<h4 className="label-meta text-muted">Proposal · {changeCount(changes)}</h4>
 
-			{call.unreadable === null ? (
-				<ul className="flex list-none flex-col gap-1">
-					{changes.map((change) => (
-						<li key={change} className="text-[0.8125rem] leading-snug text-ink">
-							{change}
-						</li>
-					))}
-				</ul>
-			) : (
-				<p className="text-[0.8125rem] leading-snug text-ink">{unreadableText}</p>
-			)}
+			<ProposalChanges changes={changes} unreadable={call.unreadable} />
 
 			{refusal === null ? null : (
 				<Notice>

--- a/src/client/chat/ProposalChanges.tsx
+++ b/src/client/chat/ProposalChanges.tsx
@@ -1,0 +1,42 @@
+import { cx } from '../lib/cx'
+import { unreadableText } from '../plan/refusalText'
+
+/** The ops of one Proposal as sentences: what the open card offers, and what a
+ * ruled Proposal folds away behind its note. */
+
+export interface ProposalChangesProps {
+	/** One sentence per op, out of `describeProposal`. */
+	changes: readonly string[]
+	/** Why the ops could not be read, and null where they could — §6. */
+	unreadable?: string | null
+	className?: string
+}
+
+export function ProposalChanges({
+	changes,
+	unreadable = null,
+	className,
+}: ProposalChangesProps) {
+	if (unreadable !== null) {
+		return (
+			<p className={cx('text-[0.8125rem] leading-snug text-ink', className)}>
+				{unreadableText}
+			</p>
+		)
+	}
+
+	return (
+		<ul className={cx('flex list-none flex-col gap-1', className)}>
+			{changes.map((change) => (
+				<li key={change} className="text-[0.8125rem] leading-snug text-ink">
+					{change}
+				</li>
+			))}
+		</ul>
+	)
+}
+
+/** How many changes a Proposal carries, for a heading or a summary. */
+export function changeCount(changes: readonly string[]): string {
+	return changes.length === 1 ? '1 change' : `${changes.length} changes`
+}

--- a/src/client/chat/RuledProposal.tsx
+++ b/src/client/chat/RuledProposal.tsx
@@ -1,0 +1,41 @@
+import type { Plan } from '../../shared/plan'
+import { cx } from '../lib/cx'
+import { changeCount, ProposalChanges } from './ProposalChanges'
+import { describeProposal, type ProposalCall } from './proposals'
+
+/**
+ * A Proposal the writer has already ruled on — §6. Shut, it is the one-line note
+ * the transcript used to carry; open, it prints the same sentences the card
+ * offered, so the writer can read back what they Accepted.
+ *
+ * The sentences are named out of the Plan **as it stands now**. The transcript
+ * keeps the ops and nothing keeps the Plan they were written against, so an
+ * Accepted delete names a Section the Plan no longer carries.
+ */
+
+export interface RuledProposalProps {
+	call: ProposalCall
+	/** What the changes name their Sections and References out of. */
+	plan: Plan
+	ruling: 'accepted' | 'declined'
+	className?: string
+}
+
+export function RuledProposal({ call, plan, ruling, className }: RuledProposalProps) {
+	const changes = call.ops === null ? [] : describeProposal(plan, call.ops)
+	const ruled = ruling === 'accepted' ? 'Proposal Accepted' : 'Proposal Declined'
+
+	return (
+		<details className={cx('text-[0.6875rem] text-faint', className)}>
+			<summary className="cursor-pointer">
+				{call.ops === null ? `${ruled}.` : `${ruled} · ${changeCount(changes)}`}
+			</summary>
+
+			<ProposalChanges
+				changes={changes}
+				className="mt-1.5 border-l border-rule pl-2.5"
+				unreadable={call.unreadable}
+			/>
+		</details>
+	)
+}

--- a/test/client/ruled-proposal.test.ts
+++ b/test/client/ruled-proposal.test.ts
@@ -1,0 +1,83 @@
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import type { ProposalCall } from '../../src/client/chat/proposals'
+import { RuledProposal } from '../../src/client/chat/RuledProposal'
+import type { Plan } from '../../src/shared/plan'
+import { makePlan } from '../shared/plan-fixtures'
+
+/**
+ * What a ruled Proposal keeps. The note used to say "Proposal Accepted." and
+ * nothing else, so the writer could not read back what they had agreed to.
+ */
+
+const plan: Plan = makePlan({
+	outline: [{ id: 'sec-cost', title: 'Who actually pays', children: [] }],
+})
+
+const call: ProposalCall = {
+	toolCallId: 'call-1',
+	ops: [{ op: 'setTarget', nodeId: 'sec-cost', expected: null, value: 700 }],
+	unreadable: null,
+}
+
+function ruled(ruling: 'accepted' | 'declined', held: ProposalCall = call) {
+	return renderToStaticMarkup(createElement(RuledProposal, { call: held, plan, ruling }))
+}
+
+describe('a Proposal the writer has ruled on', () => {
+	it('carries the changes it was presented with, under the ruling', () => {
+		const html = ruled('accepted')
+
+		expect(html).toContain('Proposal Accepted')
+		expect(html).toContain('Set the length of §1 Who actually pays to 700 words.')
+	})
+
+	it('keeps the changes a Decline sent back', () => {
+		const html = ruled('declined')
+
+		expect(html).toContain('Proposal Declined')
+		expect(html).toContain('Set the length of §1 Who actually pays to 700 words.')
+	})
+
+	// A record, so it stays out of the way until the writer asks for it.
+	it('folds shut, and expands', () => {
+		const html = ruled('accepted')
+
+		expect(html).toContain('<details')
+		expect(html).toContain('<summary')
+		expect(html).not.toContain('open=""')
+	})
+
+	it('counts the changes on the line the writer reads before expanding', () => {
+		expect(ruled('accepted')).toContain('1 change')
+		expect(
+			ruled('accepted', {
+				...call,
+				ops: [
+					{ op: 'setTarget', nodeId: 'sec-cost', expected: null, value: 700 },
+					{
+						op: 'setTitle',
+						nodeId: 'sec-cost',
+						expected: 'Who actually pays',
+						value: 'Who pays',
+					},
+				],
+			}),
+		).toContain('2 changes')
+	})
+
+	// The count would read "0 changes", which is not what happened.
+	it('says why instead where the payload never parsed, and counts nothing', () => {
+		const html = ruled('declined', {
+			toolCallId: 'call-1',
+			ops: null,
+			unreadable: 'ops: expected array',
+		})
+
+		expect(html).toContain('>Proposal Declined.</summary>')
+		expect(html).not.toContain('0 changes')
+		expect(html).toContain('could not be read')
+	})
+})


### PR DESCRIPTION
When a writer accepts or declines a proposal, the transcript now displays the proposal's changes instead of a bare "Proposal Accepted." or "Proposal Declined." note. This lets writers read back what they agreed to.

## Changes

- **New `RuledProposal` component**: Renders an accepted or declined proposal as a collapsible `<details>` element. The summary shows the ruling and change count; expanding reveals the full list of changes.

- **New `ProposalChanges` component**: Extracted the rendering of proposal changes (the list of sentences describing each operation) into a reusable component. Handles both readable and unreadable payloads.

- **New `changeCount` helper**: Formats the change count as "1 change" or "N changes" for use in headings and summaries.

- **Updated `ChatPanel`**: Replaced bare `<ChatNote>` elements for accepted and declined proposals with `<RuledProposal>` components that display the actual changes.

- **Refactored `ProposalCard`**: Now uses the extracted `ProposalChanges` and `changeCount` to avoid duplication.

## Implementation notes

The ruled proposal names sections and references out of the current plan state, not the plan that existed when the proposal was written. This means an accepted delete may name a section the plan no longer carries—but that's the correct behavior, since the transcript keeps only the operations.

https://claude.ai/code/session_01515vecNfEWrh79mhtpZH5n