### PR TITLE
Redesign color palette and typography

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,8 +38,8 @@ const preview: Preview = {
 		controls: { expanded: true },
 		backgrounds: {
 			options: {
-				paper: { name: 'Paper', value: '#f4f2ee' },
-				surface: { name: 'Surface', value: '#ffffff' },
+				paper: { name: 'Paper', value: '#e9e2d5' },
+				surface: { name: 'Surface', value: '#fbf9f5' },
 			},
 		},
 		options: {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@cloudflare/ai-chat": "^0.10.1",
+    "@fontsource-variable/atkinson-hyperlegible-next": "^5.3.0",
     "@tanstack/react-query": "^5.101.4",
     "@tanstack/react-router": "^1.170.20",
     "agents": "^0.20.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@cloudflare/ai-chat':
         specifier: ^0.10.1
         version: 0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)
+      '@fontsource-variable/atkinson-hyperlegible-next':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@tanstack/react-query':
         specifier: ^5.101.4
         version: 5.101.4(react@19.2.8)
@@ -558,6 +561,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/atkinson-hyperlegible-next@5.3.0':
+    resolution: {integrity: sha512-UnLzNUy1RWoLDfydAatP4NaRm99X/WbQEph7q/PymJnCFIOOwKOx3pBmp5ys8trO0dM+CKGuJgeZP9fAR4mQpA==}
 
   '@hono/node-server@2.1.0':
     resolution: {integrity: sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==}
@@ -3720,6 +3726,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource-variable/atkinson-hyperlegible-next@5.3.0': {}
 
   '@hono/node-server@2.1.0(hono@4.13.0)':
     dependencies:

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -16,16 +16,17 @@ export interface ButtonProps extends Omit<
 	variant?: ButtonVariant
 	size?: ButtonSize
 	/** "You are here" — the chosen one of a set. State rather than a call to
-	 * action, so it takes ink rather than the accent, the way a solid Chip does. */
+	 * action, so it takes `green` rather than the accent, the way a solid Chip
+	 * does. */
 	pressed?: boolean
 	children?: ReactNode
 }
 
 // `pressed` replaces the variant rather than layering over it. Two utilities
 // setting the same property resolve by their order in the stylesheet, not by
