### PR TITLE
Scale the Board's columns, and swap each column's fill for a divider

### DIFF
--- a/.storybook/screens/global/Global.stories.tsx
+++ b/.storybook/screens/global/Global.stories.tsx
@@ -44,12 +44,12 @@ export const B_Board: Story = {
 			<BoardScreen />
 			<Annotation>
 				Reading only. No drag-and-drop: the writer sets an Article's status on the Article
-				screen, which is where they are when they decide it has moved on. Any window with
-				room for four columns — 1298px and up — takes four even quarters and no sideways
-				scroll. Below that the columns scale down to 16rem and then hold, so the Board
-				scrolls sideways rather than squeezing four columns into a phone. A hairline in
-				the gutter separates them, one card tall — enough to read four columns as four
-				without a fill behind each.
+				screen, which is where they are when they decide it has moved on. At `lg` —
+				1298px, a maximized window on the main writer's monitor — the columns take four
+				even quarters and there is no sideways scroll. Below that they scale down to 16rem
+				and then hold, so the Board scrolls sideways rather than squeezing four columns
+				into a phone. A hairline in the gutter separates them, one card tall — enough to
+				read four columns as four without a fill behind each.
 			</Annotation>
 		</div>
 	),

--- a/.storybook/screens/global/Global.stories.tsx
+++ b/.storybook/screens/global/Global.stories.tsx
@@ -45,9 +45,10 @@ export const B_Board: Story = {
 			<Annotation>
 				Reading only. No drag-and-drop: the writer sets an Article's status on the Article
 				screen, which is where they are when they decide it has moved on. A hairline in
-				the gutter separates the columns, one card tall — enough to read four columns as
-				four without a fill behind each. The columns scale with the window and the Board
-				scrolls sideways rather than squeezing four columns into a phone.
+				the gutter separates the columns, running a little past the first card — enough to
+				read four columns as four without a fill behind each. The columns scale with the
+				window and the Board scrolls sideways rather than squeezing four columns into a
+				phone.
 			</Annotation>
 		</div>
 	),

--- a/.storybook/screens/global/Global.stories.tsx
+++ b/.storybook/screens/global/Global.stories.tsx
@@ -44,11 +44,12 @@ export const B_Board: Story = {
 			<BoardScreen />
 			<Annotation>
 				Reading only. No drag-and-drop: the writer sets an Article's status on the Article
-				screen, which is where they are when they decide it has moved on. A 1298px window
-				shows four even columns and no sideways scroll; narrower than that the columns
-				scale down to 16rem and then hold, so the Board scrolls sideways rather than
-				squeezing four columns into a phone. A hairline in the gutter separates them, one
-				card tall — enough to read four columns as four without a fill behind each.
+				screen, which is where they are when they decide it has moved on. Any window with
+				room for four columns — 1298px and up — takes four even quarters and no sideways
+				scroll. Below that the columns scale down to 16rem and then hold, so the Board
+				scrolls sideways rather than squeezing four columns into a phone. A hairline in
+				the gutter separates them, one card tall — enough to read four columns as four
+				without a fill behind each.
 			</Annotation>
 		</div>
 	),

--- a/.storybook/screens/global/Global.stories.tsx
+++ b/.storybook/screens/global/Global.stories.tsx
@@ -44,12 +44,10 @@ export const B_Board: Story = {
 			<BoardScreen />
 			<Annotation>
 				Reading only. No drag-and-drop: the writer sets an Article's status on the Article
-				screen, which is where they are when they decide it has moved on. At `lg` —
-				1298px, a maximized window on the main writer's monitor — the columns take four
-				even quarters and there is no sideways scroll. Below that they scale down to 16rem
-				and then hold, so the Board scrolls sideways rather than squeezing four columns
-				into a phone. A hairline in the gutter separates them, one card tall — enough to
-				read four columns as four without a fill behind each.
+				screen, which is where they are when they decide it has moved on. A hairline in
+				the gutter separates the columns, one card tall — enough to read four columns as
+				four without a fill behind each. The columns scale with the window and the Board
+				scrolls sideways rather than squeezing four columns into a phone.
 			</Annotation>
 		</div>
 	),

