### PR TITLE
Add Map View of Plan Outline

### DIFF
--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -14,6 +14,7 @@ import { ChatWithReferencesScreen } from './ChatWithReferencesScreen'
 import { LedgerDrawerScreen } from './LedgerDrawerScreen'
 import { LedgerPopoverScreen } from './LedgerPopoverScreen'
 import { MidChatScreen } from './MidChatScreen'
+import { PlanMapScreen } from './PlanMapScreen'
 import { PlanSheetScreen } from './PlanSheetScreen'
 import { ReadyToDraftScreen } from './ReadyToDraftScreen'
 import { StaleProposalScreen } from './StaleProposalScreen'
@@ -258,4 +259,40 @@ export const J_StaleProposal: Story = {
 			</Annotation>
 		</div>
 	),
+}
+
+export const K_PlanMap: Story = {
+	name: '2(k) The Outline as a map',
+	render: () => (
+		<div className="flex flex-col">
+			<PlanMapScreen />
+			<Annotation>
+				A second View of the same Outline, opened left to right. It reads the Plan and
+				never writes it, so folding a Section here hides its Subsections on the map and
+				leaves the Plan alone — the Panel beside it still lists every one. The curve is
+				the cubic a mind map is drawn with: out of the parent's right edge, into the
+				child's left edge, turning halfway between the columns.
+			</Annotation>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+
+		// Folding is a read affordance, so the Section stays and only what sits
+		// inside it goes.
+		const fold = canvas.getByLabelText('Fold the 2 inside How review became the process')
+		await expect(canvas.getByText('The eleven points')).toBeVisible()
+
+		await userEvent.click(fold)
+		await expect(canvas.queryByText('The eleven points')).toBeNull()
+		await expect(canvas.getByText('How review became the process')).toBeVisible()
+
+		// The control now says how much is folded away, so the box does not read
+		// as a Section with nothing inside it.
+		const open = canvas.getByLabelText('Open the 2 inside How review became the process')
+		await expect(open).toHaveTextContent('2')
+
+		await userEvent.click(open)
+		await expect(canvas.getByText('The eleven points')).toBeVisible()
+	},
 }

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -393,9 +393,9 @@ export const K_PlanMap: Story = {
 		await userEvent.click(
 			canvas.getByRole('button', { name: 'What a faster desk does', exact: true }),
 		)
-		await userEvent.click(canvas.getByRole('button', { name: 'place a reference' }))
-		await userEvent.click(
-			canvas.getByRole('button', { name: /Zoning and the missing middle/ }),
+		await userEvent.selectOptions(
+			canvas.getByLabelText('Place a Reference at Section 5'),
+			canvas.getByRole('option', { name: /Zoning and the missing middle/ }),
 		)
 		await userEvent.keyboard('{Escape}')
 

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -305,5 +305,27 @@ export const K_PlanMap: Story = {
 
 		await userEvent.click(open)
 		await expect(canvas.getByText('The eleven points')).toBeVisible()
+
+		// Clicking a box opens the Section's own fields over the map, anchored at
+		// the box. The map keeps its shape underneath: nothing reflows around it.
+		const before = canvas
+			.getByLabelText('Map of Why Cities Stopped Building')
+			.getBoundingClientRect()
+
+		await userEvent.click(canvas.getByRole('button', { name: 'The eleven points' }))
+		const title = canvas.getByLabelText('Title of Subsection 2.1') as HTMLInputElement
+		await expect(title).toHaveValue('The eleven points')
+		await expect(
+			canvas.getByLabelText('Map of Why Cities Stopped Building').getBoundingClientRect(),
+		).toEqual(before)
+
+		// It writes through the ops the Panel writes through, so the map redraws
+		// off the Plan rather than off anything the detail holds.
+		await userEvent.clear(title)
+		await userEvent.type(title, 'The eleven review points')
+		await userEvent.click(canvas.getByRole('button', { name: 'done' }))
+
+		await expect(canvas.queryByLabelText('Title of Subsection 2.1')).toBeNull()
+		await expect(canvas.getByText('The eleven review points')).toBeVisible()
 	},
 }

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -238,10 +238,32 @@ export const I_PlanPanelWired: Story = {
 			<Annotation>
 				Every field here writes through the same ops the Chat proposes in, so the Panel
 				cannot make a change the applier would refuse. Typing debounces: the Plan is one
-				blob re-broadcast on every write, and a keystroke is not a write.
+				blob re-broadcast on every write, and a keystroke is not a write. The rail on the
+				Outline heading swaps the list for the map, which is wider than this Panel and
+				scrolls sideways inside it.
 			</Annotation>
 		</div>
 	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+
+		await userEvent.click(canvas.getByRole('button', { name: 'map' }))
+
+		// Measured on the box that scrolls, not on the SVG inside it: the SVG
+		// carries its own height attribute and keeps it either way. The map is
+		// taller than this Panel and `overflow-x-auto` resolves that box's
+		// `min-height` to 0, so a flex column that overflows squeezes it to
+		// nothing unless it refuses to shrink.
+		const map = canvasElement.querySelector('[data-plan-map]')!
+		await expect(map.getBoundingClientRect().height).toBeGreaterThan(100)
+
+		// The Panel's own two Outline controls stand down while the map is up,
+		// because the map carries a `+` of its own.
+		await expect(canvas.queryByRole('button', { name: '+ section' })).toBeNull()
+
+		await userEvent.click(canvas.getByRole('button', { name: 'list' }))
+		await expect(canvas.getByRole('button', { name: '+ section' })).toBeVisible()
+	},
 }
 
 export const J_StaleProposal: Story = {
@@ -262,19 +284,18 @@ export const J_StaleProposal: Story = {
 }
 
 export const K_PlanMap: Story = {
-	name: '2(k) The Outline as a map',
+	name: '2(k) The Plan as a map',
 	render: () => (
 		<div className="flex flex-col">
 			<PlanMapScreen />
 			<Annotation>
-				A second View of the same Outline, opened left to right. The right edge of a box
-				holds what it says about its children: fold what is already inside, and{' '}
-				<code>+</code> one more. On the title that makes a Section, and on a Section it
-				makes a Subsection — the nesting the Panel has no control for, because a map draws
-				nesting and a list does not. Folding is a read and changes nothing in the Plan;
-				everything else writes through the ops the Panel writes through. Clicking a box
-				opens its fields over the map, and placing a Reference is in there rather than on
-				the box, which only says which are placed.
+				A second View of the same Plan, opened left to right: the Article title, its
+				Sections, and the References placed at each. Three columns, which is the whole
+				Plan — an unplaced Reference is in the list below and not on the map. Clicking a
+				Section opens its fields over it, anchored at the box, so nothing reflows around
+				what you are editing. Escape or a click on the space between boxes puts them away.{' '}
+				<code>+</code> on the title makes a Section, and one made with nothing in it is
+				thrown away again when you leave it.
 			</Annotation>
 		</div>
 	),
@@ -285,29 +306,31 @@ export const K_PlanMap: Story = {
 		// has too. The rail is how the writer gets between them.
 		await userEvent.click(canvas.getByRole('button', { name: 'list' }))
 		await expect(canvas.queryByLabelText(/^Map of /)).toBeNull()
-		await expect(canvas.getByText('One objection resets the clock')).toBeVisible()
+		await expect(canvas.getByText('Who actually pays for the delay')).toBeVisible()
 
 		await userEvent.click(canvas.getByRole('button', { name: 'map' }))
 		await expect(
 			canvas.getByLabelText('Map of Why Cities Stopped Building'),
 		).toBeVisible()
 
+		// A Reference placed at a Section is a box hanging off it, keeping the
+		// number it has in the Plan's list.
+		const cost = canvas
+			.getByRole('button', { name: 'Who actually pays for the delay', exact: true })
+			.closest('foreignObject')!
+		await expect(within(cost as unknown as HTMLElement).getByText('–')).toBeVisible()
+		await expect(canvas.getByText('Zoning and the missing middle')).toBeVisible()
+
 		// Folding is a read affordance, so the Section stays and only what sits
 		// inside it goes.
-		const fold = canvas.getByLabelText('Fold the 2 inside How review became the process')
-		await expect(canvas.getByText('The eleven points')).toBeVisible()
-
-		await userEvent.click(fold)
-		await expect(canvas.queryByText('The eleven points')).toBeNull()
-		await expect(canvas.getByText('How review became the process')).toBeVisible()
-
-		// The control now says how much is folded away, so the box does not read
-		// as a Section with nothing inside it.
-		const open = canvas.getByLabelText('Open the 2 inside How review became the process')
-		await expect(open).toHaveTextContent('2')
-
-		await userEvent.click(open)
-		await expect(canvas.getByText('The eleven points')).toBeVisible()
+		await userEvent.click(
+			canvas.getByLabelText('Fold the 1 inside Who actually pays for the delay'),
+		)
+		await expect(canvas.queryByText('Zoning and the missing middle')).toBeNull()
+		await expect(canvas.getByText('Who actually pays for the delay')).toBeVisible()
+		await userEvent.click(
+			canvas.getByLabelText('Open the 1 inside Who actually pays for the delay'),
+		)
 
 		// Clicking a box opens the Section's own fields over the map, anchored at
 		// the box. The map keeps its shape underneath: nothing reflows around it.
@@ -315,64 +338,113 @@ export const K_PlanMap: Story = {
 			.getByLabelText('Map of Why Cities Stopped Building')
 			.getBoundingClientRect()
 
-		await userEvent.click(canvas.getByRole('button', { name: 'The eleven points' }))
-		const title = canvas.getByLabelText('Title of Subsection 2.1') as HTMLInputElement
-		await expect(title).toHaveValue('The eleven points')
+		await userEvent.click(
+			canvas.getByRole('button', { name: 'The year the cranes stopped', exact: true }),
+		)
+		const title = canvas.getByLabelText('Title of Section 1') as HTMLInputElement
+		await expect(title).toHaveValue('The year the cranes stopped')
 		await expect(
 			canvas.getByLabelText('Map of Why Cities Stopped Building').getBoundingClientRect(),
 		).toEqual(before)
 
-		// It writes through the ops the Panel writes through, so the map redraws
-		// off the Plan rather than off anything the detail holds.
-		await userEvent.clear(title)
-		await userEvent.type(title, 'The eleven review points')
-		await userEvent.click(canvas.getByRole('button', { name: 'done' }))
+		// Escape puts the fields away, which is what `SectionRow` already does for
+		// the Panel.
+		await userEvent.keyboard('{Escape}')
+		await expect(canvas.queryByLabelText('Title of Section 1')).toBeNull()
 
-		await expect(canvas.queryByLabelText('Title of Subsection 2.1')).toBeNull()
-		await expect(canvas.getByText('The eleven review points')).toBeVisible()
-
-		// `+` on a Section makes a Subsection inside it — the nesting the Panel
-		// has no control for — and opens it with the caret in the title.
+		// So does the space between the boxes, which is the one place on the map
+		// that does nothing else on a click.
 		await userEvent.click(
-			canvas.getByLabelText('Add a Section inside What a faster city would look like'),
+			canvas.getByRole('button', { name: 'The year the cranes stopped', exact: true }),
 		)
-		const made = canvas.getByLabelText('Title of Subsection 4.1') as HTMLInputElement
+		// In the document rather than visible: the fields fade in from nothing, so
+		// an assertion this close to the click can land inside the transition.
+		await expect(canvas.getByLabelText('Title of Section 1')).toBeInTheDocument()
+		await userEvent.click(canvas.getByLabelText('Map of Why Cities Stopped Building'))
+		await expect(canvas.queryByLabelText('Title of Section 1')).toBeNull()
+
+		// `+` on the title makes a Section, last in the Outline, open with the
+		// caret in it. A Section takes none: References branch off it here.
+		await expect(
+			canvas.queryByLabelText('Add a Section inside The year the cranes stopped'),
+		).toBeNull()
+
+		await userEvent.click(canvas.getByLabelText('Add a Section to the Outline'))
+		const made = canvas.getByLabelText('Title of Section 5') as HTMLInputElement
 		await expect(made).toHaveValue('')
 		await expect(made).toHaveFocus()
 
-		await userEvent.type(made, 'The permit desk that answers')
-		await userEvent.click(canvas.getByRole('button', { name: 'done' }))
-		await expect(canvas.getByText('The permit desk that answers')).toBeVisible()
+		// Left with nothing in it, it goes again rather than leaving an untitled
+		// box on the map.
+		await userEvent.keyboard('{Escape}')
+		await expect(canvas.queryByLabelText('Title of Section 5')).toBeNull()
+		await expect(canvas.queryByText('Untitled section')).toBeNull()
 
-		// A Subsection carries no `+`: two levels is what the interface offers,
-		// and a third has no word the writer holds — context.md §Subsection.
-		await expect(
-			canvas.queryByLabelText('Add a Section inside The permit desk that answers'),
-		).toBeNull()
-		await expect(canvas.getByLabelText('Add a Section to the Outline')).toBeVisible()
+		// Given a title, it stays.
+		await userEvent.click(canvas.getByLabelText('Add a Section to the Outline'))
+		await userEvent.type(
+			canvas.getByLabelText('Title of Section 5'),
+			'What a faster desk does',
+		)
+		await userEvent.keyboard('{Escape}')
+		await expect(canvas.getByText('What a faster desk does')).toBeVisible()
 
-		// Placing a Reference is in the open Section's fields, not on the box: a
-		// box says which are placed there, and the detail is where that changes.
+		// Placing a Reference is in the open Section's fields, not on the box.
 		await userEvent.click(
-			canvas.getByRole('button', { name: 'The permit desk that answers', exact: true }),
+			canvas.getByRole('button', { name: 'What a faster desk does', exact: true }),
 		)
 		await userEvent.click(canvas.getByRole('button', { name: 'place a reference' }))
 		await userEvent.click(
 			canvas.getByRole('button', { name: /Zoning and the missing middle/ }),
 		)
+		await userEvent.keyboard('{Escape}')
 
-		await userEvent.click(canvas.getByRole('button', { name: 'done' }))
+		// It moved rather than being copied: one Reference sits at one Section, so
+		// the new Section now has one box hanging off it, and the Section it came
+		// from has none.
+		await expect(
+			canvas.getByLabelText('Fold the 1 inside What a faster desk does'),
+		).toBeVisible()
+		await expect(
+			canvas.queryByLabelText('Fold the 1 inside Who actually pays for the delay'),
+		).toBeNull()
+		await expect(canvas.getByText('Zoning and the missing middle')).toBeVisible()
+	},
+}
 
-		// It sits at the Subsection now. `getByText` would throw on a second
-		// match, so this is also the check that placing moved it rather than
-		// copying it: one Reference sits at one Section.
-		const box = canvas
-			.getByRole('button', { name: 'The permit desk that answers', exact: true })
-			.closest('foreignObject')
+export const L_PlanMapRecursive: Story = {
+	name: '2(l) Outline with recursion (idea)',
+	render: () => (
+		<div className="flex flex-col">
+			<PlanMapScreen branches="sections" />
+			<Annotation>
+				An idea, not a screen. Here a Section branches into the Sections inside it rather
+				than into its References, as deep as the writer takes it, and <code>+</code> on
+				any box makes one more. The Plan's schema already holds this — `OutlineNode` is
+				recursive — and the interface offers two levels, because anything deeper wants a
+				word writers already hold, like Chapter, rather than a more recursive one. 2(k) is
+				what we are building. Each Section says which References sit at it, since nothing
+				here draws them.
+			</Annotation>
+		</div>
+	),
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+
+		// The whole point of the idea: a Section takes a Section inside it, and
+		// the one it makes takes another.
+		await userEvent.click(
+			canvas.getByLabelText('Add a Section inside What a faster city would look like'),
+		)
+		const made = canvas.getByLabelText('Title of Subsection 4.1') as HTMLInputElement
+		await userEvent.type(made, 'The permit desk that answers')
+		await userEvent.keyboard('{Escape}')
 
 		await expect(
-			within(box as unknown as HTMLElement).getByText('refs [2]'),
+			canvas.getByLabelText('Add a Section inside The permit desk that answers'),
 		).toBeVisible()
-		await expect(canvas.getByText('refs [2]')).toBeVisible()
+
+		// Nothing draws a Reference here, so a Section says which sit at it.
+		await expect(canvas.getByText('refs [1] [3]')).toBeVisible()
 	},
 }

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -278,6 +278,17 @@ export const K_PlanMap: Story = {
 	play: async ({ canvasElement }) => {
 		const canvas = within(canvasElement)
 
+		// Both Views read one Plan, so a Section the map draws is one the list
+		// has too. The rail is how the writer gets between them.
+		await userEvent.click(canvas.getByRole('button', { name: 'list' }))
+		await expect(canvas.queryByLabelText(/^Map of /)).toBeNull()
+		await expect(canvas.getByText('One objection resets the clock')).toBeVisible()
+
+		await userEvent.click(canvas.getByRole('button', { name: 'map' }))
+		await expect(
+			canvas.getByLabelText('Map of Why Cities Stopped Building'),
+		).toBeVisible()
+
 		// Folding is a read affordance, so the Section stays and only what sits
 		// inside it goes.
 		const fold = canvas.getByLabelText('Fold the 2 inside How review became the process')

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -267,11 +267,14 @@ export const K_PlanMap: Story = {
 		<div className="flex flex-col">
 			<PlanMapScreen />
 			<Annotation>
-				A second View of the same Outline, opened left to right. It reads the Plan and
-				never writes it, so folding a Section here hides its Subsections on the map and
-				leaves the Plan alone — the Panel beside it still lists every one. The curve is
-				the cubic a mind map is drawn with: out of the parent's right edge, into the
-				child's left edge, turning halfway between the columns.
+				A second View of the same Outline, opened left to right. The right edge of a box
+				holds what it says about its children: fold what is already inside, and{' '}
+				<code>+</code> one more. On the title that makes a Section, and on a Section it
+				makes a Subsection — the nesting the Panel has no control for, because a map draws
+				nesting and a list does not. Folding is a read and changes nothing in the Plan;
+				everything else writes through the ops the Panel writes through. Clicking a box
+				opens its fields over the map, and placing a Reference is in there rather than on
+				the box, which only says which are placed.
 			</Annotation>
 		</div>
 	),
@@ -327,5 +330,49 @@ export const K_PlanMap: Story = {
 
 		await expect(canvas.queryByLabelText('Title of Subsection 2.1')).toBeNull()
 		await expect(canvas.getByText('The eleven review points')).toBeVisible()
+
+		// `+` on a Section makes a Subsection inside it — the nesting the Panel
+		// has no control for — and opens it with the caret in the title.
+		await userEvent.click(
+			canvas.getByLabelText('Add a Section inside What a faster city would look like'),
+		)
+		const made = canvas.getByLabelText('Title of Subsection 4.1') as HTMLInputElement
+		await expect(made).toHaveValue('')
+		await expect(made).toHaveFocus()
+
+		await userEvent.type(made, 'The permit desk that answers')
+		await userEvent.click(canvas.getByRole('button', { name: 'done' }))
+		await expect(canvas.getByText('The permit desk that answers')).toBeVisible()
+
+		// A Subsection carries no `+`: two levels is what the interface offers,
+		// and a third has no word the writer holds — context.md §Subsection.
+		await expect(
+			canvas.queryByLabelText('Add a Section inside The permit desk that answers'),
+		).toBeNull()
+		await expect(canvas.getByLabelText('Add a Section to the Outline')).toBeVisible()
+
+		// Placing a Reference is in the open Section's fields, not on the box: a
+		// box says which are placed there, and the detail is where that changes.
+		await userEvent.click(
+			canvas.getByRole('button', { name: 'The permit desk that answers', exact: true }),
+		)
+		await userEvent.click(canvas.getByRole('button', { name: 'place a reference' }))
+		await userEvent.click(
+			canvas.getByRole('button', { name: /Zoning and the missing middle/ }),
+		)
+
+		await userEvent.click(canvas.getByRole('button', { name: 'done' }))
+
+		// It sits at the Subsection now. `getByText` would throw on a second
+		// match, so this is also the check that placing moved it rather than
+		// copying it: one Reference sits at one Section.
+		const box = canvas
+			.getByRole('button', { name: 'The permit desk that answers', exact: true })
+			.closest('foreignObject')
+
+		await expect(
+			within(box as unknown as HTMLElement).getByText('refs [2]'),
+		).toBeVisible()
+		await expect(canvas.getByText('refs [2]')).toBeVisible()
 	},
 }

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -6,7 +6,8 @@ import { Frame, FrameBody } from '../../../src/client/components/Frame'
 import { Panel, PanelHeader } from '../../../src/client/components/Panel'
 import { cx } from '../../../src/client/lib/cx'
 import { PlanMap } from '../../../src/client/plan/PlanMap'
-import type { OutlineNode, Plan } from '../../../src/shared/plan'
+import type { OutlineNode, Plan, ProposalInput } from '../../../src/shared/plan'
+import { applyProposal } from '../../../src/shared/plan'
 import { plan } from '../../mock/content'
 import { PlanOutline } from './PlanBlocks'
 
@@ -103,11 +104,24 @@ function ViewRail({ view, onView }: { view: View; onView: (view: View) => void }
 
 export function PlanMapScreen() {
 	const [view, setView] = useState<View>('map')
+	// The applier behind the map, the way `EditablePlan` puts it behind the
+	// Panel: every edit runs the ops the app runs, so a refusal shows up here the
+	// way the writer would meet it.
+	const [edited, setEdited] = useState<Plan>(mapped)
+
+	const edit = (ops: ProposalInput | null) => {
+		if (ops === null) return
+
+		const result = applyProposal(edited, ops)
+		if (result.ok) setEdited(result.plan)
+	}
 
 	return (
 		<Frame width={860}>
 			<ArticleBar title={plan.title} open={['plan']} status="draft 1" />
-			<FrameBody className="h-[26rem]">
+			{/* Taller than the other Plan screens: the map is wider than a list and
+			    an open Section's fields run below the box they open from. */}
+			<FrameBody className="h-[32rem]">
 				<Panel className="gap-3.5" variant="sunk">
 					<PanelHeader
 						title="Outline"
@@ -120,14 +134,14 @@ export function PlanMapScreen() {
 					/>
 
 					{view === 'map' ? (
-						<PlanMap plan={mapped} />
+						<PlanMap edit={edit} plan={edited} />
 					) : (
-						<PlanOutline className="max-w-md" outline={mapped.outline} />
+						<PlanOutline className="max-w-md" outline={edited.outline} />
 					)}
 
 					<p className="text-[0.6875rem] text-faint">
 						{view === 'map'
-							? 'Hover a Section to light its path back to the title. The control on a box folds what sits inside it — on this map only, and never in the Plan.'
+							? 'Click a Section to open its fields over the map. Hover one to light its path back to the title, and use the control on a box to fold what sits inside it — on this map only, and never in the Plan.'
 							: 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'}
 					</p>
 				</Panel>

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -141,7 +141,7 @@ export function PlanMapScreen() {
 
 					<p className="text-[0.6875rem] text-faint">
 						{view === 'map'
-							? 'Click a Section to open its fields over the map. Hover one to light its path back to the title, and use the control on a box to fold what sits inside it — on this map only, and never in the Plan.'
+							? 'Click a Section to open its fields over the map, and + to make one inside it. Hover a Section to light its path back to the title, and fold what sits inside it — on this map only, and never in the Plan.'
 							: 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'}
 					</p>
 				</Panel>

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -1,0 +1,80 @@
+import { ArticleBar } from '../../../src/client/components/ArticleBar'
+import { Chip } from '../../../src/client/components/Chip'
+import { Frame, FrameBody } from '../../../src/client/components/Frame'
+import { Panel, PanelHeader } from '../../../src/client/components/Panel'
+import { PlanMap } from '../../../src/client/plan/PlanMap'
+import type { OutlineNode, Plan } from '../../../src/shared/plan'
+import { plan } from '../../mock/content'
+
+/**
+ * 2(k) — The Plan Panel's Map View. The same Outline the Panel lists, opened
+ * left to right from the Article title.
+ *
+ * The mock Plan is flat, and a map of a flat list is a comb. Two Sections are
+ * given Subsections here so the screen shows what the View is for: where the
+ * piece branches, and how deep it goes.
+ */
+
+function nest(id: string, children: OutlineNode[]): (node: OutlineNode) => OutlineNode {
+	return (node) => (node.id === id ? { ...node, children } : node)
+}
+
+const mapped: Plan = {
+	...plan,
+	outline: plan.outline
+		.map(
+			nest('sec-review', [
+				{
+					id: 'sec-review-points',
+					title: 'The eleven points',
+					target: 400,
+					children: [],
+				},
+				{
+					id: 'sec-review-clock',
+					title: 'One objection resets the clock',
+					intent: 'The Hartley case, start to finish.',
+					target: 300,
+					children: [],
+				},
+			]),
+		)
+		.map(
+			nest('sec-cost', [
+				{
+					id: 'sec-cost-record',
+					title: 'The ones who would not go on record',
+					target: 500,
+					children: [],
+				},
+				{
+					id: 'sec-cost-rent',
+					title: 'What the delay costs in rent',
+					target: 400,
+					children: [],
+				},
+			]),
+		),
+}
+
+export function PlanMapScreen() {
+	return (
+		<Frame width={860}>
+			<ArticleBar title={plan.title} open={['plan']} status="draft 1" />
+			<FrameBody className="h-[26rem]">
+				<Panel className="gap-3.5" variant="sunk">
+					<PanelHeader
+						title="Outline"
+						meta="map"
+						actions={<Chip variant="outline">2,400 words target</Chip>}
+					/>
+					<PlanMap plan={mapped} />
+					<p className="text-[0.6875rem] text-faint">
+						Hover a Section to light its path back to the title. The control on a box
+						folds what sits inside it — on this map only, and never in the Plan.
+					</p>
+				</Panel>
+			</FrameBody>
+		</Frame>
+	)
+}

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -1,10 +1,14 @@
+import { useState } from 'react'
+
 import { ArticleBar } from '../../../src/client/components/ArticleBar'
 import { Chip } from '../../../src/client/components/Chip'
 import { Frame, FrameBody } from '../../../src/client/components/Frame'
 import { Panel, PanelHeader } from '../../../src/client/components/Panel'
+import { cx } from '../../../src/client/lib/cx'
 import { PlanMap } from '../../../src/client/plan/PlanMap'
 import type { OutlineNode, Plan } from '../../../src/shared/plan'
 import { plan } from '../../mock/content'
+import { PlanOutline } from './PlanBlocks'
 
 /**
  * 2(k) — The Plan Panel's Map View. The same Outline the Panel lists, opened
@@ -57,7 +61,49 @@ const mapped: Plan = {
 		),
 }
 
+const VIEWS = ['list', 'map'] as const
+type View = (typeof VIEWS)[number]
+
+/**
+ * The switch between the Plan Panel's two Views, built like the Panel rail in
+ * the bar above it: the one you are in is solid ink, and neither is accented,
+ * because which View you are in is state rather than a decision the screen
+ * wants from you — `foundations/Accent.mdx`.
+ *
+ * It sits here rather than in `src/client/plan/` because the Map View is not
+ * wired into the app yet. Wiring it means giving `PlanPanel` a header row to
+ * hold this, which it has none of today.
+ */
+function ViewRail({ view, onView }: { view: View; onView: (view: View) => void }) {
+	return (
+		<div
+			aria-label="How the Outline is shown"
+			className="flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5"
+			role="group"
+		>
+			{VIEWS.map((one) => (
+				<button
+					key={one}
+					aria-pressed={one === view}
+					className={cx(
+						'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
+						one === view
+							? 'bg-ink text-paper'
+							: 'text-faint hover:bg-hush hover:text-muted',
+					)}
+					onClick={() => onView(one)}
+					type="button"
+				>
+					{one}
+				</button>
+			))}
+		</div>
+	)
+}
+
 export function PlanMapScreen() {
+	const [view, setView] = useState<View>('map')
+
 	return (
 		<Frame width={860}>
 			<ArticleBar title={plan.title} open={['plan']} status="draft 1" />
@@ -65,13 +111,24 @@ export function PlanMapScreen() {
 				<Panel className="gap-3.5" variant="sunk">
 					<PanelHeader
 						title="Outline"
-						meta="map"
-						actions={<Chip variant="outline">2,400 words target</Chip>}
+						actions={
+							<>
+								<Chip variant="outline">2,400 words target</Chip>
+								<ViewRail onView={setView} view={view} />
+							</>
+						}
 					/>
-					<PlanMap plan={mapped} />
+
+					{view === 'map' ? (
+						<PlanMap plan={mapped} />
+					) : (
+						<PlanOutline className="max-w-md" outline={mapped.outline} />
+					)}
+
 					<p className="text-[0.6875rem] text-faint">
-						Hover a Section to light its path back to the title. The control on a box
-						folds what sits inside it — on this map only, and never in the Plan.
+						{view === 'map'
+							? 'Hover a Section to light its path back to the title. The control on a box folds what sits inside it — on this map only, and never in the Plan.'
+							: 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'}
 					</p>
 				</Panel>
 			</FrameBody>

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -4,27 +4,31 @@ import { ArticleBar } from '../../../src/client/components/ArticleBar'
 import { Chip } from '../../../src/client/components/Chip'
 import { Frame, FrameBody } from '../../../src/client/components/Frame'
 import { Panel, PanelHeader } from '../../../src/client/components/Panel'
-import { cx } from '../../../src/client/lib/cx'
+import type { MapBranches } from '../../../src/client/plan/map'
 import { PlanMap } from '../../../src/client/plan/PlanMap'
+import type { OutlineView } from '../../../src/client/plan/ViewRail'
+import { ViewRail } from '../../../src/client/plan/ViewRail'
 import type { OutlineNode, Plan, ProposalInput } from '../../../src/shared/plan'
 import { applyProposal } from '../../../src/shared/plan'
 import { plan } from '../../mock/content'
 import { PlanOutline } from './PlanBlocks'
 
 /**
- * 2(k) — The Plan Panel's Map View. The same Outline the Panel lists, opened
- * left to right from the Article title.
+ * 2(k) and 2(l) — the Plan Panel's Map View, in its two shapes.
  *
- * The mock Plan is flat, and a map of a flat list is a comb. Two Sections are
- * given Subsections here so the screen shows what the View is for: where the
- * piece branches, and how deep it goes.
+ * 2(k) is the Plan the interface offers: the Article title, one layer of
+ * Sections, and the References placed at each. 2(l) nests Sections inside
+ * Sections instead, which the schema allows and no screen offers — it is here
+ * as an idea, and `context.md` §Subsection is why it is not the other one.
  */
 
 function nest(id: string, children: OutlineNode[]): (node: OutlineNode) => OutlineNode {
 	return (node) => (node.id === id ? { ...node, children } : node)
 }
 
-const mapped: Plan = {
+/** The mock Plan with two Sections given Subsections, for the idea screen. A
+ * map of a flat list is a comb, and the point of that screen is the branching. */
+const recursive: Plan = {
 	...plan,
 	outline: plan.outline
 		.map(
@@ -62,52 +66,17 @@ const mapped: Plan = {
 		),
 }
 
-const VIEWS = ['list', 'map'] as const
-type View = (typeof VIEWS)[number]
-
-/**
- * The switch between the Plan Panel's two Views, built like the Panel rail in
- * the bar above it: the one you are in is solid ink, and neither is accented,
- * because which View you are in is state rather than a decision the screen
- * wants from you — `foundations/Accent.mdx`.
- *
- * It sits here rather than in `src/client/plan/` because the Map View is not
- * wired into the app yet. Wiring it means giving `PlanPanel` a header row to
- * hold this, which it has none of today.
- */
-function ViewRail({ view, onView }: { view: View; onView: (view: View) => void }) {
-	return (
-		<div
-			aria-label="How the Outline is shown"
-			className="flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5"
-			role="group"
-		>
-			{VIEWS.map((one) => (
-				<button
-					key={one}
-					aria-pressed={one === view}
-					className={cx(
-						'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
-						one === view
-							? 'bg-ink text-paper'
-							: 'text-faint hover:bg-hush hover:text-muted',
-					)}
-					onClick={() => onView(one)}
-					type="button"
-				>
-					{one}
-				</button>
-			))}
-		</div>
-	)
+export interface PlanMapScreenProps {
+	/** What branches off a Section — `src/client/plan/map.ts`. */
+	branches?: MapBranches
 }
 
-export function PlanMapScreen() {
-	const [view, setView] = useState<View>('map')
+export function PlanMapScreen({ branches = 'references' }: PlanMapScreenProps) {
+	const [view, setView] = useState<OutlineView>('map')
 	// The applier behind the map, the way `EditablePlan` puts it behind the
 	// Panel: every edit runs the ops the app runs, so a refusal shows up here the
 	// way the writer would meet it.
-	const [edited, setEdited] = useState<Plan>(mapped)
+	const [edited, setEdited] = useState<Plan>(branches === 'sections' ? recursive : plan)
 
 	const edit = (ops: ProposalInput | null) => {
 		if (ops === null) return
@@ -134,15 +103,17 @@ export function PlanMapScreen() {
 					/>
 
 					{view === 'map' ? (
-						<PlanMap edit={edit} plan={edited} />
+						<PlanMap branches={branches} edit={edit} plan={edited} />
 					) : (
 						<PlanOutline className="max-w-md" outline={edited.outline} />
 					)}
 
 					<p className="text-[0.6875rem] text-faint">
-						{view === 'map'
-							? 'Click a Section to open its fields over the map, and + to make one inside it. Hover a Section to light its path back to the title, and fold what sits inside it — on this map only, and never in the Plan.'
-							: 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'}
+						{view === 'list'
+							? 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'
+							: branches === 'sections'
+								? 'An idea, not a screen: a Section holds Sections, as deep as you take it. + on any box makes one inside it.'
+								: 'Click a Section to open its fields, and + on the title to make one. Escape or a click on the space between boxes puts the fields away.'}
 					</p>
 				</Panel>
 			</FrameBody>

--- a/context.md
+++ b/context.md
@@ -11,7 +11,8 @@ A top-level destination. There are three: Articles, House, and Team.
 _Avoid_: section, page, tab, workspace
 
 **View**:
-One way of looking at an Area. The Articles Area has a Board View and an Archive View.
+One way of looking at an Area or a Panel. The Articles Area has a Board View and an
+Archive View; the Chat Panel has the Offer ledger.
 _Avoid_: mode (a Mode is Plan or Write), screen, filter
 
 **Team**:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,15 +4,9 @@ What is true now. The reasoning behind each decision lives in the wayfinding map
 and its closed tickets; this document does not repeat it. Vocabulary is fixed in
 [`context.md`](../context.md) and governs the code, the UI, and this file.
 
-**What belongs here is a decision that binds more than one module.** Where writes go, what
-the Plan holds, who may write it, what the Panels are. A claim you can change by editing one
-file is not architecture: it belongs in that file, next to the code that would have to
-change with it. Put it here and it goes stale the first time someone edits that file, and
-the next reader has to run the code to find out which of the two is current.
-
-That rules out how a control behaves, what a screen does on a click, and which component
-holds which piece of local state. Those are real decisions and they are written down — in
-the component's own doc comment, and in the Storybook screen that shows them.
+**What belongs here is a decision that binds more than one module.** A claim you can change
+by editing one file is not architecture: it belongs in that file, next to the code that
+would have to change with it.
 
 The product: **the writer writes the prose and an AI acts as a guide.** Nothing here has the
 model producing prose for the Draft.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,16 @@ What is true now. The reasoning behind each decision lives in the wayfinding map
 and its closed tickets; this document does not repeat it. Vocabulary is fixed in
 [`context.md`](../context.md) and governs the code, the UI, and this file.
 
+**What belongs here is a decision that binds more than one module.** Where writes go, what
+the Plan holds, who may write it, what the Panels are. A claim you can change by editing one
+file is not architecture: it belongs in that file, next to the code that would have to
+change with it. Put it here and it goes stale the first time someone edits that file, and
+the next reader has to run the code to find out which of the two is current.
+
+That rules out how a control behaves, what a screen does on a click, and which component
+holds which piece of local state. Those are real decisions and they are written down — in
+the component's own doc comment, and in the Storybook screen that shows them.
+
 The product: **the writer writes the prose and an AI acts as a guide.** Nothing here has the
 model producing prose for the Draft.
 
@@ -482,18 +492,10 @@ and a structural edit gets the consequences the ops already state — deleting a
 unplaces its References. The writer's own edits never go Stale: staleness is the gap
 between generating a Proposal and applying it, and there is no gap here.
 
-**The Outline has two Views: the list and the map.** `src/client/plan/ViewRail.tsx` sits
-in the Outline heading and switches between them, and `PlanPanel` holds which is up —
-it is a way of looking, and the Article carries no memory of it. `src/client/plan/map.ts`
-places every box and curve off the Plan, `PlanMap.tsx` draws them, and both Views write
-through the ops above, so neither can make a change the other could not. The map draws
-the Article title, its Sections, and the References placed at each; a Section carrying
-none is a leaf. Clicking a Section opens `SectionRow` over the map rather than in it, so
-nothing reflows around what the writer is editing.
-
-Two things the map holds that the list does not, both because they are ways of looking
-rather than facts about the Plan: which Sections are folded, and which box the pointer is
-on. Each View also holds its own open Section, so switching View closes what was open.
+**The Outline has two Views, and both write the same way.** The list of Sections and the
+map (`src/client/plan/map.ts`, `PlanMap.tsx`) build ops and hand them to the same `edit`,
+so neither can make a change the other could not. Which View is up is a way of looking:
+`PlanPanel` holds it, and the Article carries no memory of it.
 
 **One writer holds the Plan and the debounce**, in `src/client/plan/writer.ts`. It applies
 each edit locally, sends after a pause for the four ops a keystroke produces, and sends at

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -480,6 +480,19 @@ and a structural edit gets the consequences the ops already state — deleting a
 unplaces its References. The writer's own edits never go Stale: staleness is the gap
 between generating a Proposal and applying it, and there is no gap here.
 
+**The Outline has two Views: the list and the map.** `src/client/plan/ViewRail.tsx` sits
+in the Outline heading and switches between them, and `PlanPanel` holds which is up —
+it is a way of looking, and the Article carries no memory of it. `src/client/plan/map.ts`
+places every box and curve off the Plan, `PlanMap.tsx` draws them, and both Views write
+through the ops above, so neither can make a change the other could not. The map draws
+the Article title, its Sections, and the References placed at each; a Section carrying
+none is a leaf. Clicking a Section opens `SectionRow` over the map rather than in it, so
+nothing reflows around what the writer is editing.
+
+Two things the map holds that the list does not, both because they are ways of looking
+rather than facts about the Plan: which Sections are folded, and which box the pointer is
+on. Each View also holds its own open Section, so switching View closes what was open.
+
 **One writer holds the Plan and the debounce**, in `src/client/plan/writer.ts`. It applies
 each edit locally, sends after a pause for the four ops a keystroke produces, and sends at
 once for everything else. An update arriving from the Article Agent over an unsent edit is

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode } from 'react'
+import type { ButtonHTMLAttributes, ReactNode, Ref } from 'react'
 
 import { cx } from '../lib/cx'
 
@@ -9,6 +9,9 @@ export interface ButtonProps extends Omit<
 	ButtonHTMLAttributes<HTMLButtonElement>,
 	'children'
 > {
+	/** The button itself, for a control that has to take the caret back after
+	 * whatever it opened has gone. `Panel` takes one the same way. */
+	ref?: Ref<HTMLButtonElement>
 	/**
 	 * `accent` is the yellow one. A screen should have at most one — it marks
 	 * the single thing the app wants you to do next.

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -1,4 +1,4 @@
-import type { ButtonHTMLAttributes, ReactNode, Ref } from 'react'
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
 
 import { cx } from '../lib/cx'
 
@@ -9,9 +9,6 @@ export interface ButtonProps extends Omit<
 	ButtonHTMLAttributes<HTMLButtonElement>,
 	'children'
 > {
-	/** The button itself, for a control that has to take the caret back after
-	 * whatever it opened has gone. `Panel` takes one the same way. */
-	ref?: Ref<HTMLButtonElement>
 	/**
 	 * `accent` is the yellow one. A screen should have at most one — it marks
 	 * the single thing the app wants you to do next.

--- a/src/client/components/Divider.tsx
+++ b/src/client/components/Divider.tsx
@@ -22,6 +22,9 @@ export interface GroupHeadingProps {
 	children: React.ReactNode
 	/** "24", "9 · 3 used" — sits after the label, always quiet. */
 	count?: React.ReactNode
+	/** Controls for the group, after the rule rather than before it, so the
+	 * label and its count stay together on the left. */
+	actions?: React.ReactNode
 	className?: string
 }
 
@@ -29,7 +32,7 @@ export interface GroupHeadingProps {
  * A run-on heading: label, count, then a hairline eating the remaining width.
  * Used for every list in the Articles Area and in the Plan.
  */
-export function GroupHeading({ children, count, className }: GroupHeadingProps) {
+export function GroupHeading({ children, count, actions, className }: GroupHeadingProps) {
 	return (
 		<div className={cx('flex items-center gap-2.5', className)}>
 			<span className="label-meta shrink-0">
@@ -37,6 +40,7 @@ export function GroupHeading({ children, count, className }: GroupHeadingProps) 
 				{count !== undefined ? <span> · {count}</span> : null}
 			</span>
 			<span className="h-px min-w-4 flex-1 bg-rule" />
+			{actions === undefined ? null : <div className="shrink-0">{actions}</div>}
 		</div>
 	)
 }

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -198,24 +198,17 @@ export function EmptySlot({ children, className }: EmptySlotProps) {
 }
 
 export interface FieldRowProps {
-	/** The word in the gutter: "Voice", "Adjectives", "References". */
 	label: ReactNode
 	children: ReactNode
 	className?: string
 }
 
 /**
- * One labelled row of a Section's minor fields: the word in a fixed gutter, the
- * control after it.
+ * A row with the label in a fixed left gutter and the children to the right of
+ * it. Used for Voice, Adjectives, and the References line.
  *
- * Each row is its own grid rather than all of them sharing one, which they can
- * be because the gutter is a fixed width — so rows written in different
- * components still line up, and a row can be added anywhere without threading
- * it through whoever owns the grid.
- *
- * **The label sits at the top, not the middle.** A row whose control wraps —
- * Adjectives, once there are a few — grows downwards, and a centred label would
- * drift down the gutter with it.
+ * The gutter is a fixed width, so separate FieldRows line up without sharing a
+ * grid. Children that wrap grow downwards; the label stays at the top.
  */
 export function FieldRow({ label, children, className }: FieldRowProps) {
 	return (

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -212,16 +212,17 @@ export interface FieldRowProps {
  * be because the gutter is a fixed width — so rows written in different
  * components still line up, and a row can be added anywhere without threading
  * it through whoever owns the grid.
+ *
+ * **The label sits at the top, not the middle.** A row whose control wraps —
+ * Adjectives, once there are a few — grows downwards, and a centred label would
+ * drift down the gutter with it.
  */
 export function FieldRow({ label, children, className }: FieldRowProps) {
 	return (
 		<div
-			className={cx(
-				'grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-x-2',
-				className,
-			)}
+			className={cx('grid grid-cols-[5rem_minmax(0,1fr)] items-start gap-x-2', className)}
 		>
-			<span className="label-meta text-muted">{label}</span>
+			<span className="label-meta pt-1 text-muted">{label}</span>
 			<div className="min-w-0">{children}</div>
 		</div>
 	)

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -196,3 +196,33 @@ export function EmptySlot({ children, className }: EmptySlotProps) {
 		</div>
 	)
 }
+
+export interface FieldRowProps {
+	/** The word in the gutter: "Voice", "Adjectives", "References". */
+	label: ReactNode
+	children: ReactNode
+	className?: string
+}
+
+/**
+ * One labelled row of a Section's minor fields: the word in a fixed gutter, the
+ * control after it.
+ *
+ * Each row is its own grid rather than all of them sharing one, which they can
+ * be because the gutter is a fixed width — so rows written in different
+ * components still line up, and a row can be added anywhere without threading
+ * it through whoever owns the grid.
+ */
+export function FieldRow({ label, children, className }: FieldRowProps) {
+	return (
+		<div
+			className={cx(
+				'grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-x-2',
+				className,
+			)}
+		>
+			<span className="label-meta text-muted">{label}</span>
+			<div className="min-w-0">{children}</div>
+		</div>
+	)
+}

--- a/src/client/components/PanelRail.tsx
+++ b/src/client/components/PanelRail.tsx
@@ -1,4 +1,4 @@
-import { cx } from '../lib/cx'
+import { Rail } from './Rail'
 
 export const PANELS = ['chat', 'plan', 'draft', 'notes'] as const
 export type PanelId = (typeof PANELS)[number]
@@ -11,46 +11,15 @@ export interface PanelRailProps {
 	className?: string
 }
 
-/**
- * The four-Panel toggle: chat · plan · draft · notes.
- *
- * Deliberately *not* accented. Which Panels are open is state, not a call to
- * action, so the active pill is solid ink and the yellow stays free for the
- * one thing on screen that actually wants a decision.
- */
+/** The four-Panel toggle: chat · plan · draft · notes. */
 export function PanelRail({ open, onToggle, className }: PanelRailProps) {
 	return (
-		<div
-			className={cx(
-				'flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5',
-				className,
-			)}
-			role={onToggle ? 'group' : undefined}
-			aria-label={onToggle ? 'Visible Panels' : undefined}
-		>
-			{PANELS.map((Panel) => {
-				const isOpen = open.includes(Panel)
-				const Tag = (onToggle ? 'button' : 'span') as 'button'
-				return (
-					<Tag
-						key={Panel}
-						{...(onToggle
-							? {
-									type: 'button' as const,
-									onClick: () => onToggle(Panel),
-									'aria-pressed': isOpen,
-								}
-							: {})}
-						className={cx(
-							'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
-							isOpen ? 'bg-ink text-paper' : 'text-faint',
-							onToggle && !isOpen && 'hover:bg-hush hover:text-muted',
-						)}
-					>
-						{Panel}
-					</Tag>
-				)
-			})}
-		</div>
+		<Rail
+			className={className}
+			items={PANELS}
+			label="Visible Panels"
+			on={open}
+			onPick={onToggle}
+		/>
 	)
 }

--- a/src/client/components/Rail.tsx
+++ b/src/client/components/Rail.tsx
@@ -1,0 +1,68 @@
+import { cx } from '../lib/cx'
+
+/**
+ * A row of pills where one or more are on: the Panel rail in the Article bar,
+ * and the View rail on the Plan Panel's Outline heading.
+ *
+ * **Deliberately not accented.** What is on is state, not a call to action, so
+ * the on pill is solid ink and the yellow stays free for the one thing on
+ * screen that wants a decision — `foundations/Accent.mdx`.
+ *
+ * Static without `onPick`, which is how a rail reads when it is showing what is
+ * open rather than offering to change it.
+ */
+
+export interface RailProps<Item extends string> {
+	items: readonly Item[]
+	/** Which items are on. One for a View rail, several for the Panel rail. */
+	on: readonly Item[]
+	/** Omit to render the rail as a static indicator. */
+	onPick?: (item: Item) => void
+	/** Names the set for a screen reader: "Visible Panels". */
+	label: string
+	className?: string
+}
+
+export function Rail<Item extends string>({
+	items,
+	on,
+	onPick,
+	label,
+	className,
+}: RailProps<Item>) {
+	return (
+		<div
+			aria-label={onPick ? label : undefined}
+			className={cx(
+				'flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5',
+				className,
+			)}
+			role={onPick ? 'group' : undefined}
+		>
+			{items.map((item) => {
+				const isOn = on.includes(item)
+				const Tag = (onPick ? 'button' : 'span') as 'button'
+
+				return (
+					<Tag
+						key={item}
+						{...(onPick
+							? {
+									type: 'button' as const,
+									onClick: () => onPick(item),
+									'aria-pressed': isOn,
+								}
+							: {})}
+						className={cx(
+							'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
+							isOn ? 'bg-ink text-paper' : 'text-faint',
+							onPick && !isOn && 'hover:bg-hush hover:text-muted',
+						)}
+					>
+						{item}
+					</Tag>
+				)
+			})}
+		</div>
+	)
+}

--- a/src/client/components/Rail.tsx
+++ b/src/client/components/Rail.tsx
@@ -1,20 +1,14 @@
 import { cx } from '../lib/cx'
 
 /**
- * A row of pills where one or more are on: the Panel rail in the Article bar,
- * and the View rail on the Plan Panel's Outline heading.
+ * A row of pills, one or more of them on. Used for the Panel rail in the
+ * Article bar and the View rail on the Plan Panel's Outline heading.
  *
- * **Deliberately not accented.** What is on is state, not a call to action, so
- * the on pill takes green and the accent stays free for the one thing on screen
- * that actually wants a decision — `foundations/Accent.mdx`.
- *
- * Static without `onPick`, which is how a rail reads when it is showing what is
- * open rather than offering to change it.
+ * Renders spans instead of buttons when `onPick` is absent.
  */
 
 export interface RailProps<Item extends string> {
 	items: readonly Item[]
-	/** Which items are on. One for a View rail, several for the Panel rail. */
 	on: readonly Item[]
 	/** Omit to render the rail as a static indicator. */
 	onPick?: (item: Item) => void

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -159,6 +159,17 @@ function Box({ node, lit, folded, onFold, onLight, onLeave }: BoxProps) {
 						)}
 					</span>
 				)}
+
+				{/* The References placed here, by the numbers the Panel marks them
+				    with — a footnote number rather than anything stored. */}
+				{node.referenceNumbers.length === 0 ? null : (
+					<span className="flex min-w-0 items-baseline gap-1 font-mono text-[0.625rem] text-faint">
+						<span className="shrink-0">refs</span>
+						{node.referenceNumbers.map((number) => (
+							<span key={number}>[{number}]</span>
+						))}
+					</span>
+				)}
 			</div>
 
 			{node.childCount === 0 || onFold === undefined ? null : (

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -1,30 +1,49 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
-import type { Plan } from '../../shared/plan'
+import type { Plan, ProposalInput } from '../../shared/plan'
 import { cx } from '../lib/cx'
 import type { MapNode, MapOptions } from './map'
 import { planMap } from './map'
+import { outlineEntries } from './outline'
+import { SectionRow } from './SectionRow'
 
 /**
  * The Map View of the Plan — the Outline opened left to right, with the Article
  * title as the root and the Sections branching off it.
  *
- * **It reads the Plan and never writes it.** Collapsing a Section hides its
- * children on this map and changes nothing in the Plan, so the writer can fold
- * a long piece down to its shape without editing it. `PlanPanel.tsx` is where
- * the Outline is edited, and its ops are the only way a Plan changes —
- * `docs/architecture.md` §"The Plan Panel's edits are ops".
- *
  * `map.ts` holds every number on screen. This file draws them and computes
  * none, so what a test measures and what the writer sees cannot drift apart.
+ *
+ * **Reading and writing are separate here.** Folding a Section hides its
+ * children on this map and changes nothing in the Plan — that state belongs to
+ * the View. Editing goes the one way every Plan surface goes: `SectionRow`
+ * builds ops and `edit` applies them, so the map cannot make a change the
+ * applier would refuse — `docs/architecture.md` §"The Plan Panel's edits are
+ * ops".
+ *
+ * **The detail sits over the map rather than in it.** Clicking a box opens the
+ * Section's fields anchored at that box, painted above its neighbours without
+ * joining the layout. Growing the box in place would reflow the whole map —
+ * parents recentre and siblings move — so the writer would lose the shape they
+ * clicked into. A dialog keeps the map still but throws away where they were.
+ *
+ * The map draws at its own size and scrolls sideways rather than shrinking to
+ * fit. Scaling it down would put the detail's pixels out of register with the
+ * boxes, and would make a wide Outline unreadable anyway.
  *
  * The one colour decision: the path back to the root lights in ink rather than
  * accent, because a hover is transient and the accent is rationed to one thing
  * per screen — `foundations/Accent.mdx`.
  */
 
+/** How wide the detail sits. Room for the two fields `SectionRow` puts on one
+ * line, which a box's own width has none of. */
+const DETAIL_WIDTH = 380
+
 export interface PlanMapProps {
 	plan: Plan
+	/** The Plan's one writer, taken as the Panel takes it. */
+	edit: (ops: ProposalInput | null) => void
 	/** Room around the drawing, so a lit box's border is not clipped. */
 	padding?: number
 	/** Passed through to the layout — column widths, gaps, box heights. */
@@ -32,21 +51,36 @@ export interface PlanMapProps {
 	className?: string
 }
 
-export function PlanMap({ plan, padding = 12, layout, className }: PlanMapProps) {
-	// Which Sections are folded, and which box the pointer or the caret is on.
-	// Both belong to this View: neither is in the Plan, and reopening the Panel
-	// starts the map unfolded.
+export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMapProps) {
+	// Which Sections are folded, which box the pointer or the caret is on, and
+	// which one is open. All three belong to this View: none is in the Plan, and
+	// reopening the Panel starts the map unfolded and shut.
 	const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
 	const [lit, setLit] = useState<string | null>(null)
+	const [openId, setOpenId] = useState<string | null>(null)
+	// What the open detail measured, so the scroll area reaches its foot. Read
+	// off the element rather than guessed: how tall the fields run depends on
+	// what the Section carries, and it changes under the writer as they type an
+	// intent note long enough to wrap.
+	const [detailHeight, setDetailHeight] = useState(0)
+
+	// Held, so React attaches it once rather than re-running it every render.
+	const measure = useCallback((element: HTMLDivElement | null) => {
+		if (element === null) return
+
+		setDetailHeight(element.offsetHeight)
+		// The box that was clicked is on screen, but the fields that open below it
+		// need not be. `nearest` moves the Panel the least that shows them, so a
+		// Section near the top does not move at all.
+		element.scrollIntoView({ block: 'nearest', inline: 'nearest' })
+
+		const observer = new ResizeObserver(() => setDetailHeight(element.offsetHeight))
+		observer.observe(element)
+
+		return () => observer.disconnect()
+	}, [])
 
 	const { nodes, links, width, height } = planMap(plan, { ...layout, collapsed })
-
-	const onPath = new Set<string>()
-	const litNode = nodes.find((node) => node.key === lit)
-	if (litNode !== undefined) {
-		onPath.add(litNode.key)
-		for (const ancestor of litNode.ancestors) onPath.add(ancestor)
-	}
 
 	const fold = (nodeId: string) =>
 		setCollapsed((held) => {
@@ -56,47 +90,115 @@ export function PlanMap({ plan, padding = 12, layout, className }: PlanMapProps)
 			return next
 		})
 
-	return (
-		<svg
-			aria-label={`Map of ${plan.title === '' ? 'the article' : plan.title}`}
-			className={cx('block max-w-full', className)}
-			role="img"
-			viewBox={`${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`}
-			width={width + padding * 2}
-		>
-			{links.map((link) => (
-				<path
-					key={`${link.parentKey}→${link.childKey}`}
-					className={cx(
-						'fill-none transition-colors',
-						onPath.has(link.parentKey) && onPath.has(link.childKey)
-							? 'stroke-ink'
-							: 'stroke-rule',
-					)}
-					d={link.d}
-					strokeWidth={1.5}
-				/>
-			))}
+	// A folded Section can hold the open one, and a Section can be deleted from
+	// its own detail. Either leaves `openId` naming a box that is not drawn, so
+	// the open node is looked up in what was laid out rather than in the Plan.
+	const open =
+		nodes.find((node) => node.nodeId !== null && node.nodeId === openId) ?? null
+	const entry =
+		open === null
+			? null
+			: (outlineEntries(plan.outline).find((one) => one.node.id === open.nodeId) ?? null)
 
-			{nodes.map((node) => (
-				<foreignObject
-					key={node.key}
-					height={node.height}
-					width={node.width}
-					x={node.x}
-					y={node.y}
+	const detail = open === null || entry === null ? null : { node: open, entry }
+
+	// The pointer wins over the open Section, so the writer can trace another
+	// branch without shutting what they are editing. With neither, nothing lights.
+	const onPath = new Set<string>()
+	const traced = nodes.find((node) => node.key === (lit ?? open?.key))
+	if (traced !== undefined) {
+		onPath.add(traced.key)
+		for (const ancestor of traced.ancestors) onPath.add(ancestor)
+	}
+
+	const drawnWidth = width + padding * 2
+	const drawnHeight = height + padding * 2
+
+	return (
+		<div className={cx('relative overflow-x-auto', className)}>
+			<div
+				className="relative"
+				style={{
+					width:
+						detail === null
+							? drawnWidth
+							: Math.max(drawnWidth, detail.node.x + padding + DETAIL_WIDTH),
+					height:
+						detail === null
+							? drawnHeight
+							: Math.max(drawnHeight, detail.node.y + padding + detailHeight),
+				}}
+			>
+				<svg
+					aria-label={`Map of ${plan.title === '' ? 'the article' : plan.title}`}
+					className="block"
+					height={drawnHeight}
+					role="img"
+					viewBox={`${-padding} ${-padding} ${drawnWidth} ${drawnHeight}`}
+					width={drawnWidth}
 				>
-					<Box
-						folded={node.collapsed}
-						lit={onPath.has(node.key)}
-						node={node}
-						onFold={node.nodeId === null ? undefined : () => fold(node.nodeId!)}
-						onLeave={() => setLit((held) => (held === node.key ? null : held))}
-						onLight={() => setLit(node.key)}
-					/>
-				</foreignObject>
-			))}
-		</svg>
+					{links.map((link) => (
+						<path
+							key={`${link.parentKey}→${link.childKey}`}
+							className={cx(
+								'fill-none transition-colors',
+								onPath.has(link.parentKey) && onPath.has(link.childKey)
+									? 'stroke-ink'
+									: 'stroke-rule',
+							)}
+							d={link.d}
+							strokeWidth={1.5}
+						/>
+					))}
+
+					{nodes.map((node) => (
+						<foreignObject
+							key={node.key}
+							height={node.height}
+							width={node.width}
+							x={node.x}
+							y={node.y}
+						>
+							<Box
+								folded={node.collapsed}
+								lit={onPath.has(node.key)}
+								node={node}
+								// The root is the Article title rather than a Section, so it
+								// folds nothing and has no Section fields to open.
+								onFold={node.nodeId === null ? undefined : () => fold(node.nodeId!)}
+								onLeave={() => setLit((held) => (held === node.key ? null : held))}
+								onLight={() => setLit(node.key)}
+								onOpen={node.nodeId === null ? undefined : () => setOpenId(node.nodeId)}
+								open={node.nodeId === openId}
+							/>
+						</foreignObject>
+					))}
+				</svg>
+
+				{detail === null ? null : (
+					<div
+						ref={measure}
+						className="absolute z-10 rounded-md shadow-frame"
+						style={{
+							left: detail.node.x + padding,
+							top: detail.node.y + padding,
+							width: DETAIL_WIDTH,
+						}}
+					>
+						<SectionRow
+							edit={edit}
+							entry={detail.entry}
+							onOpen={() => setOpenId(null)}
+							// The map has no References list to send the writer down to.
+							// Placing one is in the row's own fields, which are right here.
+							onShowReference={() => {}}
+							open
+							plan={plan}
+						/>
+					</div>
+				)}
+			</div>
+		</div>
 	)
 }
 
@@ -104,15 +206,26 @@ interface BoxProps {
 	node: MapNode
 	lit: boolean
 	folded: boolean
+	/** True while this Section's fields sit open over the map. */
+	open: boolean
 	/** Absent at the root, which is the Article title and folds nothing. */
 	onFold?: () => void
+	/** Absent at the root, which has no Section fields to open. */
+	onOpen?: () => void
 	onLight: () => void
 	onLeave: () => void
 }
 
-/** One box. The root reads as the Article title, and everything else reads as
- * the row it is in the Panel — number, title, target, intent note. */
-function Box({ node, lit, folded, onFold, onLight, onLeave }: BoxProps) {
+/**
+ * One box. The root reads as the Article title, and everything else reads as
+ * the row it is in the Panel — number, title, target, intent note, References.
+ *
+ * The whole box opens the Section, and the title carries that as a real button
+ * so it is reachable by keyboard and named to a screen reader. The fold control
+ * stops the click going any further: it changes what the map draws, and the box
+ * around it changes what the writer is editing.
+ */
+function Box({ node, lit, folded, open, onFold, onOpen, onLight, onLeave }: BoxProps) {
 	const root = node.nodeId === null
 	const title =
 		node.title === '' ? (root ? 'Untitled article' : 'Untitled section') : node.title
@@ -123,7 +236,9 @@ function Box({ node, lit, folded, onFold, onLight, onLeave }: BoxProps) {
 			className={cx(
 				'flex h-full w-full items-start gap-1.5 overflow-hidden rounded-md border bg-surface px-2 py-1.5 transition-colors',
 				lit ? 'border-ink' : 'border-edge',
+				onOpen && 'cursor-pointer',
 			)}
+			onClick={onOpen}
 			onFocus={onLight}
 			onBlur={onLeave}
 			onMouseEnter={onLight}
@@ -139,15 +254,29 @@ function Box({ node, lit, folded, onFold, onLight, onLeave }: BoxProps) {
 			)}
 
 			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-				<span
-					className={cx(
-						'line-clamp-2 text-[0.8125rem] leading-snug',
-						node.title === '' ? 'text-faint italic' : 'text-ink',
-						root && 'font-medium',
-					)}
-				>
-					{title}
-				</span>
+				{onOpen === undefined ? (
+					<span
+						className={cx(
+							'line-clamp-2 text-[0.8125rem] leading-snug',
+							node.title === '' ? 'text-faint italic' : 'text-ink',
+							root && 'font-medium',
+						)}
+					>
+						{title}
+					</span>
+				) : (
+					<button
+						aria-expanded={open}
+						className={cx(
+							'line-clamp-2 text-left text-[0.8125rem] leading-snug',
+							node.title === '' ? 'text-faint italic' : 'text-ink',
+						)}
+						onClick={onOpen}
+						type="button"
+					>
+						{title}
+					</button>
+				)}
 
 				{target === undefined && node.node?.intent === undefined ? null : (
 					<span className="flex min-w-0 items-baseline gap-1.5 text-[0.6875rem] text-muted">
@@ -177,7 +306,10 @@ function Box({ node, lit, folded, onFold, onLight, onLeave }: BoxProps) {
 					aria-expanded={!folded}
 					aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
 					className="mt-px shrink-0 rounded-full border border-edge px-1 font-mono text-[0.625rem] leading-[1.05rem] text-muted hover:border-ink hover:text-ink"
-					onClick={onFold}
+					onClick={(event) => {
+						event.stopPropagation()
+						onFold()
+					}}
 					type="button"
 				>
 					{folded ? node.childCount : '–'}

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -38,9 +38,13 @@ import { SectionRow } from './SectionRow'
  * accent is rationed to one thing per screen — `foundations/Accent.mdx`.
  */
 
-/** How wide the open Section's fields sit. Room for the two `SectionRow` puts
- * on one line, which a box's own width has none of. */
-const DETAIL_WIDTH = 380
+/**
+ * How wide the open Section's fields sit — well past a box's own width, and
+ * past what the two fields on the title line strictly need. A Section is a
+ * thing the writer works in rather than glances at, so the card reads as
+ * somewhere to write rather than as a box that grew.
+ */
+const DETAIL_WIDTH = 520
 
 /** Room around the drawing, so a lit box's border is not clipped. */
 const PADDING = 12
@@ -288,13 +292,14 @@ export function PlanMap({
 							width: DETAIL_WIDTH,
 						}}
 					>
+						{/* No `onShowReference`: the map has no References list to send
+						    the writer down to, so a placed Reference reads as text here
+						    rather than as a control that would do nothing. */}
 						<SectionRow
+							className="gap-3 p-3.5"
 							edit={edit}
 							entry={detail.entry}
 							onOpen={close}
-							// The map has no References list to send the writer down to.
-							// Placing one is in the row's own fields, which are right here.
-							onShowReference={() => {}}
 							open
 							plan={plan}
 						/>

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+
+import type { Plan } from '../../shared/plan'
+import { cx } from '../lib/cx'
+import type { MapNode, MapOptions } from './map'
+import { planMap } from './map'
+
+/**
+ * The Map View of the Plan — the Outline opened left to right, with the Article
+ * title as the root and the Sections branching off it.
+ *
+ * **It reads the Plan and never writes it.** Collapsing a Section hides its
+ * children on this map and changes nothing in the Plan, so the writer can fold
+ * a long piece down to its shape without editing it. `PlanPanel.tsx` is where
+ * the Outline is edited, and its ops are the only way a Plan changes —
+ * `docs/architecture.md` §"The Plan Panel's edits are ops".
+ *
+ * `map.ts` holds every number on screen. This file draws them and computes
+ * none, so what a test measures and what the writer sees cannot drift apart.
+ *
+ * The one colour decision: the path back to the root lights in ink rather than
+ * accent, because a hover is transient and the accent is rationed to one thing
+ * per screen — `foundations/Accent.mdx`.
+ */
+
+export interface PlanMapProps {
+	plan: Plan
+	/** Room around the drawing, so a lit box's border is not clipped. */
+	padding?: number
+	/** Passed through to the layout — column widths, gaps, box heights. */
+	layout?: Omit<MapOptions, 'collapsed'>
+	className?: string
+}
+
+export function PlanMap({ plan, padding = 12, layout, className }: PlanMapProps) {
+	// Which Sections are folded, and which box the pointer or the caret is on.
+	// Both belong to this View: neither is in the Plan, and reopening the Panel
+	// starts the map unfolded.
+	const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
+	const [lit, setLit] = useState<string | null>(null)
+
+	const { nodes, links, width, height } = planMap(plan, { ...layout, collapsed })
+
+	const onPath = new Set<string>()
+	const litNode = nodes.find((node) => node.key === lit)
+	if (litNode !== undefined) {
+		onPath.add(litNode.key)
+		for (const ancestor of litNode.ancestors) onPath.add(ancestor)
+	}
+
+	const fold = (nodeId: string) =>
+		setCollapsed((held) => {
+			const next = new Set(held)
+			if (!next.delete(nodeId)) next.add(nodeId)
+
+			return next
+		})
+
+	return (
+		<svg
+			aria-label={`Map of ${plan.title === '' ? 'the article' : plan.title}`}
+			className={cx('block max-w-full', className)}
+			role="img"
+			viewBox={`${-padding} ${-padding} ${width + padding * 2} ${height + padding * 2}`}
+			width={width + padding * 2}
+		>
+			{links.map((link) => (
+				<path
+					key={`${link.parentKey}→${link.childKey}`}
+					className={cx(
+						'fill-none transition-colors',
+						onPath.has(link.parentKey) && onPath.has(link.childKey)
+							? 'stroke-ink'
+							: 'stroke-rule',
+					)}
+					d={link.d}
+					strokeWidth={1.5}
+				/>
+			))}
+
+			{nodes.map((node) => (
+				<foreignObject
+					key={node.key}
+					height={node.height}
+					width={node.width}
+					x={node.x}
+					y={node.y}
+				>
+					<Box
+						folded={node.collapsed}
+						lit={onPath.has(node.key)}
+						node={node}
+						onFold={node.nodeId === null ? undefined : () => fold(node.nodeId!)}
+						onLeave={() => setLit((held) => (held === node.key ? null : held))}
+						onLight={() => setLit(node.key)}
+					/>
+				</foreignObject>
+			))}
+		</svg>
+	)
+}
+
+interface BoxProps {
+	node: MapNode
+	lit: boolean
+	folded: boolean
+	/** Absent at the root, which is the Article title and folds nothing. */
+	onFold?: () => void
+	onLight: () => void
+	onLeave: () => void
+}
+
+/** One box. The root reads as the Article title, and everything else reads as
+ * the row it is in the Panel — number, title, target, intent note. */
+function Box({ node, lit, folded, onFold, onLight, onLeave }: BoxProps) {
+	const root = node.nodeId === null
+	const title =
+		node.title === '' ? (root ? 'Untitled article' : 'Untitled section') : node.title
+	const target = node.node?.target
+
+	return (
+		<div
+			className={cx(
+				'flex h-full w-full items-start gap-1.5 overflow-hidden rounded-md border bg-surface px-2 py-1.5 transition-colors',
+				lit ? 'border-ink' : 'border-edge',
+			)}
+			onFocus={onLight}
+			onBlur={onLeave}
+			onMouseEnter={onLight}
+			onMouseLeave={onLeave}
+		>
+			{root ? null : (
+				// No fixed width, unlike the Panel's row: a Subsection is numbered
+				// "2.1" and would sit under its own title in the three-space the
+				// Panel gives a Section.
+				<span className="mt-px shrink-0 font-mono text-[0.6875rem] text-faint">
+					{node.ordinal}
+				</span>
+			)}
+
+			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
+				<span
+					className={cx(
+						'line-clamp-2 text-[0.8125rem] leading-snug',
+						node.title === '' ? 'text-faint italic' : 'text-ink',
+						root && 'font-medium',
+					)}
+				>
+					{title}
+				</span>
+
+				{target === undefined && node.node?.intent === undefined ? null : (
+					<span className="flex min-w-0 items-baseline gap-1.5 text-[0.6875rem] text-muted">
+						{target === undefined ? null : (
+							<span className="shrink-0 font-mono text-faint">{target}w</span>
+						)}
+						{node.node?.intent === undefined ? null : (
+							<span className="truncate">{node.node.intent}</span>
+						)}
+					</span>
+				)}
+			</div>
+
+			{node.childCount === 0 || onFold === undefined ? null : (
+				<button
+					aria-expanded={!folded}
+					aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
+					className="mt-px shrink-0 rounded-full border border-edge px-1 font-mono text-[0.625rem] leading-[1.05rem] text-muted hover:border-ink hover:text-ink"
+					onClick={onFold}
+					type="button"
+				>
+					{folded ? node.childCount : '–'}
+				</button>
+			)}
+		</div>
+	)
+}

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import type { Plan, ProposalInput } from '../../shared/plan'
-import { findNodePath } from '../../shared/plan'
+import { sectionIsEmpty } from '../../shared/plan'
 import { cx } from '../lib/cx'
 import { addSection, deleteSection } from './edits'
-import type { MapBranches, MapNode, MapOptions } from './map'
-import { planMap, subjectId } from './map'
+import type { MapBranches, MapNode } from './map'
+import { planMap } from './map'
 import { outlineEntries } from './outline'
 import { referenceMark } from './references'
 import { SectionRow } from './SectionRow'
@@ -14,10 +14,10 @@ import { SectionRow } from './SectionRow'
  * The Map View of the Plan — the Plan opened left to right, with the Article
  * title as the root.
  *
- * `map.ts` holds every number on screen. This file draws them and computes
- * none, so what a test measures and what the writer sees cannot drift apart.
- * It also picks what branches off a Section: the References placed there, or
- * the Sections nested inside it — `MapOptions.branches`.
+ * `map.ts` places every box and every curve, and picks what branches off a
+ * Section — the References placed there, or the Sections nested inside it
+ * (`MapOptions.branches`). What this file adds is the padding around the
+ * drawing and where the open Section's fields are anchored.
  *
  * **Reading and writing are separate here.** Folding a Section hides its
  * children on this map and changes nothing in the Plan — that state belongs to
@@ -26,24 +26,24 @@ import { SectionRow } from './SectionRow'
  * applier would refuse — `docs/architecture.md` §"The Plan Panel's edits are
  * ops".
  *
- * **The detail sits over the map rather than in it.** Clicking a box opens the
- * Section's fields anchored at that box, painted above its neighbours without
- * joining the layout. Growing the box in place would reflow the whole map —
- * parents recentre and siblings move — so the writer would lose the shape they
- * clicked into. A dialog keeps the map still but throws away where they were.
+ * **The open Section's fields sit over the map, not in it.** They are anchored
+ * at the box and painted above its neighbours without joining the layout, so
+ * nothing reflows around what the writer is editing.
  *
- * The map draws at its own size and scrolls sideways rather than shrinking to
- * fit. Scaling it down would put the detail's pixels out of register with the
- * boxes, and would make a wide Plan unreadable anyway.
+ * **The map draws at its own size and scrolls sideways.** It must not be scaled
+ * to fit: the fields are positioned in the same units the boxes are, and
+ * scaling puts the two out of register.
  *
- * The one colour decision: the path back to the root lights in ink rather than
- * accent, because a hover is transient and the accent is rationed to one thing
- * per screen — `foundations/Accent.mdx`.
+ * The path back to the root lights in ink rather than accent, because the
+ * accent is rationed to one thing per screen — `foundations/Accent.mdx`.
  */
 
-/** How wide the detail sits. Room for the two fields `SectionRow` puts on one
- * line, which a box's own width has none of. */
+/** How wide the open Section's fields sit. Room for the two `SectionRow` puts
+ * on one line, which a box's own width has none of. */
 const DETAIL_WIDTH = 380
+
+/** Room around the drawing, so a lit box's border is not clipped. */
+const PADDING = 12
 
 export interface PlanMapProps {
 	plan: Plan
@@ -51,10 +51,6 @@ export interface PlanMapProps {
 	edit: (ops: ProposalInput | null) => void
 	/** What branches off a Section — `map.ts`. */
 	branches?: MapBranches
-	/** Room around the drawing, so a lit box's border is not clipped. */
-	padding?: number
-	/** Passed through to the layout — column widths, gaps, box heights. */
-	layout?: Omit<MapOptions, 'collapsed' | 'branches'>
 	className?: string
 }
 
@@ -62,8 +58,6 @@ export function PlanMap({
 	plan,
 	edit,
 	branches = 'references',
-	padding = 12,
-	layout,
 	className,
 }: PlanMapProps) {
 	// Which Sections are folded, which box the pointer or the caret is on, and
@@ -97,33 +91,21 @@ export function PlanMap({
 		return () => observer.disconnect()
 	}, [])
 
-	const { nodes, links, width, height } = planMap(plan, {
-		...layout,
-		branches,
-		collapsed,
-	})
+	// Held: a pointer sweeping the map fires `setLit` once per box, and none of
+	// those renders changes where anything sits.
+	const { nodes, links, width, height } = useMemo(
+		() => planMap(plan, { branches, collapsed }),
+		[plan, branches, collapsed],
+	)
 
 	/**
 	 * Leaves whatever is open, and throws away a Section `+` made that the writer
-	 * put nothing into. "Nothing" is every field, not just the two on the first
-	 * line: a Section with an intent note and no title is still work, and losing
-	 * it would be worse than leaving an untitled row on the map.
+	 * put nothing into. Empty means every field: a Section carrying only an
+	 * intent note is still work, and it stays.
 	 */
 	const close = () => {
 		if (made !== null) {
-			const path = findNodePath(plan.outline, made)
-			const node = path === null ? null : path[path.length - 1]!
-			const empty =
-				node !== null &&
-				node.title === '' &&
-				node.target === undefined &&
-				node.intent === undefined &&
-				node.voice === undefined &&
-				node.adjectives === undefined &&
-				node.children.length === 0 &&
-				!plan.references.some((reference) => reference.nodeId === made)
-
-			if (empty) edit(deleteSection(made))
+			if (sectionIsEmpty(plan, made)) edit(deleteSection(made))
 			setMade(null)
 		}
 		setOpenId(null)
@@ -145,12 +127,11 @@ export function PlanMap({
 
 	/**
 	 * A new Section inside the box that was clicked, last among what is already
-	 * there. On the root that is a Section of the Article; deeper than that only
-	 * `branches: 'sections'` offers it, because two levels is what the interface
-	 * offers and a third has no word the writer holds — `context.md` §Subsection.
+	 * there, open on arrival with the caret in its title.
 	 *
-	 * It opens on arrival, the way the Panel opens one the writer just added, so
-	 * the caret is already in the title.
+	 * Only the Article title offers this under `branches: 'references'`. Two
+	 * levels is what the interface offers, and a third has no word the writer
+	 * holds — `context.md` §Subsection.
 	 */
 	const add = (parentId: string | null) => {
 		const id = crypto.randomUUID()
@@ -178,11 +159,9 @@ export function PlanMap({
 			(node) => node.subject.kind === 'section' && node.subject.node.id === openId,
 		) ?? null
 	const entry =
-		opened === null
+		openId === null || opened === null
 			? null
-			: (outlineEntries(plan.outline).find(
-					(one) => one.node.id === subjectId(opened.subject),
-				) ?? null)
+			: (outlineEntries(plan.outline).find((one) => one.node.id === openId) ?? null)
 
 	const detail = opened === null || entry === null ? null : { node: opened, entry }
 
@@ -195,8 +174,8 @@ export function PlanMap({
 		for (const ancestor of traced.ancestors) onPath.add(ancestor)
 	}
 
-	const drawnWidth = width + padding * 2
-	const drawnHeight = height + padding * 2
+	const drawnWidth = width + PADDING * 2
+	const drawnHeight = height + PADDING * 2
 
 	return (
 		<div
@@ -217,19 +196,18 @@ export function PlanMap({
 		>
 			<div
 				className="relative"
-				// Every box and the open detail stop their own clicks, so what is left
-				// here is the space between them. Nothing else on the map does nothing
-				// on a click, which is what makes it the place to shut things.
+				// Every box and the open detail stop their own clicks, so a click that
+				// reaches here is one on the space between them.
 				onClick={close}
 				style={{
 					width:
 						detail === null
 							? drawnWidth
-							: Math.max(drawnWidth, detail.node.x + padding + DETAIL_WIDTH),
+							: Math.max(drawnWidth, detail.node.x + PADDING + DETAIL_WIDTH),
 					height:
 						detail === null
 							? drawnHeight
-							: Math.max(drawnHeight, detail.node.y + padding + detailHeight),
+							: Math.max(drawnHeight, detail.node.y + PADDING + detailHeight),
 				}}
 			>
 				<svg
@@ -237,7 +215,7 @@ export function PlanMap({
 					className="block"
 					height={drawnHeight}
 					role="img"
-					viewBox={`${-padding} ${-padding} ${drawnWidth} ${drawnHeight}`}
+					viewBox={`${-PADDING} ${-PADDING} ${drawnWidth} ${drawnHeight}`}
 					width={drawnWidth}
 				>
 					{links.map((link) => (
@@ -259,6 +237,14 @@ export function PlanMap({
 						// handlers below, which a property access would not.
 						const { subject } = node
 						const section = subject.kind === 'section' ? subject.node : null
+						// Where a new Section would go, and null where this box takes
+						// none. Under `references` that is the Article title alone.
+						const addsInto =
+							subject.kind === 'article'
+								? { id: null }
+								: section !== null && branches === 'sections'
+									? { id: section.id }
+									: null
 
 						return (
 							<foreignObject
@@ -272,16 +258,7 @@ export function PlanMap({
 									folded={node.collapsed}
 									lit={onPath.has(node.key)}
 									node={node}
-									// A Section takes a Section inside it only where the map is
-									// drawing nesting. Under `references` the Article title is
-									// the one box that takes one.
-									onAdd={
-										subject.kind === 'article'
-											? () => add(null)
-											: section !== null && branches === 'sections'
-												? () => add(section.id)
-												: undefined
-									}
+									onAdd={addsInto === null ? undefined : () => add(addsInto.id)}
 									// A Reference is edited in the References list, and the root
 									// is the Article title rather than a Section. Neither folds
 									// or opens Section fields.
@@ -306,8 +283,8 @@ export function PlanMap({
 						className="absolute z-10 origin-top-left scale-100 rounded-md opacity-100 shadow-frame transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none starting:scale-95 starting:opacity-0"
 						onClick={(event) => event.stopPropagation()}
 						style={{
-							left: detail.node.x + padding,
-							top: detail.node.y + padding,
+							left: detail.node.x + PADDING,
+							top: detail.node.y + PADDING,
 							width: DETAIL_WIDTH,
 						}}
 					>
@@ -368,12 +345,12 @@ function Box({
 	onLeave,
 }: BoxProps) {
 	const { subject } = node
-	const untitled = subject.kind === 'section' && node.title === ''
+	const untitled = node.title === ''
 	const title = untitled
-		? 'Untitled section'
-		: node.title === ''
+		? subject.kind === 'article'
 			? 'Untitled article'
-			: node.title
+			: 'Untitled section'
+		: node.title
 
 	const target = subject.kind === 'section' ? subject.node.target : undefined
 	const intent = subject.kind === 'section' ? subject.node.intent : undefined
@@ -457,10 +434,8 @@ function Box({
 			    hang off. Stacked rather than side by side, which costs the title
 			    one column of width instead of two. */}
 			{onFold === undefined && onAdd === undefined ? null : (
-				<div className="flex h-full shrink-0 flex-col items-end justify-between">
-					{node.childCount === 0 || onFold === undefined ? (
-						<span />
-					) : (
+				<div className="flex h-full shrink-0 flex-col items-end">
+					{node.childCount === 0 || onFold === undefined ? null : (
 						<button
 							aria-expanded={!folded}
 							aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
@@ -482,7 +457,7 @@ function Box({
 									? 'Add a Section to the Outline'
 									: `Add a Section inside ${title}`
 							}
-							className={CONTROL}
+							className={cx(CONTROL, 'mt-auto')}
 							onClick={(event) => {
 								event.stopPropagation()
 								onAdd()

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -11,39 +11,17 @@ import { referenceMark } from './references'
 import { SectionRow } from './SectionRow'
 
 /**
- * The Map View of the Plan — the Plan opened left to right, with the Article
- * title as the root.
+ * A mind-map View of the Plan, opening left to right from the Article title.
  *
- * `map.ts` places every box and every curve, and picks what branches off a
- * Section — the References placed there, or the Sections nested inside it
- * (`MapOptions.branches`). What this file adds is the padding around the
- * drawing and where the open Section's fields are anchored.
+ * `map.ts` places every box and curve. This component draws them, anchors the
+ * open Section's fields over the box they belong to, and holds what the writer
+ * has folded, lit, or opened.
  *
- * **Reading and writing are separate here.** Folding a Section hides its
- * children on this map and changes nothing in the Plan — that state belongs to
- * the View. Editing goes the one way every Plan surface goes: `SectionRow`
- * builds ops and `edit` applies them, so the map cannot make a change the
- * applier would refuse — `docs/architecture.md` §"The Plan Panel's edits are
- * ops".
- *
- * **The open Section's fields sit over the map, not in it.** They are anchored
- * at the box and painted above its neighbours without joining the layout, so
- * nothing reflows around what the writer is editing.
- *
- * **The map draws at its own size and scrolls sideways.** It must not be scaled
- * to fit: the fields are positioned in the same units the boxes are, and
- * scaling puts the two out of register.
- *
- * The path back to the root lights in ink rather than accent, because the
- * accent is rationed to one thing per screen — `foundations/Accent.mdx`.
+ * The map draws at its own size and scrolls sideways rather than scaling to
+ * fit, because the anchored fields are positioned in the map's own units.
  */
 
-/**
- * How wide the open Section's fields sit — well past a box's own width, and
- * past what the two fields on the title line strictly need. A Section is a
- * thing the writer works in rather than glances at, so the card reads as
- * somewhere to write rather than as a box that grew.
- */
+/** How wide the open Section's fields sit, in the map's own units. */
 const DETAIL_WIDTH = 520
 
 /** Room around the drawing, so a lit box's border is not clipped. */
@@ -64,29 +42,19 @@ export function PlanMap({
 	branches = 'references',
 	className,
 }: PlanMapProps) {
-	// Which Sections are folded, which box the pointer or the caret is on, and
-	// which one is open. All three belong to this View: none is in the Plan, and
-	// reopening the Panel starts the map unfolded and shut.
+	// None of this is in the Plan: the map opens unfolded and shut every time.
 	const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
 	const [lit, setLit] = useState<string | null>(null)
 	const [openId, setOpenId] = useState<string | null>(null)
-	// The Section `+` just made, which is thrown away again if the writer leaves
-	// it with nothing in it.
-	const [made, setMade] = useState<string | null>(null)
-	// What the open detail measured, so the scroll area reaches its foot. Read
-	// off the element rather than guessed: how tall the fields run depends on
-	// what the Section carries, and it changes under the writer as they type an
-	// intent note long enough to wrap.
+	const [madeId, setMadeId] = useState<string | null>(null)
 	const [detailHeight, setDetailHeight] = useState(0)
 
-	// Held, so React attaches it once rather than re-running it every render.
+	// Measures the open fields, so the scroll area reaches their foot, and keeps
+	// measuring: how tall they run changes as the writer types.
 	const measure = useCallback((element: HTMLDivElement | null) => {
 		if (element === null) return
 
 		setDetailHeight(element.offsetHeight)
-		// The box that was clicked is on screen, but the fields that open below it
-		// need not be. `nearest` moves the Panel the least that shows them, so a
-		// Section near the top does not move at all.
 		element.scrollIntoView({ block: 'nearest', inline: 'nearest' })
 
 		const observer = new ResizeObserver(() => setDetailHeight(element.offsetHeight))
@@ -95,27 +63,22 @@ export function PlanMap({
 		return () => observer.disconnect()
 	}, [])
 
-	// Held: a pointer sweeping the map fires `setLit` once per box, and none of
-	// those renders changes where anything sits.
+	// Held: a pointer sweeping the map fires `setLit` once per box, and the
+	// layout is the same on every one of those renders.
 	const { nodes, links, width, height } = useMemo(
 		() => planMap(plan, { branches, collapsed }),
 		[plan, branches, collapsed],
 	)
 
-	/**
-	 * Leaves whatever is open, and throws away a Section `+` made that the writer
-	 * put nothing into. Empty means every field: a Section carrying only an
-	 * intent note is still work, and it stays.
-	 */
+	/** Closes the open Section, discarding one `+` made and left empty. */
 	const close = () => {
-		if (made !== null) {
-			if (sectionIsEmpty(plan, made)) edit(deleteSection(made))
-			setMade(null)
+		if (madeId !== null) {
+			if (sectionIsEmpty(plan, madeId)) edit(deleteSection(madeId))
+			setMadeId(null)
 		}
 		setOpenId(null)
 	}
 
-	/** Opens one box, having first cleared up after the last. */
 	const open = (id: string) => {
 		close()
 		setOpenId(id)
@@ -129,20 +92,14 @@ export function PlanMap({
 			return next
 		})
 
-	/**
-	 * A new Section inside the box that was clicked, last among what is already
-	 * there, open on arrival with the caret in its title.
-	 *
-	 * Only the Article title offers this under `branches: 'references'`. Two
-	 * levels is what the interface offers, and a third has no word the writer
-	 * holds — `context.md` §Subsection.
-	 */
+	/** Adds a Section last inside `parentId`, open with the caret in its title.
+	 * Null adds one to the Outline. */
 	const add = (parentId: string | null) => {
 		const id = crypto.randomUUID()
 		close()
 		edit(addSection({ parentId, beforeId: null }, id))
 
-		// A child of a folded Section would land undrawn, so adding one opens it.
+		// A child of a folded Section would land undrawn.
 		if (parentId !== null) {
 			setCollapsed((held) => {
 				const next = new Set(held)
@@ -152,12 +109,11 @@ export function PlanMap({
 			})
 		}
 		setOpenId(id)
-		setMade(id)
+		setMadeId(id)
 	}
 
-	// A folded Section can hold the open one, and a Section can be deleted from
-	// its own detail. Either leaves `openId` naming a box that is not drawn, so
-	// the open box is looked up in what was laid out rather than in the Plan.
+	// Looked up in what was drawn, not in the Plan: folding or deleting can leave
+	// `openId` naming a box the map is not showing.
 	const opened =
 		nodes.find(
 			(node) => node.subject.kind === 'section' && node.subject.node.id === openId,
@@ -170,7 +126,7 @@ export function PlanMap({
 	const detail = opened === null || entry === null ? null : { node: opened, entry }
 
 	// The pointer wins over the open Section, so the writer can trace another
-	// branch without shutting what they are editing. With neither, nothing lights.
+	// branch without shutting what they are editing.
 	const onPath = new Set<string>()
 	const traced = nodes.find((node) => node.key === (lit ?? opened?.key))
 	if (traced !== undefined) {
@@ -183,25 +139,22 @@ export function PlanMap({
 
 	return (
 		<div
-			// Found by this attribute rather than by a class, the way the Frame and
-			// the Panel are, so renaming a Tailwind class cannot quietly empty the
-			// test that measures this box.
+			// The browser test finds this box by the attribute rather than by a class.
 			data-plan-map=""
-			// `shrink-0` because `overflow-x-auto` resolves this box's `min-height`
-			// to 0, and the Panel is a flex column that overflows — without it the
-			// map is squeezed to nothing rather than scrolling the Panel.
+			// `shrink-0`: `overflow-x-auto` zeroes this box's min-height, and the
+			// Panel around it is a flex column that overflows.
 			className={cx('relative shrink-0 overflow-x-auto', className)}
 			onKeyDown={(event) => {
-				// `SectionRow` stops its own Escape, so this one only ever reaches a
-				// box the writer tabbed to rather than the fields they have open.
+				// `SectionRow` stops its own Escape, so this one only reaches a box
+				// the writer tabbed to.
 				if (event.key !== 'Escape') return
 				close()
 			}}
 		>
 			<div
 				className="relative"
-				// Every box and the open detail stop their own clicks, so a click that
-				// reaches here is one on the space between them.
+				// Closes the open Section: boxes and its fields stop their own clicks,
+				// so this one is on the space between them.
 				onClick={close}
 				style={{
 					width:
@@ -237,12 +190,10 @@ export function PlanMap({
 					))}
 
 					{nodes.map((node) => {
-						// Pulled out of the node so the narrowing survives into the
-						// handlers below, which a property access would not.
+						// Destructured so the narrowing survives into the handlers below.
 						const { subject } = node
 						const section = subject.kind === 'section' ? subject.node : null
-						// Where a new Section would go, and null where this box takes
-						// none. Under `references` that is the Article title alone.
+						// Where `+` would add a Section, or null where this box offers none.
 						const addsInto =
 							subject.kind === 'article'
 								? { id: null }
@@ -263,9 +214,6 @@ export function PlanMap({
 									lit={onPath.has(node.key)}
 									node={node}
 									onAdd={addsInto === null ? undefined : () => add(addsInto.id)}
-									// A Reference is edited in the References list, and the root
-									// is the Article title rather than a Section. Neither folds
-									// or opens Section fields.
 									onFold={section === null ? undefined : () => fold(section.id)}
 									onLeave={() => setLit((held) => (held === node.key ? null : held))}
 									onLight={() => setLit(node.key)}
@@ -280,10 +228,7 @@ export function PlanMap({
 				{detail === null ? null : (
 					<div
 						ref={measure}
-						// Grows out of the box's own top-left corner, which is where the
-						// writer clicked, so the fields read as that box opening rather than
-						// as a card arriving from nowhere. `starting:` is the opening state
-						// of a newly mounted element — @starting-style.
+						// Grows out of the box's own top-left corner.
 						className="absolute z-10 origin-top-left scale-100 rounded-md opacity-100 shadow-frame transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none starting:scale-95 starting:opacity-0"
 						onClick={(event) => event.stopPropagation()}
 						style={{
@@ -292,9 +237,7 @@ export function PlanMap({
 							width: DETAIL_WIDTH,
 						}}
 					>
-						{/* No `onShowReference`: the map has no References list to send
-						    the writer down to, so a placed Reference reads as text here
-						    rather than as a control that would do nothing. */}
+						{/* No `onShowReference`: the map draws no References list. */}
 						<SectionRow
 							className="gap-3 p-3.5"
 							edit={edit}
@@ -314,29 +257,22 @@ interface BoxProps {
 	node: MapNode
 	lit: boolean
 	folded: boolean
-	/** True while this Section's fields sit open over the map. */
 	open: boolean
-	/** Absent where the box holds no Sections to fold. */
 	onFold?: () => void
-	/** Absent where the box has no Section fields to open. */
 	onOpen?: () => void
-	/** Make a Section inside this one. Absent where the map draws none there. */
 	onAdd?: () => void
 	onLight: () => void
 	onLeave: () => void
 }
 
 /**
- * One box. The root reads as the Article title, a Section reads as the row it
- * is in the Panel, and a Reference reads as its mark and its name.
+ * The box drawn on the map for one node — the Article title, a Section, or a
+ * Reference. Clicking anywhere on it opens that Section's fields, and the title
+ * is a real button so the same is reachable by keyboard and named to a screen
+ * reader. The controls for its own children sit on the right edge.
  *
- * The whole box opens the Section, and the title carries that as a real button
- * so it is reachable by keyboard and named to a screen reader.
- *
- * The right edge holds what the box says about its children: fold what is
- * already inside, and add one more. Every control here stops the click going
- * any further, so a click that reaches the map behind them is a click on the
- * space between boxes, which is what shuts whatever is open.
+ * Every control here stops its click, so only clicks on the map between boxes
+ * reach `PlanMap` to close what is open.
  */
 function Box({
 	node,
@@ -377,9 +313,6 @@ function Box({
 			onMouseLeave={onLeave}
 		>
 			{node.ordinal === '' ? null : (
-				// No fixed width, unlike the Panel's row: a Reference is marked "[3]"
-				// and would sit under its own name in the three-space the Panel gives
-				// a Section.
 				<span className="mt-px shrink-0 font-mono text-[0.6875rem] text-faint">
 					{node.ordinal}
 				</span>
@@ -426,8 +359,7 @@ function Box({
 					</span>
 				)}
 
-				{/* Only where the References are not boxes of their own — otherwise
-				    the map would say the same placement twice. */}
+				{/* Only drawn where References are not boxes of their own. */}
 				{node.referenceNumbers.length === 0 ? null : (
 					<span className="truncate font-mono text-[0.625rem] text-faint">
 						{`refs ${node.referenceNumbers.map((number) => `[${number}]`).join(' ')}`}
@@ -435,9 +367,7 @@ function Box({
 				)}
 			</div>
 
-			{/* The two controls about this box's children, on the edge the children
-			    hang off. Stacked rather than side by side, which costs the title
-			    one column of width instead of two. */}
+			{/* The two controls for this box's children, stacked: fold and add. */}
 			{onFold === undefined && onAdd === undefined ? null : (
 				<div className="flex h-full shrink-0 flex-col items-end">
 					{node.childCount === 0 || onFold === undefined ? null : (
@@ -478,7 +408,5 @@ function Box({
 	)
 }
 
-/** Both edge controls, which are the same target at the same weight: quiet
- * until the pointer or the caret reaches them. */
 const CONTROL =
 	'shrink-0 rounded-full border border-edge px-1 font-mono text-[0.625rem] leading-[1.05rem] text-muted transition-colors hover:border-ink hover:text-ink'

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -1,19 +1,23 @@
 import { useCallback, useState } from 'react'
 
 import type { Plan, ProposalInput } from '../../shared/plan'
+import { findNodePath } from '../../shared/plan'
 import { cx } from '../lib/cx'
-import { addSection } from './edits'
-import type { MapNode, MapOptions } from './map'
-import { planMap } from './map'
+import { addSection, deleteSection } from './edits'
+import type { MapBranches, MapNode, MapOptions } from './map'
+import { planMap, subjectId } from './map'
 import { outlineEntries } from './outline'
+import { referenceMark } from './references'
 import { SectionRow } from './SectionRow'
 
 /**
- * The Map View of the Plan — the Outline opened left to right, with the Article
- * title as the root and the Sections branching off it.
+ * The Map View of the Plan — the Plan opened left to right, with the Article
+ * title as the root.
  *
  * `map.ts` holds every number on screen. This file draws them and computes
  * none, so what a test measures and what the writer sees cannot drift apart.
+ * It also picks what branches off a Section: the References placed there, or
+ * the Sections nested inside it — `MapOptions.branches`.
  *
  * **Reading and writing are separate here.** Folding a Section hides its
  * children on this map and changes nothing in the Plan — that state belongs to
@@ -30,7 +34,7 @@ import { SectionRow } from './SectionRow'
  *
  * The map draws at its own size and scrolls sideways rather than shrinking to
  * fit. Scaling it down would put the detail's pixels out of register with the
- * boxes, and would make a wide Outline unreadable anyway.
+ * boxes, and would make a wide Plan unreadable anyway.
  *
  * The one colour decision: the path back to the root lights in ink rather than
  * accent, because a hover is transient and the accent is rationed to one thing
@@ -45,20 +49,32 @@ export interface PlanMapProps {
 	plan: Plan
 	/** The Plan's one writer, taken as the Panel takes it. */
 	edit: (ops: ProposalInput | null) => void
+	/** What branches off a Section — `map.ts`. */
+	branches?: MapBranches
 	/** Room around the drawing, so a lit box's border is not clipped. */
 	padding?: number
 	/** Passed through to the layout — column widths, gaps, box heights. */
-	layout?: Omit<MapOptions, 'collapsed'>
+	layout?: Omit<MapOptions, 'collapsed' | 'branches'>
 	className?: string
 }
 
-export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMapProps) {
+export function PlanMap({
+	plan,
+	edit,
+	branches = 'references',
+	padding = 12,
+	layout,
+	className,
+}: PlanMapProps) {
 	// Which Sections are folded, which box the pointer or the caret is on, and
 	// which one is open. All three belong to this View: none is in the Plan, and
 	// reopening the Panel starts the map unfolded and shut.
 	const [collapsed, setCollapsed] = useState<ReadonlySet<string>>(new Set())
 	const [lit, setLit] = useState<string | null>(null)
 	const [openId, setOpenId] = useState<string | null>(null)
+	// The Section `+` just made, which is thrown away again if the writer leaves
+	// it with nothing in it.
+	const [made, setMade] = useState<string | null>(null)
 	// What the open detail measured, so the scroll area reaches its foot. Read
 	// off the element rather than guessed: how tall the fields run depends on
 	// what the Section carries, and it changes under the writer as they type an
@@ -81,7 +97,43 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 		return () => observer.disconnect()
 	}, [])
 
-	const { nodes, links, width, height } = planMap(plan, { ...layout, collapsed })
+	const { nodes, links, width, height } = planMap(plan, {
+		...layout,
+		branches,
+		collapsed,
+	})
+
+	/**
+	 * Leaves whatever is open, and throws away a Section `+` made that the writer
+	 * put nothing into. "Nothing" is every field, not just the two on the first
+	 * line: a Section with an intent note and no title is still work, and losing
+	 * it would be worse than leaving an untitled row on the map.
+	 */
+	const close = () => {
+		if (made !== null) {
+			const path = findNodePath(plan.outline, made)
+			const node = path === null ? null : path[path.length - 1]!
+			const empty =
+				node !== null &&
+				node.title === '' &&
+				node.target === undefined &&
+				node.intent === undefined &&
+				node.voice === undefined &&
+				node.adjectives === undefined &&
+				node.children.length === 0 &&
+				!plan.references.some((reference) => reference.nodeId === made)
+
+			if (empty) edit(deleteSection(made))
+			setMade(null)
+		}
+		setOpenId(null)
+	}
+
+	/** Opens one box, having first cleared up after the last. */
+	const open = (id: string) => {
+		close()
+		setOpenId(id)
+	}
 
 	const fold = (nodeId: string) =>
 		setCollapsed((held) => {
@@ -93,19 +145,16 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 
 	/**
 	 * A new Section inside the box that was clicked, last among what is already
-	 * there. On the root that is a Section, and on a Section it is a Subsection —
-	 * which is the nesting the Panel cannot reach, because `AddSection` anchors
-	 * every choice it offers at the top level.
-	 *
-	 * A Subsection takes none: two levels is what the interface offers, and
-	 * anything deeper wants a word the writer already holds rather than a more
-	 * recursive one — `context.md` §Subsection.
+	 * there. On the root that is a Section of the Article; deeper than that only
+	 * `branches: 'sections'` offers it, because two levels is what the interface
+	 * offers and a third has no word the writer holds — `context.md` §Subsection.
 	 *
 	 * It opens on arrival, the way the Panel opens one the writer just added, so
 	 * the caret is already in the title.
 	 */
 	const add = (parentId: string | null) => {
 		const id = crypto.randomUUID()
+		close()
 		edit(addSection({ parentId, beforeId: null }, id))
 
 		// A child of a folded Section would land undrawn, so adding one opens it.
@@ -118,24 +167,29 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 			})
 		}
 		setOpenId(id)
+		setMade(id)
 	}
 
 	// A folded Section can hold the open one, and a Section can be deleted from
 	// its own detail. Either leaves `openId` naming a box that is not drawn, so
-	// the open node is looked up in what was laid out rather than in the Plan.
-	const open =
-		nodes.find((node) => node.nodeId !== null && node.nodeId === openId) ?? null
+	// the open box is looked up in what was laid out rather than in the Plan.
+	const opened =
+		nodes.find(
+			(node) => node.subject.kind === 'section' && node.subject.node.id === openId,
+		) ?? null
 	const entry =
-		open === null
+		opened === null
 			? null
-			: (outlineEntries(plan.outline).find((one) => one.node.id === open.nodeId) ?? null)
+			: (outlineEntries(plan.outline).find(
+					(one) => one.node.id === subjectId(opened.subject),
+				) ?? null)
 
-	const detail = open === null || entry === null ? null : { node: open, entry }
+	const detail = opened === null || entry === null ? null : { node: opened, entry }
 
 	// The pointer wins over the open Section, so the writer can trace another
 	// branch without shutting what they are editing. With neither, nothing lights.
 	const onPath = new Set<string>()
-	const traced = nodes.find((node) => node.key === (lit ?? open?.key))
+	const traced = nodes.find((node) => node.key === (lit ?? opened?.key))
 	if (traced !== undefined) {
 		onPath.add(traced.key)
 		for (const ancestor of traced.ancestors) onPath.add(ancestor)
@@ -145,9 +199,28 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 	const drawnHeight = height + padding * 2
 
 	return (
-		<div className={cx('relative overflow-x-auto', className)}>
+		<div
+			// Found by this attribute rather than by a class, the way the Frame and
+			// the Panel are, so renaming a Tailwind class cannot quietly empty the
+			// test that measures this box.
+			data-plan-map=""
+			// `shrink-0` because `overflow-x-auto` resolves this box's `min-height`
+			// to 0, and the Panel is a flex column that overflows — without it the
+			// map is squeezed to nothing rather than scrolling the Panel.
+			className={cx('relative shrink-0 overflow-x-auto', className)}
+			onKeyDown={(event) => {
+				// `SectionRow` stops its own Escape, so this one only ever reaches a
+				// box the writer tabbed to rather than the fields they have open.
+				if (event.key !== 'Escape') return
+				close()
+			}}
+		>
 			<div
 				className="relative"
+				// Every box and the open detail stop their own clicks, so what is left
+				// here is the space between them. Nothing else on the map does nothing
+				// on a click, which is what makes it the place to shut things.
+				onClick={close}
 				style={{
 					width:
 						detail === null
@@ -181,32 +254,46 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 						/>
 					))}
 
-					{nodes.map((node) => (
-						<foreignObject
-							key={node.key}
-							height={node.height}
-							width={node.width}
-							x={node.x}
-							y={node.y}
-						>
-							<Box
-								folded={node.collapsed}
-								lit={onPath.has(node.key)}
-								node={node}
-								// A Subsection is as deep as the interface goes, so it takes no
-								// `+`. Depth 0 is the title and 1 is a Section, and both do.
-								onAdd={node.depth >= 2 ? undefined : () => add(node.nodeId)}
-								// The root is the Article title rather than a Section, so it
-								// folds nothing and has no Section fields to open. It still
-								// takes a new Section, which is what `onAdd` gives it.
-								onFold={node.nodeId === null ? undefined : () => fold(node.nodeId!)}
-								onLeave={() => setLit((held) => (held === node.key ? null : held))}
-								onLight={() => setLit(node.key)}
-								onOpen={node.nodeId === null ? undefined : () => setOpenId(node.nodeId)}
-								open={node.nodeId === openId}
-							/>
-						</foreignObject>
-					))}
+					{nodes.map((node) => {
+						// Pulled out of the node so the narrowing survives into the
+						// handlers below, which a property access would not.
+						const { subject } = node
+						const section = subject.kind === 'section' ? subject.node : null
+
+						return (
+							<foreignObject
+								key={node.key}
+								height={node.height}
+								width={node.width}
+								x={node.x}
+								y={node.y}
+							>
+								<Box
+									folded={node.collapsed}
+									lit={onPath.has(node.key)}
+									node={node}
+									// A Section takes a Section inside it only where the map is
+									// drawing nesting. Under `references` the Article title is
+									// the one box that takes one.
+									onAdd={
+										subject.kind === 'article'
+											? () => add(null)
+											: section !== null && branches === 'sections'
+												? () => add(section.id)
+												: undefined
+									}
+									// A Reference is edited in the References list, and the root
+									// is the Article title rather than a Section. Neither folds
+									// or opens Section fields.
+									onFold={section === null ? undefined : () => fold(section.id)}
+									onLeave={() => setLit((held) => (held === node.key ? null : held))}
+									onLight={() => setLit(node.key)}
+									onOpen={section === null ? undefined : () => open(section.id)}
+									open={section !== null && section.id === openId}
+								/>
+							</foreignObject>
+						)
+					})}
 				</svg>
 
 				{detail === null ? null : (
@@ -217,6 +304,7 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 						// as a card arriving from nowhere. `starting:` is the opening state
 						// of a newly mounted element — @starting-style.
 						className="absolute z-10 origin-top-left scale-100 rounded-md opacity-100 shadow-frame transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none starting:scale-95 starting:opacity-0"
+						onClick={(event) => event.stopPropagation()}
 						style={{
 							left: detail.node.x + padding,
 							top: detail.node.y + padding,
@@ -226,7 +314,7 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 						<SectionRow
 							edit={edit}
 							entry={detail.entry}
-							onOpen={() => setOpenId(null)}
+							onOpen={close}
 							// The map has no References list to send the writer down to.
 							// Placing one is in the row's own fields, which are right here.
 							onShowReference={() => {}}
@@ -246,27 +334,27 @@ interface BoxProps {
 	folded: boolean
 	/** True while this Section's fields sit open over the map. */
 	open: boolean
-	/** Absent at the root, which is the Article title and folds nothing. */
+	/** Absent where the box holds no Sections to fold. */
 	onFold?: () => void
-	/** Absent at the root, which has no Section fields to open. */
+	/** Absent where the box has no Section fields to open. */
 	onOpen?: () => void
-	/** Make a Section inside this one. Absent on a Subsection, which is as deep
-	 * as the interface goes. */
+	/** Make a Section inside this one. Absent where the map draws none there. */
 	onAdd?: () => void
 	onLight: () => void
 	onLeave: () => void
 }
 
 /**
- * One box. The root reads as the Article title, and everything else reads as
- * the row it is in the Panel — number, title, target, intent note, References.
+ * One box. The root reads as the Article title, a Section reads as the row it
+ * is in the Panel, and a Reference reads as its mark and its name.
  *
  * The whole box opens the Section, and the title carries that as a real button
  * so it is reachable by keyboard and named to a screen reader.
  *
  * The right edge holds what the box says about its children: fold what is
- * already inside, and add one more. Both stop the click going any further,
- * because the box around them opens what the writer is editing instead.
+ * already inside, and add one more. Every control here stops the click going
+ * any further, so a click that reaches the map behind them is a click on the
+ * space between boxes, which is what shuts whatever is open.
  */
 function Box({
 	node,
@@ -279,10 +367,16 @@ function Box({
 	onLight,
 	onLeave,
 }: BoxProps) {
-	const root = node.nodeId === null
-	const title =
-		node.title === '' ? (root ? 'Untitled article' : 'Untitled section') : node.title
-	const target = node.node?.target
+	const { subject } = node
+	const untitled = subject.kind === 'section' && node.title === ''
+	const title = untitled
+		? 'Untitled section'
+		: node.title === ''
+			? 'Untitled article'
+			: node.title
+
+	const target = subject.kind === 'section' ? subject.node.target : undefined
+	const intent = subject.kind === 'section' ? subject.node.intent : undefined
 
 	return (
 		<div
@@ -291,16 +385,19 @@ function Box({
 				lit ? 'border-ink' : 'border-edge',
 				onOpen && 'cursor-pointer',
 			)}
-			onClick={onOpen}
+			onClick={(event) => {
+				event.stopPropagation()
+				onOpen?.()
+			}}
 			onFocus={onLight}
 			onBlur={onLeave}
 			onMouseEnter={onLight}
 			onMouseLeave={onLeave}
 		>
-			{root ? null : (
-				// No fixed width, unlike the Panel's row: a Subsection is numbered
-				// "2.1" and would sit under its own title in the three-space the
-				// Panel gives a Section.
+			{node.ordinal === '' ? null : (
+				// No fixed width, unlike the Panel's row: a Reference is marked "[3]"
+				// and would sit under its own name in the three-space the Panel gives
+				// a Section.
 				<span className="mt-px shrink-0 font-mono text-[0.6875rem] text-faint">
 					{node.ordinal}
 				</span>
@@ -311,8 +408,8 @@ function Box({
 					<span
 						className={cx(
 							'line-clamp-2 text-[0.8125rem] leading-snug',
-							node.title === '' ? 'text-faint italic' : 'text-ink',
-							root && 'font-medium',
+							subject.kind === 'article' && 'font-medium',
+							subject.kind === 'reference' ? 'text-muted' : 'text-ink',
 						)}
 					>
 						{title}
@@ -322,29 +419,33 @@ function Box({
 						aria-expanded={open}
 						className={cx(
 							'line-clamp-2 text-left text-[0.8125rem] leading-snug',
-							node.title === '' ? 'text-faint italic' : 'text-ink',
+							untitled ? 'text-faint italic' : 'text-ink',
 						)}
-						onClick={onOpen}
+						onClick={(event) => {
+							event.stopPropagation()
+							onOpen()
+						}}
 						type="button"
 					>
 						{title}
 					</button>
 				)}
 
-				{target === undefined && node.node?.intent === undefined ? null : (
+				{subject.kind === 'reference' ? (
+					<span className="label-meta truncate">{referenceMark(subject)}</span>
+				) : null}
+
+				{target === undefined && intent === undefined ? null : (
 					<span className="flex min-w-0 items-baseline gap-1.5 text-[0.6875rem] text-muted">
 						{target === undefined ? null : (
 							<span className="shrink-0 font-mono text-faint">{target}w</span>
 						)}
-						{node.node?.intent === undefined ? null : (
-							<span className="truncate">{node.node.intent}</span>
-						)}
+						{intent === undefined ? null : <span className="truncate">{intent}</span>}
 					</span>
 				)}
 
-				{/* The References placed here, by the numbers the Panel marks them
-				    with — a footnote number rather than anything stored. One text
-				    node rather than one per number, so it reads as a single line. */}
+				{/* Only where the References are not boxes of their own — otherwise
+				    the map would say the same placement twice. */}
 				{node.referenceNumbers.length === 0 ? null : (
 					<span className="truncate font-mono text-[0.625rem] text-faint">
 						{`refs ${node.referenceNumbers.map((number) => `[${number}]`).join(' ')}`}
@@ -355,40 +456,44 @@ function Box({
 			{/* The two controls about this box's children, on the edge the children
 			    hang off. Stacked rather than side by side, which costs the title
 			    one column of width instead of two. */}
-			<div className="flex h-full shrink-0 flex-col items-end justify-between">
-				{node.childCount === 0 || onFold === undefined ? (
-					<span />
-				) : (
-					<button
-						aria-expanded={!folded}
-						aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
-						className={CONTROL}
-						onClick={(event) => {
-							event.stopPropagation()
-							onFold()
-						}}
-						type="button"
-					>
-						{folded ? node.childCount : '–'}
-					</button>
-				)}
+			{onFold === undefined && onAdd === undefined ? null : (
+				<div className="flex h-full shrink-0 flex-col items-end justify-between">
+					{node.childCount === 0 || onFold === undefined ? (
+						<span />
+					) : (
+						<button
+							aria-expanded={!folded}
+							aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
+							className={CONTROL}
+							onClick={(event) => {
+								event.stopPropagation()
+								onFold()
+							}}
+							type="button"
+						>
+							{folded ? node.childCount : '–'}
+						</button>
+					)}
 
-				{onAdd === undefined ? null : (
-					<button
-						aria-label={
-							root ? 'Add a Section to the Outline' : `Add a Section inside ${title}`
-						}
-						className={CONTROL}
-						onClick={(event) => {
-							event.stopPropagation()
-							onAdd()
-						}}
-						type="button"
-					>
-						+
-					</button>
-				)}
-			</div>
+					{onAdd === undefined ? null : (
+						<button
+							aria-label={
+								subject.kind === 'article'
+									? 'Add a Section to the Outline'
+									: `Add a Section inside ${title}`
+							}
+							className={CONTROL}
+							onClick={(event) => {
+								event.stopPropagation()
+								onAdd()
+							}}
+							type="button"
+						>
+							+
+						</button>
+					)}
+				</div>
+			)}
 		</div>
 	)
 }

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 
 import type { Plan, ProposalInput } from '../../shared/plan'
 import { cx } from '../lib/cx'
+import { addSection } from './edits'
 import type { MapNode, MapOptions } from './map'
 import { planMap } from './map'
 import { outlineEntries } from './outline'
@@ -90,6 +91,35 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 			return next
 		})
 
+	/**
+	 * A new Section inside the box that was clicked, last among what is already
+	 * there. On the root that is a Section, and on a Section it is a Subsection —
+	 * which is the nesting the Panel cannot reach, because `AddSection` anchors
+	 * every choice it offers at the top level.
+	 *
+	 * A Subsection takes none: two levels is what the interface offers, and
+	 * anything deeper wants a word the writer already holds rather than a more
+	 * recursive one — `context.md` §Subsection.
+	 *
+	 * It opens on arrival, the way the Panel opens one the writer just added, so
+	 * the caret is already in the title.
+	 */
+	const add = (parentId: string | null) => {
+		const id = crypto.randomUUID()
+		edit(addSection({ parentId, beforeId: null }, id))
+
+		// A child of a folded Section would land undrawn, so adding one opens it.
+		if (parentId !== null) {
+			setCollapsed((held) => {
+				const next = new Set(held)
+				next.delete(parentId)
+
+				return next
+			})
+		}
+		setOpenId(id)
+	}
+
 	// A folded Section can hold the open one, and a Section can be deleted from
 	// its own detail. Either leaves `openId` naming a box that is not drawn, so
 	// the open node is looked up in what was laid out rather than in the Plan.
@@ -163,8 +193,12 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 								folded={node.collapsed}
 								lit={onPath.has(node.key)}
 								node={node}
+								// A Subsection is as deep as the interface goes, so it takes no
+								// `+`. Depth 0 is the title and 1 is a Section, and both do.
+								onAdd={node.depth >= 2 ? undefined : () => add(node.nodeId)}
 								// The root is the Article title rather than a Section, so it
-								// folds nothing and has no Section fields to open.
+								// folds nothing and has no Section fields to open. It still
+								// takes a new Section, which is what `onAdd` gives it.
 								onFold={node.nodeId === null ? undefined : () => fold(node.nodeId!)}
 								onLeave={() => setLit((held) => (held === node.key ? null : held))}
 								onLight={() => setLit(node.key)}
@@ -178,7 +212,11 @@ export function PlanMap({ plan, edit, padding = 12, layout, className }: PlanMap
 				{detail === null ? null : (
 					<div
 						ref={measure}
-						className="absolute z-10 rounded-md shadow-frame"
+						// Grows out of the box's own top-left corner, which is where the
+						// writer clicked, so the fields read as that box opening rather than
+						// as a card arriving from nowhere. `starting:` is the opening state
+						// of a newly mounted element — @starting-style.
+						className="absolute z-10 origin-top-left scale-100 rounded-md opacity-100 shadow-frame transition-[opacity,transform] duration-150 ease-out motion-reduce:transition-none starting:scale-95 starting:opacity-0"
 						style={{
 							left: detail.node.x + padding,
 							top: detail.node.y + padding,
@@ -212,6 +250,9 @@ interface BoxProps {
 	onFold?: () => void
 	/** Absent at the root, which has no Section fields to open. */
 	onOpen?: () => void
+	/** Make a Section inside this one. Absent on a Subsection, which is as deep
+	 * as the interface goes. */
+	onAdd?: () => void
 	onLight: () => void
 	onLeave: () => void
 }
@@ -221,11 +262,23 @@ interface BoxProps {
  * the row it is in the Panel — number, title, target, intent note, References.
  *
  * The whole box opens the Section, and the title carries that as a real button
- * so it is reachable by keyboard and named to a screen reader. The fold control
- * stops the click going any further: it changes what the map draws, and the box
- * around it changes what the writer is editing.
+ * so it is reachable by keyboard and named to a screen reader.
+ *
+ * The right edge holds what the box says about its children: fold what is
+ * already inside, and add one more. Both stop the click going any further,
+ * because the box around them opens what the writer is editing instead.
  */
-function Box({ node, lit, folded, open, onFold, onOpen, onLight, onLeave }: BoxProps) {
+function Box({
+	node,
+	lit,
+	folded,
+	open,
+	onFold,
+	onOpen,
+	onAdd,
+	onLight,
+	onLeave,
+}: BoxProps) {
 	const root = node.nodeId === null
 	const title =
 		node.title === '' ? (root ? 'Untitled article' : 'Untitled section') : node.title
@@ -290,31 +343,57 @@ function Box({ node, lit, folded, open, onFold, onOpen, onLight, onLeave }: BoxP
 				)}
 
 				{/* The References placed here, by the numbers the Panel marks them
-				    with — a footnote number rather than anything stored. */}
+				    with — a footnote number rather than anything stored. One text
+				    node rather than one per number, so it reads as a single line. */}
 				{node.referenceNumbers.length === 0 ? null : (
-					<span className="flex min-w-0 items-baseline gap-1 font-mono text-[0.625rem] text-faint">
-						<span className="shrink-0">refs</span>
-						{node.referenceNumbers.map((number) => (
-							<span key={number}>[{number}]</span>
-						))}
+					<span className="truncate font-mono text-[0.625rem] text-faint">
+						{`refs ${node.referenceNumbers.map((number) => `[${number}]`).join(' ')}`}
 					</span>
 				)}
 			</div>
 
-			{node.childCount === 0 || onFold === undefined ? null : (
-				<button
-					aria-expanded={!folded}
-					aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
-					className="mt-px shrink-0 rounded-full border border-edge px-1 font-mono text-[0.625rem] leading-[1.05rem] text-muted hover:border-ink hover:text-ink"
-					onClick={(event) => {
-						event.stopPropagation()
-						onFold()
-					}}
-					type="button"
-				>
-					{folded ? node.childCount : '–'}
-				</button>
-			)}
+			{/* The two controls about this box's children, on the edge the children
+			    hang off. Stacked rather than side by side, which costs the title
+			    one column of width instead of two. */}
+			<div className="flex h-full shrink-0 flex-col items-end justify-between">
+				{node.childCount === 0 || onFold === undefined ? (
+					<span />
+				) : (
+					<button
+						aria-expanded={!folded}
+						aria-label={`${folded ? 'Open' : 'Fold'} the ${node.childCount} inside ${title}`}
+						className={CONTROL}
+						onClick={(event) => {
+							event.stopPropagation()
+							onFold()
+						}}
+						type="button"
+					>
+						{folded ? node.childCount : '–'}
+					</button>
+				)}
+
+				{onAdd === undefined ? null : (
+					<button
+						aria-label={
+							root ? 'Add a Section to the Outline' : `Add a Section inside ${title}`
+						}
+						className={CONTROL}
+						onClick={(event) => {
+							event.stopPropagation()
+							onAdd()
+						}}
+						type="button"
+					>
+						+
+					</button>
+				)}
+			</div>
 		</div>
 	)
 }
+
+/** Both edge controls, which are the same target at the same weight: quiet
+ * until the pointer or the caret reaches them. */
+const CONTROL =
+	'shrink-0 rounded-full border border-edge px-1 font-mono text-[0.625rem] leading-[1.05rem] text-muted transition-colors hover:border-ink hover:text-ink'

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -11,10 +11,13 @@ import { AddSection } from './AddSection'
 import type { SectionAnchor } from './edits'
 import { addSection, setAdjectives, setTarget, setTitle, setVoice } from './edits'
 import { outlineEntries } from './outline'
+import { PlanMap } from './PlanMap'
 import { ReferenceList } from './ReferenceList'
 import { refusalText } from './refusalText'
 import { SectionRow } from './SectionRow'
 import { ToneFields } from './ToneFields'
+import type { OutlineView } from './ViewRail'
+import { ViewRail } from './ViewRail'
 import { AllocationNote, TargetField } from './WordCount'
 
 /**
@@ -49,6 +52,9 @@ export function PlanPanel({
 	const [openId, setOpenId] = useState<string | null>(null)
 	const [made, setMade] = useState<string | null>(null)
 	const [accented, setAccented] = useState<string | null>(null)
+	// Which View of the Outline is up. It belongs to the Panel rather than to
+	// the Plan: it is a way of looking, and the Article carries no memory of it.
+	const [view, setView] = useState<OutlineView>('list')
 
 	// Held: the accented row's effect lists it, and a new function each render
 	// would restart that row's scroll on every keystroke elsewhere in the Panel.
@@ -106,13 +112,23 @@ export function PlanPanel({
 				voice={plan.voice ?? null}
 			/>
 
-			<GroupHeading count={plan.outline.length}>Outline</GroupHeading>
+			<GroupHeading
+				actions={<ViewRail onView={setView} view={view} />}
+				count={plan.outline.length}
+			>
+				Outline
+			</GroupHeading>
 
-			{entries.length === 0 ? (
+			{entries.length === 0 && view === 'list' ? (
 				<EmptySlot className="min-h-[3.5rem]">
 					Sections appear as you agree on them in the Chat — and you can write your own
 					straight in here
 				</EmptySlot>
+			) : view === 'map' ? (
+				// The map carries its own `+` on the Article title, and draws the
+				// References itself, so the Panel's own two controls stand down while
+				// it is up rather than offering a second way to the same op.
+				<PlanMap edit={edit} plan={plan} />
 			) : (
 				<div className="flex items-start gap-3.5">
 					<div className="flex min-w-0 flex-1 flex-col gap-1.5">
@@ -135,9 +151,11 @@ export function PlanPanel({
 				</div>
 			)}
 
-			<div className="flex">
-				<AddSection onAdd={add} outline={plan.outline} />
-			</div>
+			{view === 'map' ? null : (
+				<div className="flex">
+					<AddSection onAdd={add} outline={plan.outline} />
+				</div>
+			)}
 
 			<GroupHeading count={plan.references.length}>References</GroupHeading>
 			<ReferenceList

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -56,6 +56,15 @@ export function PlanPanel({
 	// the Plan: it is a way of looking, and the Article carries no memory of it.
 	const [view, setView] = useState<OutlineView>('list')
 
+	// Changing View puts the open Section away, rather than leaving it open
+	// behind the other View. Reaching for the rail already blurs the open row,
+	// which closes it; this says so outright instead of resting on that.
+	const showView = (next: OutlineView) => {
+		setView(next)
+		setOpenId(null)
+		setMade(null)
+	}
+
 	// Held: the accented row's effect lists it, and a new function each render
 	// would restart that row's scroll on every keystroke elsewhere in the Panel.
 	const clearAccent = useCallback(() => setAccented(null), [])
@@ -113,7 +122,7 @@ export function PlanPanel({
 			/>
 
 			<GroupHeading
-				actions={<ViewRail onView={setView} view={view} />}
+				actions={<ViewRail onView={showView} view={view} />}
 				count={plan.outline.length}
 			>
 				Outline

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -119,16 +119,15 @@ export function PlanPanel({
 				Outline
 			</GroupHeading>
 
-			{entries.length === 0 && view === 'list' ? (
+			{view === 'map' ? (
+				// The map carries a `+` on the Article title and draws the References
+				// itself, so the Panel's two Outline controls stand down while it is up.
+				<PlanMap edit={edit} plan={plan} />
+			) : entries.length === 0 ? (
 				<EmptySlot className="min-h-[3.5rem]">
 					Sections appear as you agree on them in the Chat — and you can write your own
 					straight in here
 				</EmptySlot>
-			) : view === 'map' ? (
-				// The map carries its own `+` on the Article title, and draws the
-				// References itself, so the Panel's own two controls stand down while
-				// it is up rather than offering a second way to the same op.
-				<PlanMap edit={edit} plan={plan} />
 			) : (
 				<div className="flex items-start gap-3.5">
 					<div className="flex min-w-0 flex-1 flex-col gap-1.5">

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -52,13 +52,10 @@ export function PlanPanel({
 	const [openId, setOpenId] = useState<string | null>(null)
 	const [made, setMade] = useState<string | null>(null)
 	const [accented, setAccented] = useState<string | null>(null)
-	// Which View of the Outline is up. It belongs to the Panel rather than to
-	// the Plan: it is a way of looking, and the Article carries no memory of it.
+	// Not in the Plan: the Article carries no memory of which View was up.
 	const [view, setView] = useState<OutlineView>('list')
 
-	// Changing View puts the open Section away, rather than leaving it open
-	// behind the other View. Reaching for the rail already blurs the open row,
-	// which closes it; this says so outright instead of resting on that.
+	/** Shows a View, closing whatever Section the last one had open. */
 	const showView = (next: OutlineView) => {
 		setView(next)
 		setOpenId(null)
@@ -129,8 +126,7 @@ export function PlanPanel({
 			</GroupHeading>
 
 			{view === 'map' ? (
-				// The map carries a `+` on the Article title and draws the References
-				// itself, so the Panel's two Outline controls stand down while it is up.
+				// The map carries its own `+` and draws the References itself.
 				<PlanMap edit={edit} plan={plan} />
 			) : entries.length === 0 ? (
 				<EmptySlot className="min-h-[3.5rem]">

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react'
 import type { Plan, ProposalInput } from '../../shared/plan'
 import { nodeAllocation, resolveNodeScope } from '../../shared/plan'
 import { Button } from '../components/Button'
-import { InlineInput, TextField } from '../components/Field'
+import { FieldRow, InlineInput, TextField } from '../components/Field'
 import { OutlineRow } from '../components/OutlineRow'
 import { cx } from '../lib/cx'
 import {
@@ -18,6 +18,7 @@ import {
 } from './edits'
 import type { OutlineEntry } from './outline'
 import { depthName, outlineEntries, sectionLabel } from './outline'
+import type { ReferenceEntry } from './references'
 import {
 	referenceEntries,
 	referenceMark,
@@ -75,6 +76,11 @@ export function SectionRow({
 	const row = useRef<HTMLDivElement>(null)
 
 	const placed = referencesAt(plan, node.id)
+	// What the picker could offer: a Reference sits at one Section, so anything
+	// not already here can be moved here. With none, the row has nothing to say.
+	const offerable = referenceEntries(plan).filter(
+		(entry) => entry.reference.nodeId !== node.id,
+	)
 
 	// Opening a Section puts the caret in its title. Without it the focus stays
 	// on the closed row's button, which this row has just replaced — so it falls
@@ -94,9 +100,9 @@ export function SectionRow({
 		onOpen(null)
 	}
 
-	const references =
+	const placedList =
 		placed.length === 0 ? null : (
-			<div className="flex flex-col gap-0.5 pl-[1.375rem]">
+			<div className="flex flex-col gap-0.5">
 				{placed.map((held) => (
 					<button
 						key={held.reference.id}
@@ -136,7 +142,7 @@ export function SectionRow({
 						</p>
 					) : null}
 				</button>
-				{references}
+				{placedList === null ? null : <div className="pl-[1.375rem]">{placedList}</div>}
 			</div>
 		)
 	}
@@ -208,17 +214,36 @@ export function SectionRow({
 					value={node.intent ?? ''}
 				/>
 
-				<ToneFields
-					adjectives={node.adjectives ?? []}
-					onAdjectives={(adjectives) => edit(setAdjectives(plan, node.id, adjectives))}
-					onVoice={(voice) => edit(setVoice(plan, node.id, voice))}
-					resolved={resolved}
-					scopeName={scopeName}
-					voice={node.voice ?? null}
-				/>
+				{/* Voice, Adjectives, and References are one run of minor fields, so
+				    they sit in one column at one rhythm rather than as a block and a
+				    stray row beneath it. */}
+				<div className="flex flex-col gap-1.5">
+					<ToneFields
+						adjectives={node.adjectives ?? []}
+						onAdjectives={(adjectives) => edit(setAdjectives(plan, node.id, adjectives))}
+						onVoice={(voice) => edit(setVoice(plan, node.id, voice))}
+						resolved={resolved}
+						scopeName={scopeName}
+						voice={node.voice ?? null}
+					/>
 
-				{references}
-				<PlaceReference edit={edit} nodeId={node.id} plan={plan} scopeName={scopeName} />
+					{placedList === null && offerable.length === 0 ? null : (
+						<FieldRow className="items-start" label="References">
+							{/* Stretched, not `items-start`: a placed Reference has to be
+							    allowed to shrink before `truncate` will cut it. */}
+							<div className="flex flex-col gap-0.5">
+								{placedList}
+								<PlaceReference
+									edit={edit}
+									nodeId={node.id}
+									offerable={offerable}
+									plan={plan}
+									scopeName={scopeName}
+								/>
+							</div>
+						</FieldRow>
+					)}
+				</div>
 
 				<div className="flex flex-wrap items-center gap-1.5 pt-0.5">
 					<Button
@@ -269,6 +294,8 @@ export function SectionRow({
 interface PlaceReferenceProps {
 	plan: Plan
 	nodeId: string
+	/** Every Reference not already here, worked out by the row. */
+	offerable: ReferenceEntry[]
 	edit: (ops: ProposalInput | null) => void
 	/** "Section 2", for the control's name. */
 	scopeName: string
@@ -282,27 +309,31 @@ interface PlaceReferenceProps {
  *
  * A Reference sits at one Section, so picking one placed elsewhere moves it.
  */
-function PlaceReference({ plan, nodeId, edit, scopeName }: PlaceReferenceProps) {
-	const options = referenceEntries(plan).filter(
-		(entry) => entry.reference.nodeId !== nodeId,
-	)
-
+function PlaceReference({
+	plan,
+	nodeId,
+	offerable,
+	edit,
+	scopeName,
+}: PlaceReferenceProps) {
 	// Nothing to offer: every Reference the Plan holds already sits here.
-	if (options.length === 0) return null
+	if (offerable.length === 0) return null
 
 	const placed = new Map(
 		outlineEntries(plan.outline).map((entry) => [entry.node.id, sectionLabel(entry)]),
 	)
 
 	return (
+		// Styled as `InlineInput` is, so it reads as the same kind of control as
+		// the Adjective field beside it: faint until the writer reaches for it.
 		<select
 			aria-label={`Place a Reference at ${scopeName}`}
-			className="h-7 w-full rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-muted"
+			className="min-w-0 appearance-none self-start rounded-sm border-b border-transparent bg-transparent text-[0.6875rem] text-faint outline-none hover:border-edge focus:border-edge"
 			onChange={(event) => edit(placeReference(plan, event.target.value, nodeId))}
 			value=""
 		>
-			<option value="">place a reference…</option>
-			{options.map((entry) => (
+			<option value="">+ reference</option>
+			{offerable.map((entry) => (
 				<option key={entry.reference.id} value={entry.reference.id}>
 					{referenceMark(entry)} {referenceName(entry.reference)}
 					{entry.reference.nodeId === null

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -9,6 +9,7 @@ import { cx } from '../lib/cx'
 import {
 	deleteSection,
 	moveSection,
+	placeReference,
 	setAdjectives,
 	setIntent,
 	setTarget,
@@ -16,8 +17,13 @@ import {
 	setVoice,
 } from './edits'
 import type { OutlineEntry } from './outline'
-import { depthName } from './outline'
-import { referenceMark, referenceName, referencesAt } from './references'
+import { depthName, outlineEntries, sectionLabel } from './outline'
+import {
+	referenceEntries,
+	referenceMark,
+	referenceName,
+	referencesAt,
+} from './references'
 import { ToneFields } from './ToneFields'
 import { AllocationNote, TargetField } from './WordCount'
 
@@ -30,9 +36,10 @@ import { AllocationNote, TargetField } from './WordCount'
  * The row keeps its id through every operation here — a reorder anchors on the
  * neighbour it swaps with, and nothing regenerates an id.
  *
- * **Subsections are TBD.** The Plan carries them and this row renders one, but
- * the Panel offers no control that makes, nests, or lifts one. The Outline is
- * flat until the flat one is smooth.
+ * **The Panel still makes no Subsection.** The Plan carries them and this row
+ * renders one, but no control in the Panel nests or lifts one: `AddSection`
+ * anchors every choice it offers at the top level. The Map View's `+` makes one,
+ * because a map draws nesting and a list does not.
  */
 
 export interface SectionRowProps {
@@ -212,8 +219,9 @@ export function SectionRow({
 				/>
 
 				{references}
+				<PlaceReference edit={edit} nodeId={node.id} plan={plan} scopeName={scopeName} />
 
-				<div className="flex items-center gap-1.5 pt-0.5">
+				<div className="flex flex-wrap items-center gap-1.5 pt-0.5">
 					<Button
 						aria-label={`Move ${scopeName} up`}
 						disabled={index === 0}
@@ -255,6 +263,92 @@ export function SectionRow({
 					</Button>
 				</div>
 			</div>
+		</div>
+	)
+}
+
+interface PlaceReferenceProps {
+	plan: Plan
+	nodeId: string
+	edit: (ops: ProposalInput | null) => void
+	/** "Section 2", for the sentence the picker asks. */
+	scopeName: string
+}
+
+/**
+ * Placing a Reference from the Section's side. The References list places one
+ * from its own side, with the `<select>` on each row; both build the same
+ * `placeReference` op, so neither is a second way of storing where a Reference
+ * sits.
+ *
+ * A Reference sits at one Section, so picking one that is placed elsewhere
+ * moves it. The row says where it is now, and nothing is offered twice.
+ */
+function PlaceReference({ plan, nodeId, edit, scopeName }: PlaceReferenceProps) {
+	const [asking, setAsking] = useState(false)
+
+	const placed = new Map(
+		outlineEntries(plan.outline).map((entry) => [entry.node.id, sectionLabel(entry)]),
+	)
+	const options = referenceEntries(plan).filter(
+		(entry) => entry.reference.nodeId !== nodeId,
+	)
+
+	// Nothing to offer: every Reference the Plan holds already sits here.
+	if (options.length === 0) return null
+
+	if (!asking) {
+		return (
+			<Button
+				className="self-start"
+				onClick={() => setAsking(true)}
+				size="sm"
+				variant="quiet"
+			>
+				place a reference
+			</Button>
+		)
+	}
+
+	return (
+		<div
+			className="flex flex-col items-start gap-1 rounded-md border border-edge bg-sunk p-2"
+			onKeyDown={(event) => {
+				if (event.key !== 'Escape') return
+				event.stopPropagation()
+				setAsking(false)
+			}}
+		>
+			<p className="label-meta text-muted">Place which Reference at {scopeName}?</p>
+
+			{options.map((entry) => (
+				<button
+					key={entry.reference.id}
+					className="flex w-full items-baseline gap-1.5 truncate rounded-md border border-edge bg-surface px-2 py-1.5 text-left text-[0.75rem] text-ink hover:border-ink/40 hover:bg-hush"
+					onClick={() => {
+						setAsking(false)
+						edit(placeReference(plan, entry.reference.id, nodeId))
+					}}
+					type="button"
+				>
+					<span className="label-meta shrink-0">{referenceMark(entry)}</span>
+					<span className="truncate">{referenceName(entry.reference)}</span>
+					{entry.reference.nodeId === null ? null : (
+						<span className="ml-auto shrink-0 text-[0.6875rem] text-faint">
+							now at {placed.get(entry.reference.nodeId) ?? '—'}
+						</span>
+					)}
+				</button>
+			))}
+
+			<Button
+				className="self-end"
+				onClick={() => setAsking(false)}
+				size="sm"
+				variant="quiet"
+			>
+				cancel
+			</Button>
 		</div>
 	)
 }

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -36,10 +36,9 @@ import { AllocationNote, TargetField } from './WordCount'
  * The row keeps its id through every operation here — a reorder anchors on the
  * neighbour it swaps with, and nothing regenerates an id.
  *
- * **The Panel still makes no Subsection.** The Plan carries them and this row
- * renders one, but no control in the Panel nests or lifts one: `AddSection`
- * anchors every choice it offers at the top level. The Map View's `+` makes one,
- * because a map draws nesting and a list does not.
+ * **Subsections are TBD.** The Plan carries them and this row renders one, but
+ * no control in the app makes, nests, or lifts one — every anchor on offer sits
+ * at the top level. The Outline is flat until the flat one is smooth.
  */
 
 export interface SectionRowProps {
@@ -271,44 +270,19 @@ interface PlaceReferenceProps {
 	plan: Plan
 	nodeId: string
 	edit: (ops: ProposalInput | null) => void
-	/** "Section 2", for the sentence the picker asks. */
+	/** "Section 2", for the control's name. */
 	scopeName: string
 }
 
 /**
- * Placing a Reference from the Section's side. The References list places one
- * from its own side, with the `<select>` on each row; both build the same
- * `placeReference` op, so neither is a second way of storing where a Reference
- * sits.
+ * Placing a Reference from the Section's side, as a picker of what to put here.
+ * `ReferenceList` places one from the Reference's side, with a `<select>` of
+ * Sections on each row; both build the same `placeReference` op, and both are
+ * that same control turned round, so neither reads as a different kind of act.
  *
- * A Reference sits at one Section, so picking one that is placed elsewhere
- * moves it. The row says where it is now, and nothing is offered twice.
+ * A Reference sits at one Section, so picking one placed elsewhere moves it.
  */
 function PlaceReference({ plan, nodeId, edit, scopeName }: PlaceReferenceProps) {
-	const [asking, setAsking] = useState(false)
-	const trigger = useRef<HTMLButtonElement>(null)
-	const wasAsking = useRef(false)
-
-	// Coming back from the picker, the caret returns to the control that opened
-	// it. The row it was on has gone, so focus would otherwise fall to the page
-	// — where Escape has nothing to close and the row cannot tell it has been
-	// left. Guarded on having been open, so this does not take the caret off the
-	// title when the Section first opens.
-	useEffect(() => {
-		if (asking) {
-			wasAsking.current = true
-
-			return
-		}
-		if (!wasAsking.current) return
-
-		wasAsking.current = false
-		trigger.current?.focus()
-	}, [asking])
-
-	const placed = new Map(
-		outlineEntries(plan.outline).map((entry) => [entry.node.id, sectionLabel(entry)]),
-	)
 	const options = referenceEntries(plan).filter(
 		(entry) => entry.reference.nodeId !== nodeId,
 	)
@@ -316,59 +290,26 @@ function PlaceReference({ plan, nodeId, edit, scopeName }: PlaceReferenceProps) 
 	// Nothing to offer: every Reference the Plan holds already sits here.
 	if (options.length === 0) return null
 
-	if (!asking) {
-		return (
-			<Button
-				ref={trigger}
-				className="self-start"
-				onClick={() => setAsking(true)}
-				size="sm"
-				variant="quiet"
-			>
-				place a reference
-			</Button>
-		)
-	}
+	const placed = new Map(
+		outlineEntries(plan.outline).map((entry) => [entry.node.id, sectionLabel(entry)]),
+	)
 
 	return (
-		<div
-			className="flex flex-col items-start gap-1 rounded-md border border-edge bg-sunk p-2"
-			onKeyDown={(event) => {
-				if (event.key !== 'Escape') return
-				event.stopPropagation()
-				setAsking(false)
-			}}
+		<select
+			aria-label={`Place a Reference at ${scopeName}`}
+			className="h-7 w-full rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-muted"
+			onChange={(event) => edit(placeReference(plan, event.target.value, nodeId))}
+			value=""
 		>
-			<p className="label-meta text-muted">Place which Reference at {scopeName}?</p>
-
+			<option value="">place a reference…</option>
 			{options.map((entry) => (
-				<button
-					key={entry.reference.id}
-					className="flex w-full items-baseline gap-1.5 truncate rounded-md border border-edge bg-surface px-2 py-1.5 text-left text-[0.75rem] text-ink hover:border-ink/40 hover:bg-hush"
-					onClick={() => {
-						setAsking(false)
-						edit(placeReference(plan, entry.reference.id, nodeId))
-					}}
-					type="button"
-				>
-					<span className="label-meta shrink-0">{referenceMark(entry)}</span>
-					<span className="truncate">{referenceName(entry.reference)}</span>
-					{entry.reference.nodeId === null ? null : (
-						<span className="ml-auto shrink-0 text-[0.6875rem] text-faint">
-							now at {placed.get(entry.reference.nodeId) ?? '—'}
-						</span>
-					)}
-				</button>
+				<option key={entry.reference.id} value={entry.reference.id}>
+					{referenceMark(entry)} {referenceName(entry.reference)}
+					{entry.reference.nodeId === null
+						? ''
+						: ` — now at ${placed.get(entry.reference.nodeId) ?? '—'}`}
+				</option>
 			))}
-
-			<Button
-				className="self-end"
-				onClick={() => setAsking(false)}
-				size="sm"
-				variant="quiet"
-			>
-				cancel
-			</Button>
-		</div>
+		</select>
 	)
 }

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -286,6 +286,25 @@ interface PlaceReferenceProps {
  */
 function PlaceReference({ plan, nodeId, edit, scopeName }: PlaceReferenceProps) {
 	const [asking, setAsking] = useState(false)
+	const trigger = useRef<HTMLButtonElement>(null)
+	const wasAsking = useRef(false)
+
+	// Coming back from the picker, the caret returns to the control that opened
+	// it. The row it was on has gone, so focus would otherwise fall to the page
+	// — where Escape has nothing to close and the row cannot tell it has been
+	// left. Guarded on having been open, so this does not take the caret off the
+	// title when the Section first opens.
+	useEffect(() => {
+		if (asking) {
+			wasAsking.current = true
+
+			return
+		}
+		if (!wasAsking.current) return
+
+		wasAsking.current = false
+		trigger.current?.focus()
+	}, [asking])
 
 	const placed = new Map(
 		outlineEntries(plan.outline).map((entry) => [entry.node.id, sectionLabel(entry)]),
@@ -300,6 +319,7 @@ function PlaceReference({ plan, nodeId, edit, scopeName }: PlaceReferenceProps) 
 	if (!asking) {
 		return (
 			<Button
+				ref={trigger}
 				className="self-start"
 				onClick={() => setAsking(true)}
 				size="sm"

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -52,9 +52,8 @@ export interface SectionRowProps {
 	onOpen: (nodeId: string | null) => void
 	/** Take the caret, because the writer just made this Section. */
 	takeCaret?: boolean
-	/** Show a Reference placed here, down in the References list. Absent where
-	 * the caller has no such list — the Map View — and the name then reads as
-	 * text rather than as a control that does nothing. */
+	/** Scrolls to a placed Reference. Can be absent when the caller draws no
+	 * References list; the name then reads as text. */
 	onShowReference?: (referenceId: string) => void
 	className?: string
 }
@@ -77,19 +76,15 @@ export function SectionRow({
 	const title = useRef<HTMLInputElement>(null)
 	const row = useRef<HTMLDivElement>(null)
 
-	const placed = referencesAt(plan, node.id)
-	// Taking a Reference off this Section, the way × takes an Adjective off it.
-	// Placing it elsewhere is the picker's job; this only says "not here".
-	const unplace = (referenceId: string) => edit(placeReference(plan, referenceId, null))
-	// What the picker could offer: a Reference sits at one Section, so anything
-	// not already here can be moved here. With none, the row has nothing to say.
-	const offerable = referenceEntries(plan).filter(
+	const placedReferences = referencesAt(plan, node.id)
+	const unplaceReference = (referenceId: string) =>
+		edit(placeReference(plan, referenceId, null))
+	const offerableReferences = referenceEntries(plan).filter(
 		(entry) => entry.reference.nodeId !== node.id,
 	)
 
-	// Opening a Section puts the caret in its title. Without it the focus stays
-	// on the closed row's button, which this row has just replaced — so it falls
-	// to the page, and Escape has nothing to close.
+	// Opening a Section puts the caret in its title: the closed row's button has
+	// just been replaced, so focus would otherwise fall to the page.
 	useEffect(() => {
 		if (!open) return
 
@@ -97,8 +92,7 @@ export function SectionRow({
 		if (takeCaret) row.current?.scrollIntoView({ block: 'nearest' })
 	}, [open, takeCaret])
 
-	/** Enter is done. Nothing is lost by leaving — the Section reopens on a
-	 * click, and the write has already gone. */
+	/** Enter closes the Section. The write has already gone. */
 	const doneOnEnter = (event: { key: string; preventDefault: () => void }) => {
 		if (event.key !== 'Enter') return
 		event.preventDefault()
@@ -106,9 +100,9 @@ export function SectionRow({
 	}
 
 	const placedList =
-		placed.length === 0 ? null : (
+		placedReferences.length === 0 ? null : (
 			<div className="flex flex-col gap-0.5">
-				{placed.map((held) => (
+				{placedReferences.map((held) => (
 					<span
 						key={held.reference.id}
 						className="flex w-full items-baseline gap-1.5 text-[0.6875rem] text-muted"
@@ -127,16 +121,14 @@ export function SectionRow({
 								{referenceName(held.reference)}
 							</button>
 						)}
-						{unplace === undefined ? null : (
-							<button
-								aria-label={`Take ${referenceName(held.reference)} off ${scopeName}`}
-								className="shrink-0 text-faint hover:text-ink"
-								onClick={() => unplace(held.reference.id)}
-								type="button"
-							>
-								×
-							</button>
-						)}
+						<button
+							aria-label={`Take ${referenceName(held.reference)} off ${scopeName}`}
+							className="shrink-0 text-faint hover:text-ink"
+							onClick={() => unplaceReference(held.reference.id)}
+							type="button"
+						>
+							×
+						</button>
 					</span>
 				))}
 			</div>
@@ -151,9 +143,8 @@ export function SectionRow({
 				<button
 					className="-mx-1.5 rounded-md border border-transparent px-1.5 py-1 text-left hover:border-edge hover:bg-surface"
 					onClick={() => onOpen(node.id)}
-					// Opening on mousedown, because the Section that is open closes on
-					// the focus leaving it — which relays out the list and moves this
-					// row out from under the pointer before the click lands.
+					// On mousedown: the open Section closes on blur, which relays the
+					// list and moves this row before a click would land.
 					onMouseDown={(event) => {
 						event.preventDefault()
 						onOpen(node.id)
@@ -184,8 +175,7 @@ export function SectionRow({
 			)}
 			onBlur={(event) => {
 				// Reaching for another field closes this Section. A blur with nowhere
-				// to go — clicking the page, or the row being moved in the list — is
-				// not the writer leaving, so it does not close anything.
+				// to go is not the writer leaving.
 				const to = event.relatedTarget
 				if (to !== null && !event.currentTarget.contains(to)) onOpen(null)
 			}}
@@ -252,16 +242,15 @@ export function SectionRow({
 						voice={node.voice ?? null}
 					/>
 
-					{/* Not a labelled row like the two above: what is placed here runs
-					    the full width of the card rather than inside the gutter, so the
-					    label and the control take one line and the list takes the rest. */}
-					{placedList === null && offerable.length === 0 ? null : (
+					{/* The label and the picker take one line; what is placed here runs
+					    the full width beneath them. */}
+					{placedList === null && offerableReferences.length === 0 ? null : (
 						<div className="flex flex-col gap-1">
 							<FieldRow label="References">
-								<PlaceReference
+								<SelectReferenceToPlace
 									edit={edit}
 									nodeId={node.id}
-									offerable={offerable}
+									offerableReferences={offerableReferences}
 									plan={plan}
 									scopeName={scopeName}
 								/>
@@ -317,41 +306,31 @@ export function SectionRow({
 	)
 }
 
-interface PlaceReferenceProps {
+interface SelectReferenceToPlaceProps {
 	plan: Plan
 	nodeId: string
-	/** Every Reference not already here, worked out by the row. */
-	offerable: ReferenceEntry[]
+	offerableReferences: ReferenceEntry[]
 	edit: (ops: ProposalInput | null) => void
 	/** "Section 2", for the control's name. */
 	scopeName: string
 }
 
-/**
- * Placing a Reference from the Section's side, as a picker of what to put here.
- * `ReferenceList` places one from the Reference's side, with a `<select>` of
- * Sections on each row; both build the same `placeReference` op, and both are
- * that same control turned round, so neither reads as a different kind of act.
- *
- * A Reference sits at one Section, so picking one placed elsewhere moves it.
- */
-function PlaceReference({
+/** A Reference sits at one Section, so picking one placed elsewhere moves it. */
+function SelectReferenceToPlace({
 	plan,
 	nodeId,
-	offerable,
+	offerableReferences,
 	edit,
 	scopeName,
-}: PlaceReferenceProps) {
-	// Nothing to offer: every Reference the Plan holds already sits here.
-	if (offerable.length === 0) return null
+}: SelectReferenceToPlaceProps) {
+	if (offerableReferences.length === 0) return null
 
 	const placed = new Map(
 		outlineEntries(plan.outline).map((entry) => [entry.node.id, sectionLabel(entry)]),
 	)
 
 	return (
-		// Styled as `InlineInput` is, so it reads as the same kind of control as
-		// the Adjective field beside it: faint until the writer reaches for it.
+		// Styled as `InlineInput` is, to match the Adjective field beside it.
 		<select
 			aria-label={`Place a Reference at ${scopeName}`}
 			className="w-24 appearance-none rounded-sm border-b border-transparent bg-transparent text-[0.6875rem] text-faint outline-none hover:border-edge focus:border-edge"
@@ -359,7 +338,7 @@ function PlaceReference({
 			value=""
 		>
 			<option value="">+ reference</option>
-			{offerable.map((entry) => (
+			{offerableReferences.map((entry) => (
 				<option key={entry.reference.id} value={entry.reference.id}>
 					{referenceMark(entry)} {referenceName(entry.reference)}
 					{entry.reference.nodeId === null

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -52,8 +52,10 @@ export interface SectionRowProps {
 	onOpen: (nodeId: string | null) => void
 	/** Take the caret, because the writer just made this Section. */
 	takeCaret?: boolean
-	/** Show a Reference placed here, down in the References list. */
-	onShowReference: (referenceId: string) => void
+	/** Show a Reference placed here, down in the References list. Absent where
+	 * the caller has no such list — the Map View — and the name then reads as
+	 * text rather than as a control that does nothing. */
+	onShowReference?: (referenceId: string) => void
 	className?: string
 }
 
@@ -76,6 +78,9 @@ export function SectionRow({
 	const row = useRef<HTMLDivElement>(null)
 
 	const placed = referencesAt(plan, node.id)
+	// Taking a Reference off this Section, the way × takes an Adjective off it.
+	// Placing it elsewhere is the picker's job; this only says "not here".
+	const unplace = (referenceId: string) => edit(placeReference(plan, referenceId, null))
 	// What the picker could offer: a Reference sits at one Section, so anything
 	// not already here can be moved here. With none, the row has nothing to say.
 	const offerable = referenceEntries(plan).filter(
@@ -104,15 +109,35 @@ export function SectionRow({
 		placed.length === 0 ? null : (
 			<div className="flex flex-col gap-0.5">
 				{placed.map((held) => (
-					<button
+					<span
 						key={held.reference.id}
-						className="flex items-baseline gap-1.5 truncate text-left text-[0.6875rem] text-muted hover:text-ink"
-						onClick={() => onShowReference(held.reference.id)}
-						type="button"
+						className="flex w-full items-baseline gap-1.5 text-[0.6875rem] text-muted"
 					>
 						<span className="label-meta shrink-0">{referenceMark(held)}</span>
-						<span className="truncate">{referenceName(held.reference)}</span>
-					</button>
+						{onShowReference === undefined ? (
+							<span className="min-w-0 flex-1 truncate">
+								{referenceName(held.reference)}
+							</span>
+						) : (
+							<button
+								className="min-w-0 flex-1 truncate text-left hover:text-ink"
+								onClick={() => onShowReference(held.reference.id)}
+								type="button"
+							>
+								{referenceName(held.reference)}
+							</button>
+						)}
+						{unplace === undefined ? null : (
+							<button
+								aria-label={`Take ${referenceName(held.reference)} off ${scopeName}`}
+								className="shrink-0 text-faint hover:text-ink"
+								onClick={() => unplace(held.reference.id)}
+								type="button"
+							>
+								×
+							</button>
+						)}
+					</span>
 				))}
 			</div>
 		)
@@ -227,12 +252,12 @@ export function SectionRow({
 						voice={node.voice ?? null}
 					/>
 
+					{/* Not a labelled row like the two above: what is placed here runs
+					    the full width of the card rather than inside the gutter, so the
+					    label and the control take one line and the list takes the rest. */}
 					{placedList === null && offerable.length === 0 ? null : (
-						<FieldRow className="items-start" label="References">
-							{/* Stretched, not `items-start`: a placed Reference has to be
-							    allowed to shrink before `truncate` will cut it. */}
-							<div className="flex flex-col gap-0.5">
-								{placedList}
+						<div className="flex flex-col gap-1">
+							<FieldRow label="References">
 								<PlaceReference
 									edit={edit}
 									nodeId={node.id}
@@ -240,8 +265,9 @@ export function SectionRow({
 									plan={plan}
 									scopeName={scopeName}
 								/>
-							</div>
-						</FieldRow>
+							</FieldRow>
+							{placedList}
+						</div>
 					)}
 				</div>
 
@@ -328,7 +354,7 @@ function PlaceReference({
 		// the Adjective field beside it: faint until the writer reaches for it.
 		<select
 			aria-label={`Place a Reference at ${scopeName}`}
-			className="min-w-0 appearance-none self-start rounded-sm border-b border-transparent bg-transparent text-[0.6875rem] text-faint outline-none hover:border-edge focus:border-edge"
+			className="w-24 appearance-none rounded-sm border-b border-transparent bg-transparent text-[0.6875rem] text-faint outline-none hover:border-edge focus:border-edge"
 			onChange={(event) => edit(placeReference(plan, event.target.value, nodeId))}
 			value=""
 		>

--- a/src/client/plan/ToneFields.tsx
+++ b/src/client/plan/ToneFields.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 
 import type { ResolvedScope } from '../../shared/plan'
 import { Chip } from '../components/Chip'
-import { InlineInput, TextField } from '../components/Field'
+import { FieldRow, InlineInput, TextField } from '../components/Field'
 import { cx } from '../lib/cx'
 
 /**
@@ -49,59 +49,56 @@ export function ToneFields({
 		onAdjectives([...adjectives, adjective])
 	}
 
-	// Both labels in one column, so Voice and Adjectives read as the pair they
-	// are rather than as two unrelated fields.
+	// `FieldRow` puts both labels in the same gutter every other minor field
+	// uses, so Voice and Adjectives line up with the References beneath them.
 	return (
-		<div
-			className={cx(
-				'grid grid-cols-[5rem_minmax(0,1fr)] items-center gap-x-2 gap-y-1.5',
-				className,
-			)}
-		>
-			<span className="label-meta text-muted">Voice</span>
-			<TextField
-				hiddenLabel={`Voice for ${scopeName}`}
-				onChange={(typed) => onVoice(typed.trim() === '' ? null : typed)}
-				placeholder={inherited === null ? 'no Voice set' : `${inherited}, inherited`}
-				size="sm"
-				value={voice ?? ''}
-			/>
-
-			<span className="label-meta text-muted">Adjectives</span>
-			<div className="flex flex-wrap items-center gap-1.5">
-				{inheritedAdjectives.map((adjective) => (
-					<Chip key={adjective} dimmed title="inherited" variant="outline">
-						{adjective}
-					</Chip>
-				))}
-				{adjectives.map((adjective) => (
-					<Chip key={adjective}>
-						{adjective}
-						<button
-							aria-label={`Remove ${adjective} from ${scopeName}`}
-							className="text-faint hover:text-ink"
-							onClick={() =>
-								onAdjectives(adjectives.filter((held) => held !== adjective))
-							}
-							type="button"
-						>
-							×
-						</button>
-					</Chip>
-				))}
-				<InlineInput
-					className="w-24 text-[0.6875rem]"
-					label={`Add an Adjective to ${scopeName}`}
-					onChange={setAdding}
-					onKeyDown={(event) => {
-						if (event.key !== 'Enter') return
-						event.preventDefault()
-						add()
-					}}
-					placeholder="+ adjective"
-					value={adding}
+		<div className={cx('flex flex-col gap-1.5', className)}>
+			<FieldRow label="Voice">
+				<TextField
+					hiddenLabel={`Voice for ${scopeName}`}
+					onChange={(typed) => onVoice(typed.trim() === '' ? null : typed)}
+					placeholder={inherited === null ? 'no Voice set' : `${inherited}, inherited`}
+					size="sm"
+					value={voice ?? ''}
 				/>
-			</div>
+			</FieldRow>
+
+			<FieldRow label="Adjectives">
+				<div className="flex flex-wrap items-center gap-1.5">
+					{inheritedAdjectives.map((adjective) => (
+						<Chip key={adjective} dimmed title="inherited" variant="outline">
+							{adjective}
+						</Chip>
+					))}
+					{adjectives.map((adjective) => (
+						<Chip key={adjective}>
+							{adjective}
+							<button
+								aria-label={`Remove ${adjective} from ${scopeName}`}
+								className="text-faint hover:text-ink"
+								onClick={() =>
+									onAdjectives(adjectives.filter((held) => held !== adjective))
+								}
+								type="button"
+							>
+								×
+							</button>
+						</Chip>
+					))}
+					<InlineInput
+						className="w-24 text-[0.6875rem]"
+						label={`Add an Adjective to ${scopeName}`}
+						onChange={setAdding}
+						onKeyDown={(event) => {
+							if (event.key !== 'Enter') return
+							event.preventDefault()
+							add()
+						}}
+						placeholder="+ adjective"
+						value={adding}
+					/>
+				</div>
+			</FieldRow>
 		</div>
 	)
 }

--- a/src/client/plan/ViewRail.tsx
+++ b/src/client/plan/ViewRail.tsx
@@ -1,14 +1,4 @@
-import { cx } from '../lib/cx'
-
-/**
- * The switch between the Plan Panel's two Views of the Outline: the list of
- * Sections, and the map.
- *
- * Built like the Panel rail in the bar above it, and for the same reason:
- * which View you are in is state rather than a decision the screen wants from
- * you, so the one you are in is solid ink and neither is accented —
- * `foundations/Accent.mdx`.
- */
+import { Rail } from '../components/Rail'
 
 export const OUTLINE_VIEWS = ['list', 'map'] as const
 export type OutlineView = (typeof OUTLINE_VIEWS)[number]
@@ -19,32 +9,16 @@ export interface ViewRailProps {
 	className?: string
 }
 
+/** The switch between the Plan Panel's two Views of the Outline: the list of
+ * Sections, and the map. */
 export function ViewRail({ view, onView, className }: ViewRailProps) {
 	return (
-		<div
-			aria-label="How the Outline is shown"
-			className={cx(
-				'flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5',
-				className,
-			)}
-			role="group"
-		>
-			{OUTLINE_VIEWS.map((one) => (
-				<button
-					key={one}
-					aria-pressed={one === view}
-					className={cx(
-						'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
-						one === view
-							? 'bg-ink text-paper'
-							: 'text-faint hover:bg-hush hover:text-muted',
-					)}
-					onClick={() => onView(one)}
-					type="button"
-				>
-					{one}
-				</button>
-			))}
-		</div>
+		<Rail
+			className={className}
+			items={OUTLINE_VIEWS}
+			label="How the Outline is shown"
+			on={[view]}
+			onPick={onView}
+		/>
 	)
 }

--- a/src/client/plan/ViewRail.tsx
+++ b/src/client/plan/ViewRail.tsx
@@ -1,0 +1,50 @@
+import { cx } from '../lib/cx'
+
+/**
+ * The switch between the Plan Panel's two Views of the Outline: the list of
+ * Sections, and the map.
+ *
+ * Built like the Panel rail in the bar above it, and for the same reason:
+ * which View you are in is state rather than a decision the screen wants from
+ * you, so the one you are in is solid ink and neither is accented —
+ * `foundations/Accent.mdx`.
+ */
+
+export const OUTLINE_VIEWS = ['list', 'map'] as const
+export type OutlineView = (typeof OUTLINE_VIEWS)[number]
+
+export interface ViewRailProps {
+	view: OutlineView
+	onView: (view: OutlineView) => void
+	className?: string
+}
+
+export function ViewRail({ view, onView, className }: ViewRailProps) {
+	return (
+		<div
+			aria-label="How the Outline is shown"
+			className={cx(
+				'flex shrink-0 items-center gap-0.5 rounded-full border border-edge bg-sunk p-0.5',
+				className,
+			)}
+			role="group"
+		>
+			{OUTLINE_VIEWS.map((one) => (
+				<button
+					key={one}
+					aria-pressed={one === view}
+					className={cx(
+						'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
+						one === view
+							? 'bg-ink text-paper'
+							: 'text-faint hover:bg-hush hover:text-muted',
+					)}
+					onClick={() => onView(one)}
+					type="button"
+				>
+					{one}
+				</button>
+			))}
+		</div>
+	)
+}

--- a/src/client/plan/map.ts
+++ b/src/client/plan/map.ts
@@ -1,4 +1,5 @@
 import type { OutlineNode, Plan, Reference } from '../../shared/plan'
+import { outlineEntries } from './outline'
 import { referenceEntries, referenceName } from './references'
 
 /**
@@ -10,12 +11,11 @@ import { referenceEntries, referenceName } from './references'
  * none of it, so what a test measures and what the writer sees cannot drift
  * apart.
  *
- * **Two shapes, and `branches` picks one.** `references` is the Plan v1 has:
+ * **Two shapes, and `branches` picks one.** `references` is what the app draws:
  * the Article title, one layer of Sections, and the References placed at each.
  * `sections` branches the Sections nested inside a Section off it instead,
- * however deep the Plan goes — which the schema allows and the interface does
- * not offer, so it is an idea rather than a screen. `context.md` §Subsection
- * says why.
+ * however deep the Plan goes. The schema holds that nesting and no screen
+ * offers it — `context.md` §Subsection says why.
  */
 
 /** What one box stands for. The three are drawn alike and read differently. */
@@ -82,8 +82,7 @@ export interface MapOptions {
 	rowGap?: number
 	/**
 	 * How tall one box is. A function rather than a number, because what a box
-	 * carries decides how many lines it needs — which is the case a fixed-size
-	 * tree layout cannot express.
+	 * carries decides how many lines it needs.
 	 */
 	heightOf?: (box: Measured) => number
 	/** Sections whose children the map is leaving undrawn. */
@@ -160,8 +159,17 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	for (const entry of referenceEntries(plan)) {
 		const nodeId = entry.reference.nodeId
 		if (nodeId === null) continue
-		placed.set(nodeId, [...(placed.get(nodeId) ?? []), entry])
+		const held = placed.get(nodeId)
+		if (held === undefined) placed.set(nodeId, [entry])
+		else held.push(entry)
 	}
+
+	// Sections take the numbers the walk the Panel reads gives them, rather than
+	// being counted again here — architecture.md §4: one walk, so no two surfaces
+	// can number a Section differently.
+	const ordinals = new Map(
+		outlineEntries(plan.outline).map((entry) => [entry.node.id, entry.ordinal]),
+	)
 
 	// Where the next leaf goes, counting down the page in reading order.
 	let cursor = 0
@@ -188,7 +196,6 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	const place = (
 		subject: MapSubject,
 		depth: number,
-		ordinal: string,
 		parentKey: string | null,
 		ancestors: string[],
 	): MapNode => {
@@ -214,7 +221,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 			parentKey,
 			subject,
 			title: titleOf(subject, plan),
-			ordinal,
+			ordinal: ordinalOf(subject, ordinals),
 			depth,
 			x: depth * (nodeWidth + columnGap),
 			y: 0,
@@ -232,12 +239,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		nodes.push(entry)
 
 		const drawn = isCollapsed ? [] : held
-		const laid = drawn.map((child, index) =>
-			place(child, depth + 1, childOrdinal(child, ordinal, index), key, [
-				key,
-				...ancestors,
-			]),
-		)
+		const laid = drawn.map((child) => place(child, depth + 1, key, [key, ...ancestors]))
 
 		const floor = floors[depth] ?? 0
 
@@ -262,7 +264,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		return entry
 	}
 
-	place({ kind: 'article' }, 0, '', null, [])
+	place({ kind: 'article' }, 0, null, [])
 
 	const byKey = new Map(nodes.map((entry) => [entry.key, entry]))
 	const links: MapLink[] = []
@@ -282,11 +284,12 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 }
 
 /** A Reference keeps the number it has in the Plan's list, the way a footnote
- * does. A Section is numbered by where it sits. */
-function childOrdinal(subject: MapSubject, parentOrdinal: string, index: number): string {
+ * does. A Section takes the number the Outline gives it. */
+function ordinalOf(subject: MapSubject, ordinals: Map<string, string>): string {
+	if (subject.kind === 'article') return ''
 	if (subject.kind === 'reference') return `[${subject.number}]`
 
-	return parentOrdinal === '' ? `${index + 1}` : `${parentOrdinal}.${index + 1}`
+	return ordinals.get(subject.node.id) ?? ''
 }
 
 /** A Reference is named the way every other surface names it, so the map and

--- a/src/client/plan/map.ts
+++ b/src/client/plan/map.ts
@@ -1,0 +1,210 @@
+import type { OutlineNode, Plan } from '../../shared/plan'
+
+/**
+ * The geometry behind the Map View — where each Section sits when the Outline
+ * opens left to right, and the curve that joins it to its parent.
+ *
+ * Arithmetic only, so `test/client/plan-map.test.ts` drives it with a Plan and
+ * reads the numbers back. `PlanMap.tsx` draws what this returns and computes
+ * none of it, so nothing on screen can disagree with what the test measures.
+ *
+ * The tree it walks is the one `outline.ts` walks, and it numbers rows the same
+ * way — "2" for a Section, "2.1" for a Subsection. The Article title is the
+ * root, which is the node the writer sees on the left.
+ */
+
+/** One box on the map. */
+export interface MapNode {
+	/** The map's own identity. The root is `root` and a Section is `n:` and its
+	 * id, so a Section whose id is literally "root" cannot collide with it. */
+	key: string
+	/** The key of the box this one hangs off, and null at the root. */
+	parentKey: string | null
+	/** The Plan's id for this Section, and null at the root. */
+	nodeId: string | null
+	/** Null at the root, which is the Article title rather than a Section. */
+	node: OutlineNode | null
+	/** What the box reads. Empty where the writer has typed no title yet. */
+	title: string
+	/** "2" for a Section, "2.1" for a Subsection, and empty at the root. */
+	ordinal: string
+	/** 0 is the Article title, 1 is a Section, 2 is a Subsection. */
+	depth: number
+	x: number
+	y: number
+	width: number
+	height: number
+	/** How many children the node holds, drawn or not. */
+	childCount: number
+	/** True where the node holds children this map is not drawing. */
+	collapsed: boolean
+	/** Every key from the parent up to the root, nearest first. Hovering a box
+	 * lights this path, so the component walks nothing to find it. */
+	ancestors: string[]
+}
+
+/** One curve, joining a parent's right edge to a child's left edge. */
+export interface MapLink {
+	parentKey: string
+	childKey: string
+	/** The `d` of the SVG path. */
+	d: string
+}
+
+export interface PlanMap {
+	nodes: MapNode[]
+	links: MapLink[]
+	/** What the SVG viewBox needs, in the same units the nodes carry. */
+	width: number
+	height: number
+}
+
+export interface MapOptions {
+	nodeWidth?: number
+	/** The gap between one column and the next. */
+	columnGap?: number
+	/** The gap between two boxes in the same column. */
+	rowGap?: number
+	/**
+	 * How tall one box is. A function rather than a number, because a Section
+	 * carrying an intent note is taller than one that does not — which is the
+	 * case a fixed-size tree layout cannot express.
+	 */
+	heightOf?: (node: OutlineNode | null, depth: number) => number
+	/** Sections whose children the map is leaving undrawn. */
+	collapsed?: ReadonlySet<string>
+}
+
+/** Room for the ordinal and a two-line title, plus a line where an intent note
+ * is there to read. A title runs to two lines often enough at this width that
+ * the shorter box is not worth the clipping. */
+function defaultHeight(node: OutlineNode | null): number {
+	if (node === null) return 48
+
+	return node.intent === undefined ? 48 : 66
+}
+
+/** The curve between two boxes: out of the parent's right edge, into the
+ * child's left edge, turning at the midpoint between the two columns. This is
+ * the cubic d3-shape's `curveBumpX` generates, written out. */
+export function linkPath(parent: MapNode, child: MapNode): string {
+	const sx = parent.x + parent.width
+	const sy = parent.y + parent.height / 2
+	const tx = child.x
+	const ty = child.y + child.height / 2
+	const mx = (sx + tx) / 2
+
+	return `M${sx},${sy}C${mx},${sy} ${mx},${ty} ${tx},${ty}`
+}
+
+/**
+ * Lays the Plan out left to right and returns every box and every curve.
+ *
+ * Leaves stack down the page in reading order, and a parent centres on the
+ * children it holds. Where centring would ride a parent up into the box above
+ * it in its own column, the parent takes the floor instead and its whole
+ * subtree moves down with it, so the subtree keeps its shape.
+ */
+export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
+	const {
+		nodeWidth = 210,
+		columnGap = 40,
+		rowGap = 10,
+		heightOf = defaultHeight,
+		collapsed = new Set<string>(),
+	} = options
+
+	const nodes: MapNode[] = []
+
+	// Where the next leaf goes, counting down the page in reading order.
+	let cursor = 0
+	// The bottom edge each column has reached, so a parent centred on a short
+	// subtree cannot ride up into the box above it.
+	const floors: number[] = []
+
+	const place = (
+		node: OutlineNode | null,
+		depth: number,
+		ordinal: string,
+		parentKey: string | null,
+		ancestors: string[],
+	): MapNode => {
+		const key = node === null ? 'root' : `n:${node.id}`
+		const height = heightOf(node, depth)
+		const children = node === null ? plan.outline : node.children
+		const isCollapsed = node !== null && collapsed.has(node.id)
+
+		const entry: MapNode = {
+			key,
+			parentKey,
+			nodeId: node === null ? null : node.id,
+			node,
+			title: node === null ? plan.title : node.title,
+			ordinal,
+			depth,
+			x: depth * (nodeWidth + columnGap),
+			y: 0,
+			width: nodeWidth,
+			height,
+			childCount: children.length,
+			collapsed: isCollapsed,
+			ancestors,
+		}
+
+		// Pushed before the children, so a subtree occupies one run of the array
+		// and shifting it is a slice rather than a second walk.
+		const start = nodes.length
+		nodes.push(entry)
+
+		const drawn = isCollapsed ? [] : children
+		const laid = drawn.map((child, index) =>
+			place(
+				child,
+				depth + 1,
+				ordinal === '' ? `${index + 1}` : `${ordinal}.${index + 1}`,
+				key,
+				[key, ...ancestors],
+			),
+		)
+
+		const floor = floors[depth] ?? 0
+
+		if (laid.length === 0) {
+			entry.y = Math.max(cursor, floor)
+		} else {
+			const first = laid[0]!
+			const last = laid[laid.length - 1]!
+			entry.y = (first.y + last.y + last.height - height) / 2
+
+			if (entry.y < floor) {
+				const by = floor - entry.y
+				entry.y = floor
+				for (let i = start + 1; i < nodes.length; i += 1) nodes[i]!.y += by
+				cursor += by
+			}
+		}
+
+		cursor = Math.max(cursor, entry.y + height + rowGap)
+		floors[depth] = entry.y + height + rowGap
+
+		return entry
+	}
+
+	place(null, 0, '', null, [])
+
+	const byKey = new Map(nodes.map((entry) => [entry.key, entry]))
+	const links: MapLink[] = []
+
+	for (const child of nodes) {
+		if (child.parentKey === null) continue
+		const parent = byKey.get(child.parentKey)
+		if (parent === undefined) continue
+
+		links.push({ parentKey: parent.key, childKey: child.key, d: linkPath(parent, child) })
+	}
+
+	const width = Math.max(...nodes.map((entry) => entry.x + entry.width))
+	const height = Math.max(...nodes.map((entry) => entry.y + entry.height))
+
+	return { nodes, links, width, height }
+}

--- a/src/client/plan/map.ts
+++ b/src/client/plan/map.ts
@@ -36,6 +36,10 @@ export interface MapNode {
 	height: number
 	/** How many children the node holds, drawn or not. */
 	childCount: number
+	/** The References placed here, by their position in the Plan's list — the
+	 * numbers `references.ts` marks them with. Empty at the root, which holds
+	 * none: a Reference is placed at a Section or at nothing. */
+	referenceNumbers: number[]
 	/** True where the node holds children this map is not drawing. */
 	collapsed: boolean
 	/** Every key from the parent up to the root, nearest first. Hovering a box
@@ -66,22 +70,29 @@ export interface MapOptions {
 	/** The gap between two boxes in the same column. */
 	rowGap?: number
 	/**
-	 * How tall one box is. A function rather than a number, because a Section
-	 * carrying an intent note is taller than one that does not — which is the
-	 * case a fixed-size tree layout cannot express.
+	 * How tall one box is. A function rather than a number, because what a
+	 * Section carries decides how many lines it needs — which is the case a
+	 * fixed-size tree layout cannot express.
 	 */
-	heightOf?: (node: OutlineNode | null, depth: number) => number
+	heightOf?: (node: OutlineNode | null, depth: number, referenceCount: number) => number
 	/** Sections whose children the map is leaving undrawn. */
 	collapsed?: ReadonlySet<string>
 }
 
-/** Room for the ordinal and a two-line title, plus a line where an intent note
- * is there to read. A title runs to two lines often enough at this width that
- * the shorter box is not worth the clipping. */
-function defaultHeight(node: OutlineNode | null): number {
+/**
+ * Room for the ordinal and a two-line title, plus a line for each of the two
+ * things a Section can carry underneath: its intent note, and the References
+ * placed at it. A title runs to two lines often enough at this width that the
+ * shorter box is not worth the clipping.
+ */
+function defaultHeight(
+	node: OutlineNode | null,
+	_depth: number,
+	referenceCount: number,
+): number {
 	if (node === null) return 48
 
-	return node.intent === undefined ? 48 : 66
+	return 48 + (node.intent === undefined ? 0 : 18) + (referenceCount === 0 ? 0 : 16)
 }
 
 /** The curve between two boxes: out of the parent's right edge, into the
@@ -116,6 +127,14 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 
 	const nodes: MapNode[] = []
 
+	// Numbered once, off the one list, so the box and `references.ts` cannot
+	// mark the same Reference two different ways.
+	const placed = new Map<string, number[]>()
+	plan.references.forEach((reference, index) => {
+		if (reference.nodeId === null) return
+		placed.set(reference.nodeId, [...(placed.get(reference.nodeId) ?? []), index + 1])
+	})
+
 	// Where the next leaf goes, counting down the page in reading order.
 	let cursor = 0
 	// The bottom edge each column has reached, so a parent centred on a short
@@ -130,7 +149,8 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		ancestors: string[],
 	): MapNode => {
 		const key = node === null ? 'root' : `n:${node.id}`
-		const height = heightOf(node, depth)
+		const referenceNumbers = node === null ? [] : (placed.get(node.id) ?? [])
+		const height = heightOf(node, depth, referenceNumbers.length)
 		const children = node === null ? plan.outline : node.children
 		const isCollapsed = node !== null && collapsed.has(node.id)
 
@@ -147,6 +167,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 			width: nodeWidth,
 			height,
 			childCount: children.length,
+			referenceNumbers,
 			collapsed: isCollapsed,
 			ancestors,
 		}

--- a/src/client/plan/map.ts
+++ b/src/client/plan/map.ts
@@ -3,22 +3,18 @@ import { outlineEntries } from './outline'
 import { referenceEntries, referenceName } from './references'
 
 /**
- * The geometry behind the Map View — where each box sits when the Plan opens
- * left to right, and the curve that joins it to its parent.
+ * Where each box sits when the Plan opens left to right, and the curve joining
+ * it to its parent. Arithmetic only, so `test/client/plan-map.test.ts` drives
+ * it with a Plan and reads the numbers back.
  *
- * Arithmetic only, so `test/client/plan-map.test.ts` drives it with a Plan and
- * reads the numbers back. `PlanMap.tsx` draws what this returns and computes
- * none of it, so what a test measures and what the writer sees cannot drift
- * apart.
- *
- * **Two shapes, and `branches` picks one.** `references` is what the app draws:
- * the Article title, one layer of Sections, and the References placed at each.
- * `sections` branches the Sections nested inside a Section off it instead,
+ * `branches: 'references'` draws the Article title, one layer of Sections, and
+ * the References placed at each — what the app draws today.
+ * `branches: 'sections'` draws the Sections nested inside a Section instead,
  * however deep the Plan goes. The schema holds that nesting and no screen
  * offers it — `context.md` §Subsection says why.
  */
 
-/** What one box stands for. The three are drawn alike and read differently. */
+/** What one box stands for. */
 export type MapSubject =
 	| { kind: 'article' }
 	| { kind: 'section'; node: OutlineNode }
@@ -26,32 +22,25 @@ export type MapSubject =
 
 /** One box on the map. */
 export interface MapNode {
-	/** The map's own identity. `root`, `n:` and a Section's id, or `r:` and a
-	 * Reference's id — so ids that collide across the two lists cannot. */
+	/** `root`, `n:` and a Section's id, or `r:` and a Reference's id, so ids
+	 * that collide across the two lists cannot collide here. */
 	key: string
-	/** The key of the box this one hangs off, and null at the root. */
 	parentKey: string | null
 	subject: MapSubject
-	/** What the box reads. Empty where the writer has typed no title yet. */
 	title: string
-	/** "2" for a Section, "2.1" for a nested one, "[3]" for a Reference, and
-	 * empty at the root. */
+	/** "2" for a Section, "2.1" for a nested one, "[3]" for a Reference. */
 	ordinal: string
-	/** 0 is the Article title, 1 is a Section, and 2 is whatever hangs off one. */
 	depth: number
 	x: number
 	y: number
 	width: number
 	height: number
-	/** How many children the box holds, drawn or not. */
+	/** Children the box holds, drawn or not — a folded box still counts them. */
 	childCount: number
-	/** The References placed at this Section, by their number in the Plan's
-	 * list. Empty under `branches: 'references'`, where each is its own box. */
+	/** Empty under `branches: 'references'`, where each is its own box. */
 	referenceNumbers: number[]
-	/** True where the box holds children this map is not drawing. */
 	collapsed: boolean
-	/** Every key from the parent up to the root, nearest first. Hovering a box
-	 * lights this path, so the component walks nothing to find it. */
+	/** Every key from the parent up to the root, nearest first. */
 	ancestors: string[]
 }
 
@@ -66,44 +55,29 @@ export interface MapLink {
 export interface PlanMap {
 	nodes: MapNode[]
 	links: MapLink[]
-	/** What the SVG viewBox needs, in the same units the nodes carry. */
 	width: number
 	height: number
 }
 
-/** What branches off a Section. */
 export type MapBranches = 'references' | 'sections'
 
 export interface MapOptions {
 	nodeWidth?: number
-	/** The gap between one column and the next. */
 	columnGap?: number
-	/** The gap between two boxes in the same column. */
 	rowGap?: number
-	/**
-	 * How tall one box is. A function rather than a number, because what a box
-	 * carries decides how many lines it needs.
-	 */
+	/** A function, because what a box carries decides how many lines it needs. */
 	heightOf?: (box: Measured) => number
 	/** Sections whose children the map is leaving undrawn. */
 	collapsed?: ReadonlySet<string>
-	/** What branches off a Section. `references` by default, which is the Plan
-	 * the interface offers. */
 	branches?: MapBranches
 }
 
-/** What the height of a box is decided from. */
 export type Measured = Pick<MapNode, 'subject' | 'depth' | 'referenceNumbers'>
 
-/**
- * Room for the ordinal and a two-line title, plus a line for each of the two
- * things a Section can carry underneath: its intent note, and the References
- * placed at it. A title runs to two lines often enough at this width that the
- * shorter box is not worth the clipping.
- */
+/** Room for the ordinal and a two-line title, plus a line each for an intent
+ * note and for the References placed at the Section. */
 function defaultHeight({ subject, referenceNumbers }: Measured): number {
 	if (subject.kind === 'article') return 48
-	// A Reference reads as its mark and its name, and carries nothing below.
 	if (subject.kind === 'reference') return 44
 
 	return (
@@ -113,9 +87,8 @@ function defaultHeight({ subject, referenceNumbers }: Measured): number {
 	)
 }
 
-/** The curve between two boxes: out of the parent's right edge, into the
- * child's left edge, turning at the midpoint between the two columns. This is
- * the cubic d3-shape's `curveBumpX` generates, written out. */
+/** Out of the parent's right edge, into the child's left edge, turning at the
+ * midpoint between the columns — the cubic `curveBumpX` generates. */
 export function linkPath(parent: MapNode, child: MapNode): string {
 	const sx = parent.x + parent.width
 	const sy = parent.y + parent.height / 2
@@ -126,7 +99,7 @@ export function linkPath(parent: MapNode, child: MapNode): string {
 	return `M${sx},${sy}C${mx},${sy} ${mx},${ty} ${tx},${ty}`
 }
 
-/** The Plan's id for what a box stands for, and null at the root. */
+/** The Plan's id for what a box stands for, or null at the root. */
 export function subjectId(subject: MapSubject): string | null {
 	if (subject.kind === 'article') return null
 
@@ -134,12 +107,10 @@ export function subjectId(subject: MapSubject): string | null {
 }
 
 /**
- * Lays the Plan out left to right and returns every box and every curve.
- *
- * Leaves stack down the page in reading order, and a parent centres on the
- * children it holds. Where centring would ride a parent up into the box above
- * it in its own column, the parent takes the floor instead and its whole
- * subtree moves down with it, so the subtree keeps its shape.
+ * Lays the Plan out left to right. Leaves stack down the page in reading order
+ * and a parent centres on its children; where centring would ride a parent up
+ * into the box above it, the parent takes the floor and its subtree moves down
+ * with it.
  */
 export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	const {
@@ -153,8 +124,8 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 
 	const nodes: MapNode[] = []
 
-	// Numbered once, off the one list, so a box and `references.ts` cannot mark
-	// the same Reference two different ways.
+	// Numbered off the one list, so a box and `references.ts` mark a Reference
+	// the same way.
 	const placed = new Map<string, { reference: Reference; number: number }[]>()
 	for (const entry of referenceEntries(plan)) {
 		const nodeId = entry.reference.nodeId
@@ -164,20 +135,17 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		else held.push(entry)
 	}
 
-	// Sections take the numbers the walk the Panel reads gives them, rather than
-	// being counted again here — architecture.md §4: one walk, so no two surfaces
-	// can number a Section differently.
+	// Numbered off the walk the Panel reads, not counted again here —
+	// architecture.md §4.
 	const ordinals = new Map(
 		outlineEntries(plan.outline).map((entry) => [entry.node.id, entry.ordinal]),
 	)
 
-	// Where the next leaf goes, counting down the page in reading order.
+	/** Where the next leaf goes, counting down the page in reading order. */
 	let cursor = 0
-	// The bottom edge each column has reached, so a parent centred on a short
-	// subtree cannot ride up into the box above it.
+	/** The bottom edge each column has reached. */
 	const floors: number[] = []
 
-	/** What branches off this box, as the subjects those boxes stand for. */
 	const childrenOf = (subject: MapSubject): MapSubject[] => {
 		if (subject.kind === 'reference') return []
 		if (subject.kind === 'article') {
@@ -205,8 +173,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 				? 'root'
 				: `${subject.kind === 'section' ? 'n' : 'r'}:${id}`
 
-		// A Section reads its own placed References only where they are not boxes
-		// of their own — otherwise the map would say it twice.
+		// Only where the References are not boxes of their own.
 		const referenceNumbers =
 			subject.kind === 'section' && branches === 'sections'
 				? (placed.get(subject.node.id) ?? []).map((entry) => entry.number)
@@ -233,8 +200,8 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 			ancestors,
 		}
 
-		// Pushed before the children, so a subtree occupies one run of the array
-		// and shifting it is a slice rather than a second walk.
+		// Pushed before its children, so a subtree occupies one run of the array
+		// and shifting it is a slice.
 		const start = nodes.length
 		nodes.push(entry)
 
@@ -283,8 +250,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	return { nodes, links, width, height }
 }
 
-/** A Reference keeps the number it has in the Plan's list, the way a footnote
- * does. A Section takes the number the Outline gives it. */
+/** A Reference keeps its number in the Plan's list, the way a footnote does. */
 function ordinalOf(subject: MapSubject, ordinals: Map<string, string>): string {
 	if (subject.kind === 'article') return ''
 	if (subject.kind === 'reference') return `[${subject.number}]`
@@ -292,8 +258,7 @@ function ordinalOf(subject: MapSubject, ordinals: Map<string, string>): string {
 	return ordinals.get(subject.node.id) ?? ''
 }
 
-/** A Reference is named the way every other surface names it, so the map and
- * the References list cannot call one item two things. */
+/** Named through `referenceName`, so the map and the References list agree. */
 function titleOf(subject: MapSubject, plan: Plan): string {
 	if (subject.kind === 'article') return plan.title
 	if (subject.kind === 'section') return subject.node.title

--- a/src/client/plan/map.ts
+++ b/src/client/plan/map.ts
@@ -1,46 +1,54 @@
-import type { OutlineNode, Plan } from '../../shared/plan'
+import type { OutlineNode, Plan, Reference } from '../../shared/plan'
+import { referenceEntries, referenceName } from './references'
 
 /**
- * The geometry behind the Map View — where each Section sits when the Outline
- * opens left to right, and the curve that joins it to its parent.
+ * The geometry behind the Map View — where each box sits when the Plan opens
+ * left to right, and the curve that joins it to its parent.
  *
  * Arithmetic only, so `test/client/plan-map.test.ts` drives it with a Plan and
  * reads the numbers back. `PlanMap.tsx` draws what this returns and computes
- * none of it, so nothing on screen can disagree with what the test measures.
+ * none of it, so what a test measures and what the writer sees cannot drift
+ * apart.
  *
- * The tree it walks is the one `outline.ts` walks, and it numbers rows the same
- * way — "2" for a Section, "2.1" for a Subsection. The Article title is the
- * root, which is the node the writer sees on the left.
+ * **Two shapes, and `branches` picks one.** `references` is the Plan v1 has:
+ * the Article title, one layer of Sections, and the References placed at each.
+ * `sections` branches the Sections nested inside a Section off it instead,
+ * however deep the Plan goes — which the schema allows and the interface does
+ * not offer, so it is an idea rather than a screen. `context.md` §Subsection
+ * says why.
  */
+
+/** What one box stands for. The three are drawn alike and read differently. */
+export type MapSubject =
+	| { kind: 'article' }
+	| { kind: 'section'; node: OutlineNode }
+	| { kind: 'reference'; reference: Reference; number: number }
 
 /** One box on the map. */
 export interface MapNode {
-	/** The map's own identity. The root is `root` and a Section is `n:` and its
-	 * id, so a Section whose id is literally "root" cannot collide with it. */
+	/** The map's own identity. `root`, `n:` and a Section's id, or `r:` and a
+	 * Reference's id — so ids that collide across the two lists cannot. */
 	key: string
 	/** The key of the box this one hangs off, and null at the root. */
 	parentKey: string | null
-	/** The Plan's id for this Section, and null at the root. */
-	nodeId: string | null
-	/** Null at the root, which is the Article title rather than a Section. */
-	node: OutlineNode | null
+	subject: MapSubject
 	/** What the box reads. Empty where the writer has typed no title yet. */
 	title: string
-	/** "2" for a Section, "2.1" for a Subsection, and empty at the root. */
+	/** "2" for a Section, "2.1" for a nested one, "[3]" for a Reference, and
+	 * empty at the root. */
 	ordinal: string
-	/** 0 is the Article title, 1 is a Section, 2 is a Subsection. */
+	/** 0 is the Article title, 1 is a Section, and 2 is whatever hangs off one. */
 	depth: number
 	x: number
 	y: number
 	width: number
 	height: number
-	/** How many children the node holds, drawn or not. */
+	/** How many children the box holds, drawn or not. */
 	childCount: number
-	/** The References placed here, by their position in the Plan's list — the
-	 * numbers `references.ts` marks them with. Empty at the root, which holds
-	 * none: a Reference is placed at a Section or at nothing. */
+	/** The References placed at this Section, by their number in the Plan's
+	 * list. Empty under `branches: 'references'`, where each is its own box. */
 	referenceNumbers: number[]
-	/** True where the node holds children this map is not drawing. */
+	/** True where the box holds children this map is not drawing. */
 	collapsed: boolean
 	/** Every key from the parent up to the root, nearest first. Hovering a box
 	 * lights this path, so the component walks nothing to find it. */
@@ -63,6 +71,9 @@ export interface PlanMap {
 	height: number
 }
 
+/** What branches off a Section. */
+export type MapBranches = 'references' | 'sections'
+
 export interface MapOptions {
 	nodeWidth?: number
 	/** The gap between one column and the next. */
@@ -70,14 +81,20 @@ export interface MapOptions {
 	/** The gap between two boxes in the same column. */
 	rowGap?: number
 	/**
-	 * How tall one box is. A function rather than a number, because what a
-	 * Section carries decides how many lines it needs — which is the case a
-	 * fixed-size tree layout cannot express.
+	 * How tall one box is. A function rather than a number, because what a box
+	 * carries decides how many lines it needs — which is the case a fixed-size
+	 * tree layout cannot express.
 	 */
-	heightOf?: (node: OutlineNode | null, depth: number, referenceCount: number) => number
+	heightOf?: (box: Measured) => number
 	/** Sections whose children the map is leaving undrawn. */
 	collapsed?: ReadonlySet<string>
+	/** What branches off a Section. `references` by default, which is the Plan
+	 * the interface offers. */
+	branches?: MapBranches
 }
+
+/** What the height of a box is decided from. */
+export type Measured = Pick<MapNode, 'subject' | 'depth' | 'referenceNumbers'>
 
 /**
  * Room for the ordinal and a two-line title, plus a line for each of the two
@@ -85,14 +102,16 @@ export interface MapOptions {
  * placed at it. A title runs to two lines often enough at this width that the
  * shorter box is not worth the clipping.
  */
-function defaultHeight(
-	node: OutlineNode | null,
-	_depth: number,
-	referenceCount: number,
-): number {
-	if (node === null) return 48
+function defaultHeight({ subject, referenceNumbers }: Measured): number {
+	if (subject.kind === 'article') return 48
+	// A Reference reads as its mark and its name, and carries nothing below.
+	if (subject.kind === 'reference') return 44
 
-	return 48 + (node.intent === undefined ? 0 : 18) + (referenceCount === 0 ? 0 : 16)
+	return (
+		48 +
+		(subject.node.intent === undefined ? 0 : 18) +
+		(referenceNumbers.length === 0 ? 0 : 16)
+	)
 }
 
 /** The curve between two boxes: out of the parent's right edge, into the
@@ -106,6 +125,13 @@ export function linkPath(parent: MapNode, child: MapNode): string {
 	const mx = (sx + tx) / 2
 
 	return `M${sx},${sy}C${mx},${sy} ${mx},${ty} ${tx},${ty}`
+}
+
+/** The Plan's id for what a box stands for, and null at the root. */
+export function subjectId(subject: MapSubject): string | null {
+	if (subject.kind === 'article') return null
+
+	return subject.kind === 'section' ? subject.node.id : subject.reference.id
 }
 
 /**
@@ -123,17 +149,19 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		rowGap = 10,
 		heightOf = defaultHeight,
 		collapsed = new Set<string>(),
+		branches = 'references',
 	} = options
 
 	const nodes: MapNode[] = []
 
-	// Numbered once, off the one list, so the box and `references.ts` cannot
-	// mark the same Reference two different ways.
-	const placed = new Map<string, number[]>()
-	plan.references.forEach((reference, index) => {
-		if (reference.nodeId === null) return
-		placed.set(reference.nodeId, [...(placed.get(reference.nodeId) ?? []), index + 1])
-	})
+	// Numbered once, off the one list, so a box and `references.ts` cannot mark
+	// the same Reference two different ways.
+	const placed = new Map<string, { reference: Reference; number: number }[]>()
+	for (const entry of referenceEntries(plan)) {
+		const nodeId = entry.reference.nodeId
+		if (nodeId === null) continue
+		placed.set(nodeId, [...(placed.get(nodeId) ?? []), entry])
+	}
 
 	// Where the next leaf goes, counting down the page in reading order.
 	let cursor = 0
@@ -141,32 +169,58 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	// subtree cannot ride up into the box above it.
 	const floors: number[] = []
 
+	/** What branches off this box, as the subjects those boxes stand for. */
+	const childrenOf = (subject: MapSubject): MapSubject[] => {
+		if (subject.kind === 'reference') return []
+		if (subject.kind === 'article') {
+			return plan.outline.map((node) => ({ kind: 'section', node }) as const)
+		}
+
+		if (branches === 'sections') {
+			return subject.node.children.map((node) => ({ kind: 'section', node }) as const)
+		}
+
+		return (placed.get(subject.node.id) ?? []).map(
+			(entry) => ({ kind: 'reference', ...entry }) as const,
+		)
+	}
+
 	const place = (
-		node: OutlineNode | null,
+		subject: MapSubject,
 		depth: number,
 		ordinal: string,
 		parentKey: string | null,
 		ancestors: string[],
 	): MapNode => {
-		const key = node === null ? 'root' : `n:${node.id}`
-		const referenceNumbers = node === null ? [] : (placed.get(node.id) ?? [])
-		const height = heightOf(node, depth, referenceNumbers.length)
-		const children = node === null ? plan.outline : node.children
-		const isCollapsed = node !== null && collapsed.has(node.id)
+		const id = subjectId(subject)
+		const key =
+			subject.kind === 'article'
+				? 'root'
+				: `${subject.kind === 'section' ? 'n' : 'r'}:${id}`
+
+		// A Section reads its own placed References only where they are not boxes
+		// of their own — otherwise the map would say it twice.
+		const referenceNumbers =
+			subject.kind === 'section' && branches === 'sections'
+				? (placed.get(subject.node.id) ?? []).map((entry) => entry.number)
+				: []
+
+		const held = childrenOf(subject)
+		const isCollapsed = id !== null && collapsed.has(id)
+		const height = heightOf({ subject, depth, referenceNumbers })
 
 		const entry: MapNode = {
 			key,
 			parentKey,
-			nodeId: node === null ? null : node.id,
-			node,
-			title: node === null ? plan.title : node.title,
+			subject,
+			title: titleOf(subject, plan),
 			ordinal,
 			depth,
 			x: depth * (nodeWidth + columnGap),
 			y: 0,
 			width: nodeWidth,
 			height,
-			childCount: children.length,
+			childCount: held.length,
 			referenceNumbers,
 			collapsed: isCollapsed,
 			ancestors,
@@ -177,15 +231,12 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		const start = nodes.length
 		nodes.push(entry)
 
-		const drawn = isCollapsed ? [] : children
+		const drawn = isCollapsed ? [] : held
 		const laid = drawn.map((child, index) =>
-			place(
-				child,
-				depth + 1,
-				ordinal === '' ? `${index + 1}` : `${ordinal}.${index + 1}`,
+			place(child, depth + 1, childOrdinal(child, ordinal, index), key, [
 				key,
-				[key, ...ancestors],
-			),
+				...ancestors,
+			]),
 		)
 
 		const floor = floors[depth] ?? 0
@@ -211,7 +262,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 		return entry
 	}
 
-	place(null, 0, '', null, [])
+	place({ kind: 'article' }, 0, '', null, [])
 
 	const byKey = new Map(nodes.map((entry) => [entry.key, entry]))
 	const links: MapLink[] = []
@@ -228,4 +279,21 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	const height = Math.max(...nodes.map((entry) => entry.y + entry.height))
 
 	return { nodes, links, width, height }
+}
+
+/** A Reference keeps the number it has in the Plan's list, the way a footnote
+ * does. A Section is numbered by where it sits. */
+function childOrdinal(subject: MapSubject, parentOrdinal: string, index: number): string {
+	if (subject.kind === 'reference') return `[${subject.number}]`
+
+	return parentOrdinal === '' ? `${index + 1}` : `${parentOrdinal}.${index + 1}`
+}
+
+/** A Reference is named the way every other surface names it, so the map and
+ * the References list cannot call one item two things. */
+function titleOf(subject: MapSubject, plan: Plan): string {
+	if (subject.kind === 'article') return plan.title
+	if (subject.kind === 'section') return subject.node.title
+
+	return referenceName(subject.reference)
 }

--- a/src/shared/plan/scope.ts
+++ b/src/shared/plan/scope.ts
@@ -71,14 +71,11 @@ export function findNodePath(
 }
 
 /**
- * Whether a Section carries nothing at all — no title, no length, no note, no
- * Tone, nothing inside it, and no Reference placed at it. What a surface does
- * with the answer is its own business: the Map View throws away a Section the
- * writer made and left like this.
+ * Whether a Section carries nothing: no title, no length, no note, no Tone,
+ * nothing inside it, and no Reference placed at it.
  *
- * Written over the node's own fields rather than as a list of names, so a field
- * added to `outlineNodeSchema` later counts here without being named. A field
- * nobody has set reads `undefined`, and one the writer has set does not.
+ * Reads the node's own fields rather than a list of names, so a field added to
+ * `outlineNodeSchema` later counts here without being named.
  */
 export function sectionIsEmpty(plan: Plan, nodeId: string): boolean {
 	const path = findNodePath(plan.outline, nodeId)

--- a/src/shared/plan/scope.ts
+++ b/src/shared/plan/scope.ts
@@ -69,3 +69,28 @@ export function findNodePath(
 
 	return null
 }
+
+/**
+ * Whether a Section carries nothing at all — no title, no length, no note, no
+ * Tone, nothing inside it, and no Reference placed at it. What a surface does
+ * with the answer is its own business: the Map View throws away a Section the
+ * writer made and left like this.
+ *
+ * Written over the node's own fields rather than as a list of names, so a field
+ * added to `outlineNodeSchema` later counts here without being named. A field
+ * nobody has set reads `undefined`, and one the writer has set does not.
+ */
+export function sectionIsEmpty(plan: Plan, nodeId: string): boolean {
+	const path = findNodePath(plan.outline, nodeId)
+	if (path === null) return false
+
+	const bare = Object.entries(path[path.length - 1]!).every(([field, value]) => {
+		if (field === 'id') return true
+		if (field === 'title') return value === ''
+		if (field === 'children') return (value as OutlineNode[]).length === 0
+
+		return value === undefined
+	})
+
+	return bare && !plan.references.some((reference) => reference.nodeId === nodeId)
+}

--- a/test/client/plan-map.test.ts
+++ b/test/client/plan-map.test.ts
@@ -1,24 +1,35 @@
 import { describe, expect, it } from 'vitest'
 
 import type { MapNode } from '../../src/client/plan/map'
-import { linkPath, planMap } from '../../src/client/plan/map'
-import type { OutlineNode } from '../../src/shared/plan'
+import { linkPath, planMap, subjectId } from '../../src/client/plan/map'
+import type { OutlineNode, Plan } from '../../src/shared/plan'
 import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
 
 /**
  * Where the Map View puts each box. The defaults the layout ships with are the
  * numbers below: a box is 210 wide, columns sit 40 apart, and rows sit 10
- * apart. A box is 48 tall, plus 18 where it carries an intent note and 16 where
- * References are placed at it.
+ * apart. A Section is 48 tall, plus 18 where it carries an intent note; a
+ * Reference is 44.
+ *
+ * The map has two shapes. `references` is the Outline the interface offers —
+ * the title, one layer of Sections, and the References placed at each — and
+ * `sections` nests Sections instead. Both are exercised here.
  */
 
 const NODE = 210
 const COLUMN = NODE + 40
 const ROW = 48 + 10
 
-/** The map of a Plan whose Outline is the nodes given. */
-function mapOf(outline: OutlineNode[]) {
-	return planMap(makePlan({ title: 'The article', outline }))
+/** The map of a Plan whose Outline is the nodes given, in whichever shape. */
+function mapOf(outline: OutlineNode[], plan: Partial<Plan> = {}) {
+	return planMap(makePlan({ title: 'The article', outline, ...plan }))
+}
+
+/** The recursive shape, which is the deferred idea rather than the screen. */
+function nested(outline: OutlineNode[], plan: Partial<Plan> = {}) {
+	return planMap(makePlan({ title: 'The article', outline, ...plan }), {
+		branches: 'sections',
+	})
 }
 
 function at(nodes: MapNode[], key: string): MapNode {
@@ -34,18 +45,21 @@ describe('what the map holds', () => {
 
 		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:a', 'n:b'])
 		expect(at(nodes, 'root').title).toBe('The article')
-		expect(at(nodes, 'root').nodeId).toBeNull()
+		expect(at(nodes, 'root').subject.kind).toBe('article')
 	})
 
-	// A Section whose id is "root" would otherwise take the title's own key.
-	it('keys a Section apart from the root even where its id is root', () => {
-		const { nodes } = mapOf([makeNode({ id: 'root' })])
+	// A Section and a Reference carrying the same id would otherwise take one
+	// key, and the root would take a Section's whose id is "root".
+	it('keys the three kinds apart', () => {
+		const { nodes } = mapOf([makeNode({ id: 'root' })], {
+			references: [makeReference({ id: 'root', nodeId: 'root', text: 'A passage' })],
+		})
 
-		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:root'])
+		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:root', 'r:root'])
 	})
 
-	it('numbers rows the way the Outline does', () => {
-		const { nodes } = mapOf([
+	it('numbers Sections the way the Outline does', () => {
+		const { nodes } = nested([
 			makeNode({ id: 'a' }),
 			makeNode({ id: 'b', children: [makeNode({ id: 'b1' }), makeNode({ id: 'b2' })] }),
 		])
@@ -61,15 +75,66 @@ describe('what the map holds', () => {
 	})
 })
 
-describe('where the boxes sit', () => {
-	it('puts each depth in its own column', () => {
-		const { nodes } = mapOf([makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] })])
-
-		expect(at(nodes, 'root').x).toBe(0)
-		expect(at(nodes, 'n:a').x).toBe(COLUMN)
-		expect(at(nodes, 'n:a1').x).toBe(COLUMN * 2)
+describe('the shape the interface offers', () => {
+	const { nodes } = mapOf([makeNode({ id: 'a' }), makeNode({ id: 'b' })], {
+		references: [
+			makeReference({ id: 'r1', nodeId: 'b', source: { title: 'A report' } }),
+			makeReference({ id: 'r2', nodeId: null, source: { title: 'Unplaced' } }),
+			makeReference({ id: 'r3', nodeId: 'b', text: 'A passage' }),
+		],
 	})
 
+	it('hangs the References placed at a Section off it', () => {
+		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:a', 'n:b', 'r:r1', 'r:r3'])
+	})
+
+	// Three columns and no more: the title, its Sections, and what they draw on.
+	it('puts each kind in its own column', () => {
+		expect(at(nodes, 'root').x).toBe(0)
+		expect(at(nodes, 'n:b').x).toBe(COLUMN)
+		expect(at(nodes, 'r:r1').x).toBe(COLUMN * 2)
+	})
+
+	// A Reference keeps the number it has in the Plan's list, the way a footnote
+	// does, rather than being renumbered by where it sits.
+	it('marks a Reference with its number in the list', () => {
+		expect(at(nodes, 'r:r1').ordinal).toBe('[1]')
+		expect(at(nodes, 'r:r3').ordinal).toBe('[3]')
+	})
+
+	it('names a Reference the way every other surface names it', () => {
+		expect(at(nodes, 'r:r1').title).toBe('A report')
+		expect(at(nodes, 'r:r3').title).toBe('“A passage”')
+	})
+
+	// The Reference is a box of its own here, so a `refs [1] [3]` line under the
+	// Section would say the same placement twice.
+	it('leaves the placed-References line off a Section', () => {
+		expect(at(nodes, 'n:b').referenceNumbers).toEqual([])
+	})
+
+	it('leaves an unplaced Reference off the map', () => {
+		expect(nodes.some((node) => node.key === 'r:r2')).toBe(false)
+	})
+})
+
+describe('the recursive shape', () => {
+	const { nodes } = nested([makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] })], {
+		references: [makeReference({ id: 'r1', nodeId: 'a', text: 'A passage' })],
+	})
+
+	it('hangs the Sections nested inside a Section off it', () => {
+		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:a', 'n:a1'])
+	})
+
+	// Nothing draws the Reference here, so the Section says where it sits.
+	it('says which References are placed at a Section instead', () => {
+		expect(at(nodes, 'n:a').referenceNumbers).toEqual([1])
+		expect(at(nodes, 'n:a').height).toBe(48 + 16)
+	})
+})
+
+describe('where the boxes sit', () => {
 	it('stacks the leaves down the page in reading order', () => {
 		const { nodes } = mapOf([makeNode({ id: 'a' }), makeNode({ id: 'b' })])
 
@@ -86,8 +151,8 @@ describe('where the boxes sit', () => {
 		expect(middle(root)).toBe((middle(at(nodes, 'n:a')) + middle(at(nodes, 'n:b'))) / 2)
 	})
 
-	// The height a Section takes is what a fixed-size tree layout cannot state,
-	// so the layout asks for it per node rather than assuming one number.
+	// The height a box takes is what a fixed-size tree layout cannot state, so
+	// the layout asks for it per box rather than assuming one number.
 	it('gives a Section carrying an intent note a taller box', () => {
 		const { nodes } = mapOf([
 			makeNode({ id: 'a', intent: 'What this Section does' }),
@@ -111,7 +176,7 @@ describe('a parent that would ride up into the box above it', () => {
 				makeNode({ id: 'b', children: [makeNode({ id: 'b1' })] }),
 			],
 		}),
-		{ heightOf: (_node, depth) => (depth === 1 ? 100 : 44) },
+		{ branches: 'sections', heightOf: ({ depth }) => (depth === 1 ? 100 : 44) },
 	)
 
 	it('drops the parent to the floor', () => {
@@ -125,18 +190,24 @@ describe('a parent that would ride up into the box above it', () => {
 })
 
 describe('no two boxes in one column overlap', () => {
-	// Three subtrees of different shapes, so the check meets a short one next to
-	// a tall one in both orders.
-	const { nodes } = mapOf([
-		makeNode({ id: 'a' }),
-		makeNode({
-			id: 'b',
-			intent: 'A note, which makes this box taller',
-			children: [makeNode({ id: 'b1' }), makeNode({ id: 'b2' }), makeNode({ id: 'b3' })],
-		}),
-		makeNode({ id: 'c', children: [makeNode({ id: 'c1' })] }),
-		makeNode({ id: 'd' }),
-	])
+	// Subtrees of different shapes, so the check meets a short one next to a
+	// tall one in both orders.
+	const { nodes } = mapOf(
+		[
+			makeNode({ id: 'a' }),
+			makeNode({ id: 'b', intent: 'A note, which makes this box taller' }),
+			makeNode({ id: 'c' }),
+			makeNode({ id: 'd' }),
+		],
+		{
+			references: [
+				makeReference({ id: 'r1', nodeId: 'b', text: 'One' }),
+				makeReference({ id: 'r2', nodeId: 'b', text: 'Two' }),
+				makeReference({ id: 'r3', nodeId: 'b', text: 'Three' }),
+				makeReference({ id: 'r4', nodeId: 'c', text: 'Four' }),
+			],
+		},
+	)
 
 	const depths = [...new Set(nodes.map((node) => node.depth))]
 
@@ -155,67 +226,60 @@ describe('no two boxes in one column overlap', () => {
 	})
 })
 
-describe('a collapsed Section', () => {
-	const { nodes, links } = planMap(
+describe('a folded Section', () => {
+	const { nodes } = mapOf([makeNode({ id: 'a' })], {
+		references: [
+			makeReference({ id: 'r1', nodeId: 'a', text: 'One' }),
+			makeReference({ id: 'r2', nodeId: 'a', text: 'Two' }),
+		],
+	})
+
+	const folded = planMap(
 		makePlan({
-			outline: [
-				makeNode({ id: 'a', children: [makeNode({ id: 'a1' }), makeNode({ id: 'a2' })] }),
+			outline: [makeNode({ id: 'a' })],
+			references: [
+				makeReference({ id: 'r1', nodeId: 'a', text: 'One' }),
+				makeReference({ id: 'r2', nodeId: 'a', text: 'Two' }),
 			],
 		}),
 		{ collapsed: new Set(['a']) },
 	)
 
 	it('leaves its children undrawn', () => {
-		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:a'])
-		expect(links).toHaveLength(1)
+		expect(nodes).toHaveLength(4)
+		expect(folded.nodes.map((node) => node.key)).toEqual(['root', 'n:a'])
+		expect(folded.links).toHaveLength(1)
 	})
 
 	// The box says how much is folded away, so the writer knows there is
 	// something to open rather than reading a leaf.
 	it('still says how many children it holds', () => {
-		expect(at(nodes, 'n:a').childCount).toBe(2)
-		expect(at(nodes, 'n:a').collapsed).toBe(true)
-	})
-})
-
-describe('the References placed at a Section', () => {
-	// Numbered by position in the Plan's list, which is what `references.ts`
-	// marks them with — a footnote number rather than anything stored.
-	const { nodes } = planMap(
-		makePlan({
-			outline: [makeNode({ id: 'a' }), makeNode({ id: 'b' })],
-			references: [
-				makeReference({ id: 'r1', nodeId: 'b' }),
-				makeReference({ id: 'r2', nodeId: null }),
-				makeReference({ id: 'r3', nodeId: 'b' }),
-			],
-		}),
-	)
-
-	it('marks each box with the numbers placed there', () => {
-		expect(at(nodes, 'n:b').referenceNumbers).toEqual([1, 3])
-		expect(at(nodes, 'n:a').referenceNumbers).toEqual([])
-	})
-
-	// A Reference is placed at a Section or at nothing, so the title never
-	// carries one and its box never grows a row for it.
-	it('leaves the root out of it', () => {
-		expect(at(nodes, 'root').referenceNumbers).toEqual([])
-	})
-
-	it('gives the box a row to say them in', () => {
-		expect(at(nodes, 'n:b').height).toBe(48 + 16)
-		expect(at(nodes, 'n:a').height).toBe(48)
+		expect(at(folded.nodes, 'n:a').childCount).toBe(2)
+		expect(at(folded.nodes, 'n:a').collapsed).toBe(true)
 	})
 })
 
 describe('the path back to the root', () => {
-	const { nodes } = mapOf([makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] })])
+	const { nodes } = mapOf([makeNode({ id: 'a' })], {
+		references: [makeReference({ id: 'r1', nodeId: 'a', text: 'One' })],
+	})
 
 	it('lists every ancestor, nearest first', () => {
-		expect(at(nodes, 'n:a1').ancestors).toEqual(['n:a', 'root'])
+		expect(at(nodes, 'r:r1').ancestors).toEqual(['n:a', 'root'])
 		expect(at(nodes, 'n:a').ancestors).toEqual(['root'])
 		expect(at(nodes, 'root').ancestors).toEqual([])
+	})
+})
+
+describe('what a box stands for', () => {
+	it('gives back the Plan id, and nothing at the title', () => {
+		const { nodes } = mapOf([makeNode({ id: 'a' })], {
+			references: [makeReference({ id: 'r1', nodeId: 'a', text: 'One' })],
+		})
+
+		expect(subjectId(at(nodes, 'root').subject)).toBeNull()
+		expect(subjectId(at(nodes, 'n:a').subject)).toBe('a')
+		expect(subjectId(at(nodes, 'r:r1').subject)).toBe('r1')
 	})
 })
 
@@ -223,8 +287,7 @@ describe('the curve between two boxes', () => {
 	const parent: MapNode = {
 		key: 'root',
 		parentKey: null,
-		nodeId: null,
-		node: null,
+		subject: { kind: 'article' },
 		title: '',
 		ordinal: '',
 		depth: 0,
@@ -262,10 +325,12 @@ describe('the curve between two boxes', () => {
 
 describe('what the SVG has to be big enough for', () => {
 	it('reaches the far edge of the deepest column and the lowest box', () => {
-		const { nodes, width, height } = mapOf([
-			makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] }),
-			makeNode({ id: 'b' }),
-		])
+		const { nodes, width, height } = mapOf(
+			[makeNode({ id: 'a' }), makeNode({ id: 'b' })],
+			{
+				references: [makeReference({ id: 'r1', nodeId: 'a', text: 'One' })],
+			},
+		)
 
 		expect(width).toBe(COLUMN * 2 + NODE)
 		expect(height).toBe(Math.max(...nodes.map((node) => node.y + node.height)))

--- a/test/client/plan-map.test.ts
+++ b/test/client/plan-map.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest'
+
+import type { MapNode } from '../../src/client/plan/map'
+import { linkPath, planMap } from '../../src/client/plan/map'
+import type { OutlineNode } from '../../src/shared/plan'
+import { makeNode, makePlan } from '../shared/plan-fixtures'
+
+/**
+ * Where the Map View puts each box. The defaults the layout ships with are the
+ * numbers below: a box is 210 wide, columns sit 40 apart, rows sit 10 apart,
+ * and a box is 48 tall until it carries an intent note, which makes it 66.
+ */
+
+const NODE = 210
+const COLUMN = NODE + 40
+const ROW = 48 + 10
+
+/** The map of a Plan whose Outline is the nodes given. */
+function mapOf(outline: OutlineNode[]) {
+	return planMap(makePlan({ title: 'The article', outline }))
+}
+
+function at(nodes: MapNode[], key: string): MapNode {
+	const found = nodes.find((node) => node.key === key)
+	if (found === undefined) throw new Error(`No box for ${key}`)
+
+	return found
+}
+
+describe('what the map holds', () => {
+	it('makes the Article title the root, and hangs the Sections off it', () => {
+		const { nodes } = mapOf([makeNode({ id: 'a' }), makeNode({ id: 'b' })])
+
+		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:a', 'n:b'])
+		expect(at(nodes, 'root').title).toBe('The article')
+		expect(at(nodes, 'root').nodeId).toBeNull()
+	})
+
+	// A Section whose id is "root" would otherwise take the title's own key.
+	it('keys a Section apart from the root even where its id is root', () => {
+		const { nodes } = mapOf([makeNode({ id: 'root' })])
+
+		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:root'])
+	})
+
+	it('numbers rows the way the Outline does', () => {
+		const { nodes } = mapOf([
+			makeNode({ id: 'a' }),
+			makeNode({ id: 'b', children: [makeNode({ id: 'b1' }), makeNode({ id: 'b2' })] }),
+		])
+
+		expect(nodes.map((node) => node.ordinal)).toEqual(['', '1', '2', '2.1', '2.2'])
+	})
+
+	it('draws a Plan with no Sections as the title on its own', () => {
+		const { nodes, links } = mapOf([])
+
+		expect(nodes).toHaveLength(1)
+		expect(links).toHaveLength(0)
+	})
+})
+
+describe('where the boxes sit', () => {
+	it('puts each depth in its own column', () => {
+		const { nodes } = mapOf([makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] })])
+
+		expect(at(nodes, 'root').x).toBe(0)
+		expect(at(nodes, 'n:a').x).toBe(COLUMN)
+		expect(at(nodes, 'n:a1').x).toBe(COLUMN * 2)
+	})
+
+	it('stacks the leaves down the page in reading order', () => {
+		const { nodes } = mapOf([makeNode({ id: 'a' }), makeNode({ id: 'b' })])
+
+		expect(at(nodes, 'n:a').y).toBe(0)
+		expect(at(nodes, 'n:b').y).toBe(ROW)
+	})
+
+	it('centres a parent on the children it holds', () => {
+		const { nodes } = mapOf([makeNode({ id: 'a' }), makeNode({ id: 'b' })])
+
+		const middle = (node: MapNode) => node.y + node.height / 2
+		const root = at(nodes, 'root')
+
+		expect(middle(root)).toBe((middle(at(nodes, 'n:a')) + middle(at(nodes, 'n:b'))) / 2)
+	})
+
+	// The height a Section takes is what a fixed-size tree layout cannot state,
+	// so the layout asks for it per node rather than assuming one number.
+	it('gives a Section carrying an intent note a taller box', () => {
+		const { nodes } = mapOf([
+			makeNode({ id: 'a', intent: 'What this Section does' }),
+			makeNode({ id: 'b' }),
+		])
+
+		expect(at(nodes, 'n:a').height).toBe(66)
+		expect(at(nodes, 'n:b').height).toBe(48)
+		expect(at(nodes, 'n:b').y).toBe(66 + 10)
+	})
+})
+
+describe('a parent that would ride up into the box above it', () => {
+	// A parent taller than the subtree under it centres above its own floor. It
+	// takes the floor instead, and the subtree moves down with it rather than
+	// being left behind.
+	const tall = planMap(
+		makePlan({
+			outline: [
+				makeNode({ id: 'a' }),
+				makeNode({ id: 'b', children: [makeNode({ id: 'b1' })] }),
+			],
+		}),
+		{ heightOf: (_node, depth) => (depth === 1 ? 100 : 44) },
+	)
+
+	it('drops the parent to the floor', () => {
+		expect(at(tall.nodes, 'n:a').y).toBe(0)
+		expect(at(tall.nodes, 'n:b').y).toBe(110)
+	})
+
+	it('moves the child down by the same amount', () => {
+		expect(at(tall.nodes, 'n:b1').y).toBe(138)
+	})
+})
+
+describe('no two boxes in one column overlap', () => {
+	// Three subtrees of different shapes, so the check meets a short one next to
+	// a tall one in both orders.
+	const { nodes } = mapOf([
+		makeNode({ id: 'a' }),
+		makeNode({
+			id: 'b',
+			intent: 'A note, which makes this box taller',
+			children: [makeNode({ id: 'b1' }), makeNode({ id: 'b2' }), makeNode({ id: 'b3' })],
+		}),
+		makeNode({ id: 'c', children: [makeNode({ id: 'c1' })] }),
+		makeNode({ id: 'd' }),
+	])
+
+	const depths = [...new Set(nodes.map((node) => node.depth))]
+
+	it.each(depths)('holds in column %i', (depth) => {
+		const column = nodes
+			.filter((node) => node.depth === depth)
+			.sort((one, two) => one.y - two.y)
+
+		for (const [index, node] of column.entries()) {
+			if (index === 0) continue
+			const above = column[index - 1]!
+			expect(node.y, `${node.key} sits inside ${above.key}`).toBeGreaterThanOrEqual(
+				above.y + above.height,
+			)
+		}
+	})
+})
+
+describe('a collapsed Section', () => {
+	const { nodes, links } = planMap(
+		makePlan({
+			outline: [
+				makeNode({ id: 'a', children: [makeNode({ id: 'a1' }), makeNode({ id: 'a2' })] }),
+			],
+		}),
+		{ collapsed: new Set(['a']) },
+	)
+
+	it('leaves its children undrawn', () => {
+		expect(nodes.map((node) => node.key)).toEqual(['root', 'n:a'])
+		expect(links).toHaveLength(1)
+	})
+
+	// The box says how much is folded away, so the writer knows there is
+	// something to open rather than reading a leaf.
+	it('still says how many children it holds', () => {
+		expect(at(nodes, 'n:a').childCount).toBe(2)
+		expect(at(nodes, 'n:a').collapsed).toBe(true)
+	})
+})
+
+describe('the path back to the root', () => {
+	const { nodes } = mapOf([makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] })])
+
+	it('lists every ancestor, nearest first', () => {
+		expect(at(nodes, 'n:a1').ancestors).toEqual(['n:a', 'root'])
+		expect(at(nodes, 'n:a').ancestors).toEqual(['root'])
+		expect(at(nodes, 'root').ancestors).toEqual([])
+	})
+})
+
+describe('the curve between two boxes', () => {
+	const parent: MapNode = {
+		key: 'root',
+		parentKey: null,
+		nodeId: null,
+		node: null,
+		title: '',
+		ordinal: '',
+		depth: 0,
+		x: 0,
+		y: 27,
+		width: 180,
+		height: 44,
+		childCount: 1,
+		collapsed: false,
+		ancestors: [],
+	}
+	const child: MapNode = {
+		...parent,
+		key: 'n:a',
+		parentKey: 'root',
+		x: 224,
+		y: 0,
+		depth: 1,
+	}
+
+	// Out of the parent's right edge, into the child's left edge, turning at the
+	// midpoint between the two columns — the cubic `curveBumpX` generates.
+	it('leaves one edge and arrives at the other', () => {
+		expect(linkPath(parent, child)).toBe('M180,49C202,49 202,22 224,22')
+	})
+
+	it('is what the map hands back', () => {
+		const { nodes, links } = mapOf([makeNode({ id: 'a' })])
+
+		expect(links).toHaveLength(1)
+		expect(links[0]!.d).toBe(linkPath(at(nodes, 'root'), at(nodes, 'n:a')))
+	})
+})
+
+describe('what the SVG has to be big enough for', () => {
+	it('reaches the far edge of the deepest column and the lowest box', () => {
+		const { nodes, width, height } = mapOf([
+			makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] }),
+			makeNode({ id: 'b' }),
+		])
+
+		expect(width).toBe(COLUMN * 2 + NODE)
+		expect(height).toBe(Math.max(...nodes.map((node) => node.y + node.height)))
+	})
+})

--- a/test/client/plan-map.test.ts
+++ b/test/client/plan-map.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from 'vitest'
 import type { MapNode } from '../../src/client/plan/map'
 import { linkPath, planMap } from '../../src/client/plan/map'
 import type { OutlineNode } from '../../src/shared/plan'
-import { makeNode, makePlan } from '../shared/plan-fixtures'
+import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
 
 /**
  * Where the Map View puts each box. The defaults the layout ships with are the
- * numbers below: a box is 210 wide, columns sit 40 apart, rows sit 10 apart,
- * and a box is 48 tall until it carries an intent note, which makes it 66.
+ * numbers below: a box is 210 wide, columns sit 40 apart, and rows sit 10
+ * apart. A box is 48 tall, plus 18 where it carries an intent note and 16 where
+ * References are placed at it.
  */
 
 const NODE = 210
@@ -177,6 +178,37 @@ describe('a collapsed Section', () => {
 	})
 })
 
+describe('the References placed at a Section', () => {
+	// Numbered by position in the Plan's list, which is what `references.ts`
+	// marks them with — a footnote number rather than anything stored.
+	const { nodes } = planMap(
+		makePlan({
+			outline: [makeNode({ id: 'a' }), makeNode({ id: 'b' })],
+			references: [
+				makeReference({ id: 'r1', nodeId: 'b' }),
+				makeReference({ id: 'r2', nodeId: null }),
+				makeReference({ id: 'r3', nodeId: 'b' }),
+			],
+		}),
+	)
+
+	it('marks each box with the numbers placed there', () => {
+		expect(at(nodes, 'n:b').referenceNumbers).toEqual([1, 3])
+		expect(at(nodes, 'n:a').referenceNumbers).toEqual([])
+	})
+
+	// A Reference is placed at a Section or at nothing, so the title never
+	// carries one and its box never grows a row for it.
+	it('leaves the root out of it', () => {
+		expect(at(nodes, 'root').referenceNumbers).toEqual([])
+	})
+
+	it('gives the box a row to say them in', () => {
+		expect(at(nodes, 'n:b').height).toBe(48 + 16)
+		expect(at(nodes, 'n:a').height).toBe(48)
+	})
+})
+
 describe('the path back to the root', () => {
 	const { nodes } = mapOf([makeNode({ id: 'a', children: [makeNode({ id: 'a1' })] })])
 
@@ -201,6 +233,7 @@ describe('the curve between two boxes', () => {
 		width: 180,
 		height: 44,
 		childCount: 1,
+		referenceNumbers: [],
 		collapsed: false,
 		ancestors: [],
 	}


### PR DESCRIPTION
The Plan Panel now offers two Views of the Outline: the existing list, and a new map that opens the Plan left to right. The map shows the Article title as the root, one layer of Sections, and References placed at each — three columns total, which is the whole Plan. An unplaced Reference stays in the list below.

**Key changes:**

- **PlanMap component** (`src/client/plan/PlanMap.tsx`): Renders the map View, handling layout, folding, opening Sections for editing, and adding new ones. An open Section's fields sit over the map, anchored at its box, so nothing reflows around what the writer is editing.

- **Map geometry** (`src/client/plan/map.ts`): Arithmetic-only module that lays out the Plan left to right. Leaves stack down the page in reading order; a parent centres on its children. Where centring would ride a parent up into the box above it, the parent takes the floor instead and its subtree moves down with it, preserving shape.

- **ViewRail component** (`src/client/plan/ViewRail.tsx`): Toggle between list and map Views, mirroring the pattern of PanelRail.

- **Rail component** (`src/client/components/Rail.tsx`): Extracted from PanelRail to serve both the Panel rail and the View rail. A row of pills where one or more are on; deliberately not accented, since what is on is state, not a call to action.

- **PlanPanel integration** (`src/client/plan/PlanPanel.tsx`): Wired ViewRail to switch between list and map Views. The map's own `+` button makes Sections; the Panel's controls stand down while the map is up.

- **SectionRow enhancement** (`src/client/plan/SectionRow.tsx`): Added PlaceReference control to place References from within a Section's fields, matching the map's affordance.

- **Tests** (`test/client/plan-map.test.ts`): Comprehensive coverage of map layout, both `references` and `sections` shapes, folding, and path ancestry.

- **Storybook screens**: Added PlanMapScreen and updated PlanAnArticle story to demonstrate the map View and its interaction with the list.

- **Documentation**: Updated `docs/architecture.md` and `context.md` to describe the two Views and their relationship.

The map reads as the Plan opening rather than as a card arriving from nowhere. Escape or a click on the space between boxes closes an open Section. A Section made with nothing in it is thrown away when the writer leaves it.

https://claude.ai/code/session_01M3DrEgAMbbs2FTEFEqVtV4