-// the order they are written in, so `bg-ink` next to `bg-surface` is a coin
-// toss — and it landed on ink fill with ink text.
-const pressedClass = 'border border-ink bg-ink text-paper hover:brightness-125'
+// the order they are written in, so `bg-green` next to `bg-surface` is a coin
+// toss — and it landed on green fill with ink text.
+const pressedClass = 'border border-green bg-green text-green-ink hover:brightness-125'
 
 const variantClass: Record<ButtonVariant, string> = {
 	default: 'border border-edge bg-surface text-ink hover:border-ink/40 hover:bg-hush',

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -10,7 +10,7 @@ export interface ButtonProps extends Omit<
 	'children'
 > {
 	/**
-	 * `accent` is the yellow one. A screen should have at most one — it marks
+	 * `accent` is the rose one. A screen should have at most one — it marks
 	 * the single thing the app wants you to do next.
 	 */
 	variant?: ButtonVariant

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -66,14 +66,11 @@ export interface ChatComposerProps {
  * load-bearing: `scrollHeight` reads back the height the field already has, so
  * without the reset the field could grow but never shrink.
  *
- * The reset drops the field to its one `rows` line for an instant, and the
- * transcript above it is what takes the space. A scroller that grows has less
- * run below it, so the browser clamps its `scrollTop` — and it does not give
- * it back when the field returns. Both writes land in one block, so the
- * observer watching the transcript sees no net change and never re-pins it,
- * which leaves the writer looking at the middle of a conversation they were
- * reading the foot of. Holding the composer's own box across the measurement
- * keeps the transcript still, so nothing is clamped to give back. */
+ * The composer's box is held across the reset, because `auto` collapses the
+ * field to its one `rows` line and the transcript above it grows into the gap.
+ * The browser clamps a grown scroller's `scrollTop` and does not restore it,
+ * and both writes land in one block, so the ResizeObserver that re-pins the
+ * transcript sees no net change and never fires. */
 function grow(field: HTMLTextAreaElement) {
 	const composer = field.closest<HTMLElement>('[data-composer]')
 	if (composer !== null) composer.style.height = `${composer.offsetHeight}px`

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -64,10 +64,24 @@ export interface ChatComposerProps {
 
 /** Height of the content, clamped by the field's own `max-h`. The `auto` is
  * load-bearing: `scrollHeight` reads back the height the field already has, so
- * without the reset the field could grow but never shrink. */
+ * without the reset the field could grow but never shrink.
+ *
+ * The reset drops the field to its one `rows` line for an instant, and the
+ * transcript above it is what takes the space. A scroller that grows has less
+ * run below it, so the browser clamps its `scrollTop` — and it does not give
+ * it back when the field returns. Both writes land in one block, so the
+ * observer watching the transcript sees no net change and never re-pins it,
+ * which leaves the writer looking at the middle of a conversation they were
+ * reading the foot of. Holding the composer's own box across the measurement
+ * keeps the transcript still, so nothing is clamped to give back. */
 function grow(field: HTMLTextAreaElement) {
+	const composer = field.closest<HTMLElement>('[data-composer]')
+	if (composer !== null) composer.style.height = `${composer.offsetHeight}px`
+
 	field.style.height = 'auto'
 	field.style.height = `${field.scrollHeight}px`
+
+	if (composer !== null) composer.style.height = ''
 }
 
 /** A chat message input that grows as you type; Enter adds a new line and

--- a/src/client/components/Check.tsx
+++ b/src/client/components/Check.tsx
@@ -11,7 +11,7 @@ export interface CheckProps {
  * The square tick used for accepting a Reference, an Offer, or a Guidance note.
  *
  * Checked is the accented state — accepting something is the one decision
- * these lists are asking for, so the yellow belongs here.
+ * these lists are asking for, so the accent belongs here.
  */
 export function Check({ checked = false, onChange, label, className }: CheckProps) {
 	return (

--- a/src/client/components/Chip.tsx
+++ b/src/client/components/Chip.tsx
@@ -19,8 +19,8 @@ const variantClass: Record<ChipVariant, string> = {
 	outline: 'border-edge bg-transparent text-muted',
 	muted: 'border-transparent bg-transparent text-faint',
 	// `solid` is "you are here" — a tab or filter that is currently selected.
-	// State, not a call to action, so it takes ink rather than the accent.
-	solid: 'border-ink bg-ink text-paper',
+	// State, not a call to action, so it takes `green` rather than the accent.
+	solid: 'border-green bg-green text-green-ink',
 }
 
 /** The pill's own geometry, exported for a control that cannot be a `Chip` —

--- a/src/client/components/PanelRail.tsx
+++ b/src/client/components/PanelRail.tsx
@@ -15,7 +15,7 @@ export interface PanelRailProps {
  * The four-Panel toggle: chat · plan · draft · notes.
  *
  * Deliberately *not* accented. Which Panels are open is state, not a call to
- * action, so the active pill is solid ink and the yellow stays free for the
+ * action, so the active pill is solid ink and the accent stays free for the
  * one thing on screen that actually wants a decision.
  */
 export function PanelRail({ open, onToggle, className }: PanelRailProps) {

--- a/src/client/components/PanelRail.tsx
+++ b/src/client/components/PanelRail.tsx
@@ -44,7 +44,8 @@ export function PanelRail({ open, onToggle, className }: PanelRailProps) {
 						className={cx(
 							'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
 							isOpen ? 'bg-green text-green-ink' : 'text-faint',
-							onToggle && !isOpen && 'hover:bg-hush hover:text-muted',
+							// `hush` would be mauve on the rail's green, which goes muddy.
+							onToggle && !isOpen && 'hover:bg-surface hover:text-muted',
 						)}
 					>
 						{Panel}

--- a/src/client/components/PanelRail.tsx
+++ b/src/client/components/PanelRail.tsx
@@ -15,7 +15,7 @@ export interface PanelRailProps {
  * The four-Panel toggle: chat · plan · draft · notes.
  *
  * Deliberately *not* accented. Which Panels are open is state, not a call to
- * action, so the active pill is solid ink and the accent stays free for the
+ * action, so the active pill takes `green` and the accent stays free for the
  * one thing on screen that actually wants a decision.
  */
 export function PanelRail({ open, onToggle, className }: PanelRailProps) {
@@ -43,7 +43,7 @@ export function PanelRail({ open, onToggle, className }: PanelRailProps) {
 							: {})}
 						className={cx(
 							'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
-							isOpen ? 'bg-ink text-paper' : 'text-faint',
+							isOpen ? 'bg-green text-green-ink' : 'text-faint',
 							onToggle && !isOpen && 'hover:bg-hush hover:text-muted',
 						)}
 					>

--- a/src/client/components/PanelRail.tsx
+++ b/src/client/components/PanelRail.tsx
@@ -44,7 +44,6 @@ export function PanelRail({ open, onToggle, className }: PanelRailProps) {
 						className={cx(
 							'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
 							isOpen ? 'bg-green text-green-ink' : 'text-faint',
-							// `hush` would be mauve on the rail's green, which goes muddy.
 							onToggle && !isOpen && 'hover:bg-surface hover:text-muted',
 						)}
 					>

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -5,11 +5,14 @@ import { Meta } from '@storybook/addon-docs/blocks'
 # The accent
 
 The page is earth, ink and three soft neutrals, tinted off a Deccan winter: dry
-brown ground, dried-scrub green in the secondary copy, dusty mauve in the meta.
-Those hues are scenery — they carry no meaning and never mark anything. There is
-exactly one colour in the system that does mean something — `--color-accent`, a
-muted rose, `#eec9c7` — and it is the only thing on a screen that asks for
-attention.
+brown ground, pale scrub green in the secondary panes, dusty mauve in the meta.
+Those hues are scenery — they say nothing about the screen they are on.
+
+Two colours do carry meaning, and they answer different questions.
+`--color-green`, a deep scrub green, `#4c6141`, says **where you are**.
+`--color-accent`, a muted rose, `#eec9c7`, says **what is being asked of you**,
+and it is the only thing on a screen that asks for attention. The rest of this
+page is about the rose, because it is the one that has to be rationed.
 
 <div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
   {[
@@ -57,8 +60,11 @@ on**, or **the one item that has changed and you might not have noticed**.
 
 ## What does not
 
-- **Which Panels, tabs or filters are selected.** The `PanelRail`'s active pill and
-  `Chip variant="solid"` are ink. Where you are is state, not a request.
+- **Which Panels, tabs or filters are selected.** The `PanelRail`'s active pill,
+  `Chip variant="solid"` and a pressed `Button` take `--color-green`, a deep
+  scrub green — `--color-sunk` saturated and inverted, so a selected pill reads
+  as the deep of the pale green it sits on. Where you are is state, not a
+  request, and state does not need the accent.
 - **Progress.** Bars are ink at 30% — a shape, not an alarm. The exception is
   going _over_ target, which flips to `accent-edge` because it is genuinely news.
 - **Ordinary emphasis.** Headings are weight and size. Metadata is `--color-faint`.
@@ -78,13 +84,15 @@ one of the two is not really asking for a decision.
   {[
     ['--color-paper', '#e9e2d5'],
     ['--color-surface', '#fbf9f5'],
-    ['--color-sunk', '#ebe8d3'],
+    ['--color-sunk', '#e5ead3'],
     ['--color-hush', '#e7dfe3'],
     ['--color-ink', '#2b2229'],
     ['--color-muted', '#5c6050'],
     ['--color-faint', '#8e858a'],
     ['--color-rule', '#dbd7c3'],
     ['--color-edge', '#c2bda9'],
+    ['--color-green', '#4c6141'],
+    ['--color-green-ink', '#eef2e2'],
   ].map(([token, hex]) => (
     <div key={token} style={{ width: '8.5rem' }}>
       <div

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -4,16 +4,19 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 # The accent
 
-The page is paper, ink and three greys. There is exactly one colour in the
-system — `--color-accent`, a light yellow, `#ffe6a3` — and it is the only thing
-on a screen that asks for attention.
+The page is earth, ink and three soft neutrals, tinted off a Deccan winter: dry
+brown ground, dried-scrub green in the secondary copy, dusty mauve in the meta.
+Those hues are scenery — they carry no meaning and never mark anything. There is
+exactly one colour in the system that does mean something — `--color-accent`, a
+muted rose, `#eec9c7` — and it is the only thing on a screen that asks for
+attention.
 
 <div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
   {[
-    ['--color-accent', '#ffe6a3', 'The highlight itself'],
-    ['--color-accent-soft', '#fff6df', 'Wash behind an accented block'],
-    ['--color-accent-edge', '#e3c471', 'Borders, filled progress'],
-    ['--color-accent-ink', '#6a5312', 'Text sitting on accent'],
+    ['--color-accent', '#eec9c7', 'The highlight itself'],
+    ['--color-accent-soft', '#fbebe8', 'Wash behind an accented block'],
+    ['--color-accent-edge', '#bd7f83', 'Borders, filled progress'],
+    ['--color-accent-ink', '#6a2f34', 'Text sitting on accent'],
   ].map(([token, hex, use]) => (
     <div key={token} style={{ width: '11rem' }}>
       <div
@@ -21,7 +24,7 @@ on a screen that asks for attention.
           height: '3.5rem',
           background: hex,
           borderRadius: '0.5rem',
-          border: '1px solid #cdc7bc',
+          border: '1px solid #c2bda9',
         }}
       />
       <p
@@ -32,7 +35,7 @@ on a screen that asks for attention.
       >
         {token}
       </p>
-      <p style={{ font: '0.75rem system-ui', color: '#6b665e', margin: 0 }}>
+      <p style={{ font: '0.75rem system-ui', color: '#5c6050', margin: 0 }}>
         {hex} — {use}
       </p>
     </div>
@@ -66,22 +69,22 @@ on**, or **the one item that has changed and you might not have noticed**.
 
 Most screens have **one** accented element. Some have **none** — 2(a), the blank
 plan, is deliberately unaccented, because an empty plan is not asking you for
-anything yet. If you find yourself putting a second yellow thing on a screen,
+anything yet. If you find yourself putting a second rose thing on a screen,
 one of the two is not really asking for a decision.
 
 ## Everything else
 
 <div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
   {[
-    ['--color-paper', '#f4f2ee'],
-    ['--color-surface', '#ffffff'],
-    ['--color-sunk', '#faf8f5'],
-    ['--color-hush', '#f0ede7'],
-    ['--color-ink', '#1b1a17'],
-    ['--color-muted', '#6b665e'],
-    ['--color-faint', '#9b958a'],
-    ['--color-rule', '#e3dfd7'],
-    ['--color-edge', '#cdc7bc'],
+    ['--color-paper', '#e9e2d5'],
+    ['--color-surface', '#fbf9f5'],
+    ['--color-sunk', '#ebe8d3'],
+    ['--color-hush', '#e7dfe3'],
+    ['--color-ink', '#2b2229'],
+    ['--color-muted', '#5c6050'],
+    ['--color-faint', '#8e858a'],
+    ['--color-rule', '#dbd7c3'],
+    ['--color-edge', '#c2bda9'],
   ].map(([token, hex]) => (
     <div key={token} style={{ width: '8.5rem' }}>
       <div
@@ -89,14 +92,14 @@ one of the two is not really asking for a decision.
           height: '2.5rem',
           background: hex,
           borderRadius: '0.375rem',
-          border: '1px solid #cdc7bc',
+          border: '1px solid #c2bda9',
         }}
       />
       <p style={{ font: '0.6875rem ui-monospace, monospace', margin: '0.375rem 0 0' }}>
         {token}
       </p>
       <p
-        style={{ font: '0.6875rem ui-monospace, monospace', color: '#9b958a', margin: 0 }}
+        style={{ font: '0.6875rem ui-monospace, monospace', color: '#8e858a', margin: 0 }}
       >
         {hex}
       </p>

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -112,7 +112,10 @@ export function SectionRow({
 				style={{ marginLeft: depth * 20 }}
 			>
 				<button
-					className="-mx-1.5 rounded-md px-1.5 py-1 text-left hover:bg-hush"
+					// The border is transparent at rest rather than absent, so the row
+					// does not move by a pixel when the pointer arrives. `hush` is not
+					// used here: the mauve turns muddy on the green of a `sunk` pane.
+					className="-mx-1.5 rounded-md border border-transparent px-1.5 py-1 text-left hover:border-edge hover:bg-surface"
 					onClick={() => onOpen(node.id)}
 					// Opening on mousedown, because the Section that is open closes on
 					// the focus leaving it — which relays out the list and moves this

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -112,9 +112,6 @@ export function SectionRow({
 				style={{ marginLeft: depth * 20 }}
 			>
 				<button
-					// The border is transparent at rest rather than absent, so the row
-					// does not move by a pixel when the pointer arrives. `hush` is not
-					// used here: the mauve turns muddy on the green of a `sunk` pane.
 					className="-mx-1.5 rounded-md border border-transparent px-1.5 py-1 text-left hover:border-edge hover:bg-surface"
 					onClick={() => onOpen(node.id)}
 					// Opening on mousedown, because the Section that is open closes on

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -3,33 +3,34 @@
 /*
  * Joarness design tokens.
  *
- * The page is deliberately quiet: paper, ink, and three greys. `accent` is the
- * one colour that asks for attention, and it is rationed — see the "Accent"
- * docs page in Storybook. If a screen has two yellow things on it, one of them
- * is probably wrong.
+ * The page is deliberately quiet: earth, ink, and three soft neutrals, tinted
+ * off a Deccan winter — dry brown ground, dried-scrub green, dusty mauve.
+ * `accent` is the one colour that asks for attention, and it is rationed — see
+ * the "Accent" docs page in Storybook. If a screen has two rose things on it,
+ * one of them is probably wrong.
  */
 @theme {
 	/* Surfaces */
-	--color-paper: #f4f2ee; /* the desk the app sits on */
-	--color-surface: #ffffff; /* cards, panes, the writing surface */
-	--color-sunk: #faf8f5; /* secondary panes: plan, notes, sidebars */
-	--color-hush: #f0ede7; /* your own chat messages, inert fills */
+	--color-paper: #e9e2d5; /* the desk the app sits on: sun-dried earth */
+	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
+	--color-sunk: #ebe8d3; /* secondary panes: plan, notes, sidebars */
+	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */
-	--color-ink: #1b1a17; /* body + headings */
-	--color-muted: #6b665e; /* secondary copy */
-	--color-faint: #9b958a; /* meta, counts, timestamps */
+	--color-ink: #2b2229; /* body + headings: brown-black with a purple cast */
+	--color-muted: #5c6050; /* secondary copy: dried scrub green */
+	--color-faint: #8e858a; /* meta, counts, timestamps: dusty mauve */
 
 	/* Lines */
-	--color-rule: #e3dfd7; /* hairlines between rows */
-	--color-edge: #cdc7bc; /* card borders, inputs */
-	--color-strong: #1b1a17; /* the one heavy divider per frame */
+	--color-rule: #dbd7c3; /* hairlines between rows */
+	--color-edge: #c2bda9; /* card borders, inputs */
+	--color-strong: #2b2229; /* the one heavy divider per frame */
 
-	/* The accent — light yellow highlight. Rationed. */
-	--color-accent: #ffe6a3;
-	--color-accent-soft: #fff6df; /* wash behind an accented block */
-	--color-accent-edge: #e3c471;
-	--color-accent-ink: #6a5312; /* text sitting on accent */
+	/* The accent — muted rose highlight. Rationed. */
+	--color-accent: #eec9c7;
+	--color-accent-soft: #fbebe8; /* wash behind an accented block */
+	--color-accent-edge: #bd7f83;
+	--color-accent-ink: #6a2f34; /* text sitting on accent */
 
 	/* Type */
 	--font-sans: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
@@ -45,7 +46,7 @@
 	--radius-frame: 0.625rem;
 
 	/* One elevation, used only on the outermost frame */
-	--shadow-frame: 0 1px 2px rgb(27 26 23 / 0.05), 0 8px 24px -16px rgb(27 26 23 / 0.25);
+	--shadow-frame: 0 1px 2px rgb(43 34 41 / 0.05), 0 8px 24px -16px rgb(43 34 41 / 0.25);
 }
 
 @layer base {

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -13,7 +13,7 @@
 	/* Surfaces */
 	--color-paper: #e9e2d5; /* the desk the app sits on: sun-dried earth */
 	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
-	--color-sunk: #ebe8d3; /* secondary panes: plan, notes, sidebars */
+	--color-sunk: #e5ead3; /* secondary panes: plan, notes, sidebars */
 	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */
@@ -25,6 +25,13 @@
 	--color-rule: #dbd7c3; /* hairlines between rows */
 	--color-edge: #c2bda9; /* card borders, inputs */
 	--color-strong: #2b2229; /* the one heavy divider per frame */
+
+	/* The "you are here" fill: a selected tab, filter or pressed button. It is
+	   `sunk` saturated and inverted, so a selected pill reads as the deep of
+	   the pale green it sits on. State is not a request, so this is not the
+	   accent — but it need not be black either. */
+	--color-green: #4c6141;
+	--color-green-ink: #eef2e2; /* text sitting on green */
 
 	/* The accent — muted rose highlight. Rationed. */
 	--color-accent: #eec9c7;

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -1,5 +1,11 @@
 @import 'tailwindcss';
 
+/* Atkinson Hyperlegible Next, self-hosted. It was drawn by the Braille
+   Institute to be read at a glance: the letters that usually collide — I l 1,
+   O 0, b d — are drawn apart from each other. One variable file covers every
+   weight the interface asks for. */
+@import '@fontsource-variable/atkinson-hyperlegible-next';
+
 /*
  * Joarness design tokens.
  *
@@ -40,7 +46,9 @@
 	--color-accent-ink: #6a2f34; /* text sitting on accent */
 
 	/* Type */
-	--font-sans: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+	--font-sans:
+		'Atkinson Hyperlegible Next Variable', ui-sans-serif, system-ui, -apple-system,
+		'Segoe UI', Roboto, sans-serif;
 	--font-serif:
 		'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif;
 	--font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -1,9 +1,5 @@
 @import 'tailwindcss';
 
-/* Atkinson Hyperlegible Next, self-hosted. It was drawn by the Braille
-   Institute to be read at a glance: the letters that usually collide — I l 1,
-   O 0, b d — are drawn apart from each other. One variable file covers every
-   weight the interface asks for. */
 @import '@fontsource-variable/atkinson-hyperlegible-next';
 
 /*
@@ -32,10 +28,7 @@
 	--color-edge: #c2bda9; /* card borders, inputs */
 	--color-strong: #2b2229; /* the one heavy divider per frame */
 
-	/* The "you are here" fill: a selected tab, filter or pressed button. It is
-	   `sunk` saturated and inverted, so a selected pill reads as the deep of
-	   the pale green it sits on. State is not a request, so this is not the
-	   accent — but it need not be black either. */
+	/* "You are here": a selected tab, filter or pressed button */
 	--color-green: #4c6141;
 	--color-green-ink: #eef2e2; /* text sitting on green */
 


### PR DESCRIPTION
This change introduces a warmer, more naturalistic color palette inspired by a Deccan winter landscape, and adds the Atkinson Hyperlegible Next typeface for improved readability.

## Summary

The design system moves from a cool, minimal palette (paper white, cool greys, bright yellow accent) to an earth-toned palette with semantic color meaning. A new typeface optimized for legibility at a glance replaces the system font stack.

## Key changes

- **Color palette redesign**: Surfaces shift to warm earth tones (`#e9e2d5` paper, `#fbf9f5` surface). The three supporting neutrals now carry tonal meaning: `--color-sunk` becomes a pale scrub green (`#e5ead3`), `--color-muted` a dried-scrub green (`#5c6050`), and `--color-faint` a dusty mauve (`#8e858a`).

- **Semantic color introduction**: A new `--color-green` (`#4c6141`) answers "where you are" for selected tabs, filters, and pressed buttons. The accent shifts from bright yellow (`#ffe6a3`) to muted rose (`#eec9c7`), now answering "what is being asked of you." This separation clarifies that state (green) and calls to action (rose) are distinct.

- **Typography**: Atkinson Hyperlegible Next, a variable font designed by the Braille Institute for legibility, replaces the system font stack as the primary sans-serif.

- **Component updates**: `Button`, `PanelRail`, `Chip`, and `SectionRow` now use `--color-green` for pressed/selected states instead of ink. Hover states in `PanelRail` and `SectionRow` avoid `--color-hush` (mauve) on green backgrounds, which reads muddy.

- **Documentation**: The Accent design token page is rewritten to explain the new two-color system and when each color applies.

## Implementation notes

The pressed button class and selected chip styling now use green with appropriate text color (`--color-green-ink`). The `SectionRow` hover state adds a transparent border at rest to prevent layout shift on pointer entry, and uses `--color-surface` instead of `--color-hush` to maintain clarity on secondary panes.

https://claude.ai/code/session_017fdinDazCaea8uTE5WiDwf