--- a/.storybook/screens/global/Global.stories.tsx
+++ b/.storybook/screens/global/Global.stories.tsx
@@ -44,9 +44,11 @@ export const B_Board: Story = {
 			<BoardScreen />
 			<Annotation>
 				Reading only. No drag-and-drop: the writer sets an Article's status on the Article
-				screen, which is where they are when they decide it has moved on. The columns keep
-				their width and the Board scrolls sideways rather than squeezing four columns into
-				a phone.
+				screen, which is where they are when they decide it has moved on. A 1298px window
+				shows four even columns and no sideways scroll; narrower than that the columns
+				scale down to 16rem and then hold, so the Board scrolls sideways rather than
+				squeezing four columns into a phone. A hairline in the gutter separates them, one
+				card tall — enough to read four columns as four without a fill behind each.
 			</Annotation>
 		</div>
 	),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -440,13 +440,6 @@ narrow screen. `usePanels` holds which are open, keeps them in the one order the
 and refuses to close the last of them. All four stay mounted and a closed one is hidden. The
 **Areas** are Articles (with Board and Archive Views), House, and Team.
 
-**Three screen sizes, and the scale holds no others.** `theme.css` clears Tailwind's
-breakpoints and names two: `md` at 48rem is a laptop, and `lg` at 1298px is a maximized
-window on the main writer's monitor. A phone is the unprefixed one, so it has no name to
-misuse. `sm`, `xl`, and `2xl` generate nothing, and Tailwind fails an unknown variant
-silently, so a fourth tier is a decision made in the theme rather than a prefix someone
-reaches for.
-
 **A screen never draws a value it has not got.** An empty title, a zero count and four empty
 columns are answers, and a screen that puts one on the page before it has read anything has
 said something untrue. Whatever is still coming says so — `Skeleton` where the shape is

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -454,9 +454,10 @@ an Article and then leaving it.
 
 **The Articles Area is the list at `/` and the Board View at `/board`**, over the one index
 read, under a pathless layout route that holds both. The Board draws a column per status,
-sizes each at `clamp(16rem, 30%, 307px)`, and scrolls sideways rather than squeezing them
-below 16rem. 307px is a quarter of the rail at a 1298px window, so a window that wide or
-wider shows four even columns with no sideways scroll at all. It carries no
+grows them to share the rail off a `clamp(16rem, 30%, 307px)` basis, and scrolls sideways
+rather than squeezing them below 16rem. A window with room for four columns takes four even
+quarters, and 307px — a quarter of the rail at 1298px — is where growing stops and scrolling
+starts. It carries no
 drag-and-drop and no control on a card: the writer sets a status on the Article screen,
 which is where they are when they decide the piece has moved on. The Archive View is not built, and Archived Articles are a group at the foot of
 the list until it is.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -441,10 +441,11 @@ and refuses to close the last of them. All four stay mounted and a closed one is
 **Areas** are Articles (with Board and Archive Views), House, and Team.
 
 **Three screen sizes, and the scale holds no others.** `theme.css` clears Tailwind's
-breakpoints and names two: `sm` at 48rem is a small laptop, and `lg` at 1298px is a maximized
-window on the main writer's monitor. Everything below `sm` is a phone. `md`, `xl`, and `2xl`
-generate nothing, so a fourth tier is a decision made in the theme rather than a prefix
-someone reaches for.
+breakpoints and names two: `md` at 48rem is a laptop, and `lg` at 1298px is a maximized
+window on the main writer's monitor. A phone is the unprefixed one, so it has no name to
+misuse. `sm`, `xl`, and `2xl` generate nothing, and Tailwind fails an unknown variant
+silently, so a fourth tier is a decision made in the theme rather than a prefix someone
+reaches for.
 
 **A screen never draws a value it has not got.** An empty title, a zero count and four empty
 columns are answers, and a screen that puts one on the page before it has read anything has

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -454,13 +454,8 @@ an Article and then leaving it.
 
 **The Articles Area is the list at `/` and the Board View at `/board`**, over the one index
 read, under a pathless layout route that holds both. The Board draws a column per status,
