### PR TITLE
Refactor ReferenceCard heading and passage display logic

### DIFF
--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -44,14 +44,12 @@ export function ReferenceCard({
 	const declined = offer.disposition === 'declined'
 	const accepted = offer.disposition === 'accepted'
 	const ruled = accepted || declined
-	// The card prints a passage once, under the title it came from, the way the
-	// Plan row it will be copied into does. A Quote that names no title is headed
-	// by nothing and prints its passage alone.
-	const heading = offer.text === undefined ? referenceName(offer) : offer.source?.title
+	const headingText =
+		offer.text === undefined ? referenceName(offer) : offer.source?.title
 	const url = offer.source?.url
-	// Whether the link goes on the heading or on the line below. A passage is
-	// never the heading, because an underlined passage reads as emphasis.
-	const headingLinks = url !== undefined && heading !== undefined
+	// Whether the link goes on the heading or on the line below. A passage never
+	// heads a card, because an underlined passage reads as emphasis.
+	const headingLinks = url !== undefined && headingText !== undefined
 	const cited: ReactNode[] = [
 		...(favourite ? [<FavouriteMark key="favourite" type={favourite} />] : []),
 		...attribution(offer.source),
@@ -80,9 +78,13 @@ export function ReferenceCard({
 			) : null}
 
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
-				{heading === undefined ? null : (
+				{headingText === undefined ? null : (
 					<h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">
-						{headingLinks ? <SourceLink url={url}>{heading}</SourceLink> : heading}
+						{headingLinks ? (
+							<SourceLink url={url}>{headingText}</SourceLink>
+						) : (
+							headingText
+						)}
 					</h4>
 				)}
 				{offer.text === undefined ? null : (

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -47,8 +47,7 @@ export function ReferenceCard({
 	const headingText =
 		offer.text === undefined ? referenceName(offer) : offer.source?.title
 	const url = offer.source?.url
-	// Whether the link goes on the heading or on the line below. A passage never
-	// heads a card, because an underlined passage reads as emphasis.
+	// Whether the link goes on the heading or on the line below.
 	const headingLinks = url !== undefined && headingText !== undefined
 	const cited: ReactNode[] = [
 		...(favourite ? [<FavouriteMark key="favourite" type={favourite} />] : []),

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -44,19 +44,18 @@ export function ReferenceCard({
 	const declined = offer.disposition === 'declined'
 	const accepted = offer.disposition === 'accepted'
 	const ruled = accepted || declined
-	const heading = referenceName(offer)
-	// A Quote with no source is its own heading; do not print it twice.
-	const passage = offer.text !== undefined && offer.text !== heading
+	// The card prints a passage once, under the title it came from, the way the
+	// Plan row it will be copied into does. A Quote that names no title is headed
+	// by nothing and prints its passage alone.
+	const heading = offer.text === undefined ? referenceName(offer) : offer.source?.title
 	const url = offer.source?.url
-	// Whether the link goes on the heading or on the line below. A Quote is
-	// headed by its passage, and an underlined passage reads as emphasis.
-	const headingLinks = url !== undefined && offer.text === undefined
+	// Whether the link goes on the heading or on the line below. A passage is
+	// never the heading, because an underlined passage reads as emphasis.
+	const headingLinks = url !== undefined && heading !== undefined
 	const cited: ReactNode[] = [
 		...(favourite ? [<FavouriteMark key="favourite" type={favourite} />] : []),
 		...attribution(offer.source),
-		...(url !== undefined && !headingLinks
-			? [<SourceLink className="break-all" key="url" url={url} />]
-			: []),
+		...(url !== undefined && !headingLinks ? [<SourceLink key="url" url={url} />] : []),
 	]
 
 	return (
@@ -72,7 +71,7 @@ export function ReferenceCard({
 				// Decline and nothing undoes an Accept, so there is no state to go back to.
 				<Check
 					checked={accepted}
-					label={`Accept ${heading}`}
+					label={`Accept ${referenceName(offer)}`}
 					onChange={accepted ? undefined : onAccept}
 				/>
 			) : null}
@@ -81,15 +80,17 @@ export function ReferenceCard({
 			) : null}
 
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
-				<h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">
-					{headingLinks ? <SourceLink url={url}>{heading}</SourceLink> : heading}
-				</h4>
-				<CitedLine parts={cited} />
-				{passage ? (
-					<blockquote className="border-l-2 border-rule pl-2 text-[0.75rem] leading-relaxed text-ink">
+				{heading === undefined ? null : (
+					<h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">
+						{headingLinks ? <SourceLink url={url}>{heading}</SourceLink> : heading}
+					</h4>
+				)}
+				{offer.text === undefined ? null : (
+					<blockquote className="border-l-2 border-rule pl-2.5 text-[0.8125rem] leading-relaxed text-ink">
 						“{offer.text}”
 					</blockquote>
-				) : null}
+				)}
+				<CitedLine className="break-all" parts={cited} />
 				{!compact && offer.note !== undefined ? (
 					<p className="text-[0.75rem] leading-relaxed text-muted">{offer.note}</p>
 				) : null}

--- a/test/client/reference-card.test.ts
+++ b/test/client/reference-card.test.ts
@@ -108,6 +108,40 @@ describe('the url a card carries', () => {
 	})
 })
 
+describe('the passage a Quote card carries', () => {
+	function quoted(source: Offer['source']) {
+		const offer: Offer = {
+			id: 'o1',
+			type: 'quote',
+			text: 'Forty separate times.',
+			source,
+			disposition: 'undecided',
+			createdAt: 0,
+			decidedAt: null,
+		}
+
+		return renderToStaticMarkup(createElement(ReferenceCard, { offer }))
+	}
+
+	// The card headed the passage and then quoted it again below.
+	it('prints the passage once', () => {
+		const html = quoted({ title: 'Permit throughput', author: 'R. Okonkwo' })
+
+		expect(html.split('Forty separate times.')).toHaveLength(2)
+	})
+
+	it('heads the passage with the title it came from', () => {
+		const html = quoted({ title: 'Permit throughput', author: 'R. Okonkwo' })
+
+		expect(html).toContain('Permit throughput')
+		expect(html).toContain('R. Okonkwo')
+	})
+
+	it('prints the passage alone where the source names no title', () => {
+		expect(quoted({ author: 'R. Okonkwo' })).toContain('Forty separate times.')
+	})
+})
+
 describe('the tick a Ledger card carries', () => {
 	// Nothing undoes an Accept — `restoreOffer` undoes a Decline — so the tick
 	// does not offer a state to go back to.


### PR DESCRIPTION
## Summary

Simplified the logic for displaying headings and passages in ReferenceCard by clarifying when each element appears and consolidating related styling changes.

## Key Changes

- **Heading display**: Introduced `headingText` variable to explicitly determine what appears in the heading. For quotes with text, the heading now shows the source title (if available) rather than the passage itself, eliminating duplication.

- **Passage display**: Changed the blockquote to render only when `offer.text` is defined, making the conditional logic more direct.

- **Link placement**: Updated `headingLinks` condition to check `headingText !== undefined` instead of `offer.text === undefined`, which more accurately reflects when a link should appear on the heading.

- **Styling adjustments**:
  - Removed `break-all` class from SourceLink in the cited line (moved to CitedLine wrapper)
  - Updated blockquote padding from `pl-2` to `pl-2.5` and font size from `0.75rem` to `0.8125rem`
  - Added `break-all` class to CitedLine component

- **Test coverage**: Added comprehensive tests for quote card passage display, verifying that passages appear exactly once and that source titles are used as headings when available.

## Implementation Details

The refactoring makes the component's rendering logic more predictable: a quote card now consistently uses its source title as the heading (when available) and displays the passage text in a blockquote below, rather than using the passage as the heading and potentially duplicating it.

https://claude.ai/code/session_018HngDiUkooJihiJ2zURb8w