-sizes them at `clamp(16rem, 30%, 307px)`, and scrolls sideways rather than squeezing them
-below 16rem. At `lg` the columns grow to share the rail instead, so the widest screen takes
-four even quarters — 307px is a quarter of the rail at 1298px, which is what makes the two
-rules meet at the breakpoint rather than jump. It carries no
-drag-and-drop and no control on a card: the writer sets a status on the Article screen,
-which is where they are when they decide the piece has moved on. The Archive View is not built, and Archived Articles are a group at the foot of
-the list until it is.
+and scrolls sideways. The Archive View is not built yet, so Archived Articles are a group at
+the foot of the list until it is.
 
 **The list's tiles supplement it rather than replacing rows in it.** The three most recently
 changed Articles sit on top as tiles, and every one of them is still listed underneath, so

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -440,6 +440,12 @@ narrow screen. `usePanels` holds which are open, keeps them in the one order the
 and refuses to close the last of them. All four stay mounted and a closed one is hidden. The
 **Areas** are Articles (with Board and Archive Views), House, and Team.
 
+**Three screen sizes, and the scale holds no others.** `theme.css` clears Tailwind's
+breakpoints and names two: `sm` at 48rem is a small laptop, and `lg` at 1298px is a maximized
+window on the main writer's monitor. Everything below `sm` is a phone. `md`, `xl`, and `2xl`
+generate nothing, so a fourth tier is a decision made in the theme rather than a prefix
+someone reaches for.
+
 **A screen never draws a value it has not got.** An empty title, a zero count and four empty
 columns are answers, and a screen that puts one on the page before it has read anything has
 said something untrue. Whatever is still coming says so — `Skeleton` where the shape is
@@ -454,10 +460,10 @@ an Article and then leaving it.
 
 **The Articles Area is the list at `/` and the Board View at `/board`**, over the one index
 read, under a pathless layout route that holds both. The Board draws a column per status,
-grows them to share the rail off a `clamp(16rem, 30%, 307px)` basis, and scrolls sideways
-rather than squeezing them below 16rem. A window with room for four columns takes four even
-quarters, and 307px — a quarter of the rail at 1298px — is where growing stops and scrolling
-starts. It carries no
+sizes them at `clamp(16rem, 30%, 307px)`, and scrolls sideways rather than squeezing them
+below 16rem. At `lg` the columns grow to share the rail instead, so the widest screen takes
+four even quarters — 307px is a quarter of the rail at 1298px, which is what makes the two
+rules meet at the breakpoint rather than jump. It carries no
 drag-and-drop and no control on a card: the writer sets a status on the Article screen,
 which is where they are when they decide the piece has moved on. The Archive View is not built, and Archived Articles are a group at the foot of
 the list until it is.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -454,7 +454,9 @@ an Article and then leaving it.
 
 **The Articles Area is the list at `/` and the Board View at `/board`**, over the one index
 read, under a pathless layout route that holds both. The Board draws a column per status,
-keeps its columns' width, and scrolls sideways rather than squeezing them. It carries no
+sizes each at `clamp(16rem, 30%, 307px)`, and scrolls sideways rather than squeezing them
+below 16rem. 307px is a quarter of the rail at a 1298px window, so a window that wide or
+wider shows four even columns with no sideways scroll at all. It carries no
 drag-and-drop and no control on a card: the writer sets a status on the Article screen,
 which is where they are when they decide the piece has moved on. The Archive View is not built, and Archived Articles are a group at the foot of
 the list until it is.

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -8,7 +8,7 @@ import { BackLink, TitleBar } from '../components/TitleBar'
 import { cx } from '../lib/cx'
 import { boardColumns } from './grouping'
 
-const columnWidth = 'grow basis-[clamp(16rem,30%,307px)]'
+const columnWidth = 'w-[clamp(16rem,30%,307px)] lg:w-auto lg:grow lg:basis-0'
 
 const columnDivider =
 	'before:absolute before:top-0 before:-left-1.5 before:h-24 before:w-px before:bg-rule'

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -8,29 +8,8 @@ import { BackLink, TitleBar } from '../components/TitleBar'
 import { cx } from '../lib/cx'
 import { boardColumns } from './grouping'
 
-/**
- * A column's width, and the one number the Board's layout turns on.
- *
- * The columns grow to share the rail, so any window with room for four takes
- * four even quarters and no sideways scroll — never four columns and a gap on
- * the right.
- *
- * 307px is where growing stops and scrolling starts: a quarter of the rail at a
- * 1298px window, once three 12px gaps and the rail's own 16px of padding each
- * side are out. Narrower than that, the columns hold 307px and the Board
- * scrolls sideways until 30% of the rail is the smaller number (≈1055px, with
- * two thirds of Done off the end), and from there every column shrinks
- * together. 16rem is the floor: past it the columns hold their width again and
- * more of the Board's right-hand end goes into the scroll zone.
- */
 const columnWidth = 'grow basis-[clamp(16rem,30%,307px)]'
 
-/**
- * The hairline in the gutter, standing in for the fill each column used to
- * carry. It is one card tall because it marks where a column starts rather than
- * fencing the whole of it, and it sits half a gutter left of the column edge,
- * which centres it in the gap.
- */
 const columnDivider =
 	'before:absolute before:top-0 before:-left-1.5 before:h-24 before:w-px before:bg-rule'
 

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -11,7 +11,7 @@ import { boardColumns } from './grouping'
 const columnWidth = 'w-[clamp(16rem,30%,307px)] lg:w-auto lg:grow lg:basis-0'
 
 const columnDivider =
-	'before:absolute before:top-0 before:-left-1.5 before:h-30 before:w-px before:bg-rule'
+	'before:absolute before:top-0 before:-left-1.5 before:h-40 before:w-px before:bg-rule'
 
 /**
  * The Board View: the same unarchived Articles the list shows, by status.

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -11,7 +11,7 @@ import { boardColumns } from './grouping'
 const columnWidth = 'w-[clamp(16rem,30%,307px)] lg:w-auto lg:grow lg:basis-0'
 
 const columnDivider =
-	'before:absolute before:top-0 before:-left-1.5 before:h-24 before:w-px before:bg-rule'
+	'before:absolute before:top-0 before:-left-1.5 before:h-30 before:w-px before:bg-rule'
 
 /**
  * The Board View: the same unarchived Articles the list shows, by status.
@@ -64,7 +64,7 @@ export function BoardView({ articles, failure = null, onNew }: BoardViewProps) {
 						{/* The negative margin runs the rule to the middle of each gutter,
 						    so the four rules meet and read as one line. */}
 						<MetaLabel
-							className="-mx-1.5 shrink-0 border-b border-rule px-1.5 pb-1.5"
+							className="-mx-1.5 shrink-0 border-b border-rule px-1.5 py-1.5"
 							count={column.articles.length}
 						>
 							{column.label}

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -5,7 +5,32 @@ import { FrameBody } from '../components/Frame'
 import { MetaLabel } from '../components/MetaLabel'
 import { Notice } from '../components/Notice'
 import { BackLink, TitleBar } from '../components/TitleBar'
+import { cx } from '../lib/cx'
 import { boardColumns } from './grouping'
+
+/**
+ * A column's width, and the one number the Board's layout turns on.
+ *
+ * 307px is a quarter of the rail at a 1298px window: four columns, three 12px
+ * gaps, and the rail's own 16px of padding each side. So 1298px and wider shows
+ * four even columns with nothing in the scroll zone.
+ *
+ * Narrower than that, the columns hold 307px and the Board scrolls sideways
+ * until 30% of the rail is the smaller number (≈1055px, with two thirds of Done
+ * off the end), and from there every column shrinks together. 16rem is the
+ * floor: past it the columns hold their width again and more of the Board's
+ * right-hand end goes into the scroll zone.
+ */
+const columnWidth = 'w-[clamp(16rem,30%,307px)]'
+
+/**
+ * The hairline in the gutter, standing in for the fill each column used to
+ * carry. It is one card tall because it marks where a column starts rather than
+ * fencing the whole of it, and it sits half a gutter left of the column edge,
+ * which centres it in the gap.
+ */
+const columnDivider =
+	'before:absolute before:top-0 before:-left-1.5 before:h-24 before:w-px before:bg-rule'
 
 /**
  * The Board View: the same unarchived Articles the list shows, by status.
@@ -43,14 +68,24 @@ export function BoardView({ articles, failure = null, onNew }: BoardViewProps) {
 				</div>
 			)}
 			<FrameBody className="gap-3 overflow-x-auto p-4" row>
-				{columns.map((column) => (
-					// A sunk fill, so four columns read as four rather than as one field
-					// of cards. The tiles stay white and lift off it.
+				{columns.map((column, index) => (
+					// A divider in the gutter and a rule under the label, so four columns
+					// read as four. The column itself draws nothing, which is what lets
+					// the gutter stay this narrow: the tiles are the only boxes here.
 					<div
-						className="flex w-[12rem] shrink-0 flex-col gap-2 rounded-lg border border-rule bg-sage p-2"
+						className={cx(
+							'relative flex shrink-0 flex-col gap-2',
+							columnWidth,
+							index === 0 ? null : columnDivider,
+						)}
 						key={column.status}
 					>
-						<MetaLabel className="shrink-0 px-0.5" count={column.articles.length}>
+						{/* The negative margin runs the rule to the middle of each gutter,
+						    so the four rules meet and read as one line. */}
+						<MetaLabel
+							className="-mx-1.5 shrink-0 border-b border-rule px-1.5 pb-1.5"
+							count={column.articles.length}
+						>
 							{column.label}
 						</MetaLabel>
 						{/* Each column scrolls its own Y. */}

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -11,17 +11,19 @@ import { boardColumns } from './grouping'
 /**
  * A column's width, and the one number the Board's layout turns on.
  *
- * 307px is a quarter of the rail at a 1298px window: four columns, three 12px
- * gaps, and the rail's own 16px of padding each side. So 1298px and wider shows
- * four even columns with nothing in the scroll zone.
+ * The columns grow to share the rail, so any window with room for four takes
+ * four even quarters and no sideways scroll — never four columns and a gap on
+ * the right.
  *
- * Narrower than that, the columns hold 307px and the Board scrolls sideways
- * until 30% of the rail is the smaller number (≈1055px, with two thirds of Done
- * off the end), and from there every column shrinks together. 16rem is the
- * floor: past it the columns hold their width again and more of the Board's
- * right-hand end goes into the scroll zone.
+ * 307px is where growing stops and scrolling starts: a quarter of the rail at a
+ * 1298px window, once three 12px gaps and the rail's own 16px of padding each
+ * side are out. Narrower than that, the columns hold 307px and the Board
+ * scrolls sideways until 30% of the rail is the smaller number (≈1055px, with
+ * two thirds of Done off the end), and from there every column shrinks
+ * together. 16rem is the floor: past it the columns hold their width again and
+ * more of the Board's right-hand end goes into the scroll zone.
  */
-const columnWidth = 'w-[clamp(16rem,30%,307px)]'
+const columnWidth = 'grow basis-[clamp(16rem,30%,307px)]'
 
 /**
  * The hairline in the gutter, standing in for the fill each column used to

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -57,8 +57,6 @@
 
 	--radius-frame: 0.625rem;
 
-	/* Three screens, and no more. A phone is the unprefixed one, `md` is a
-	   laptop, and `lg` is a maximized window on the main user's monitor. */
 	--breakpoint-*: initial;
 	--breakpoint-md: 48rem; /* 768px */
 	--breakpoint-lg: 1298px;

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -58,10 +58,7 @@
 	--radius-frame: 0.625rem;
 
 	/* Three screens, and no more. A phone is the unprefixed one, `md` is a
-	   laptop, and `lg` is a maximized window on the main user's monitor.
-	   Clearing the scale first drops Tailwind's sm, xl, and 2xl, so a fourth
-	   tier has to be added here on purpose rather than reached for in a
-	   className. */
+	   laptop, and `lg` is a maximized window on the main user's monitor. */
 	--breakpoint-*: initial;
 	--breakpoint-md: 48rem; /* 768px */
 	--breakpoint-lg: 1298px;

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -57,12 +57,13 @@
 
 	--radius-frame: 0.625rem;
 
-	/* Three screens, and no more: a phone, a small laptop, and a maximized
-	   window on the main user's monitor. Clearing the scale first drops
-	   Tailwind's md, xl, and 2xl, so a fourth tier has to be added here on
-	   purpose rather than reached for in a className. */
+	/* Three screens, and no more. A phone is the unprefixed one, `md` is a
+	   laptop, and `lg` is a maximized window on the main user's monitor.
+	   Clearing the scale first drops Tailwind's sm, xl, and 2xl, so a fourth
+	   tier has to be added here on purpose rather than reached for in a
+	   className. */
 	--breakpoint-*: initial;
-	--breakpoint-sm: 48rem; /* 768px */
+	--breakpoint-md: 48rem; /* 768px */
 	--breakpoint-lg: 1298px;
 
 	/* One depth, cast in whichever direction the thing lifts: the outermost

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -19,7 +19,7 @@
 	--color-paper: #fbecdb; /* the desk the app sits on: red-brown earth */
 	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
 	--color-sunk: #f7f2ea; /* secondary panes: plan, notes, sidebars */
-	--color-sage: #d5ead3; /* chrome: title bars, Board columns */
+	--color-sage: #d5ead3; /* chrome: title bars */
 	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -57,6 +57,14 @@
 
 	--radius-frame: 0.625rem;
 
+	/* Three screens, and no more: a phone, a small laptop, and a maximized
+	   window on the main user's monitor. Clearing the scale first drops
+	   Tailwind's md, xl, and 2xl, so a fourth tier has to be added here on
+	   purpose rather than reached for in a className. */
+	--breakpoint-*: initial;
+	--breakpoint-sm: 48rem; /* 768px */
+	--breakpoint-lg: 1298px;
+
 	/* One depth, cast in whichever direction the thing lifts: the outermost
 	   frame downwards, a drawer rising from a Panel's foot upwards. */
 	--shadow-frame: 0 1px 2px rgb(43 34 41 / 0.05), 0 8px 24px -16px rgb(43 34 41 / 0.25);


### PR DESCRIPTION
The columns were a fixed 12rem, so a wide window left three quarters of the
Board empty and a narrow one scrolled sideways from the start. They now size at
clamp(16rem, 30%, 307px): 307px is a quarter of the rail at a 1298px window, so
1298px and wider shows four even columns with no sideways scroll at all.

Each column also drops its sunk fill, border, and padding for a hairline in the
gutter, one card tall, and a rule under the label that meets its neighbours. One
less background change per column is what lets the 12px gutter carry the
separation on its own.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B2dNFv97EYNsptCbathtAF