### PR TITLE
Sage chrome on a red-brown ground

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,7 +38,7 @@ const preview: Preview = {
 		controls: { expanded: true },
 		backgrounds: {
 			options: {
-				paper: { name: 'Paper', value: '#ebdccb' },
+				paper: { name: 'Paper', value: '#fbecdb' },
 				surface: { name: 'Surface', value: '#fbf9f5' },
 			},
 		},

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,7 +38,7 @@ const preview: Preview = {
 		controls: { expanded: true },
 		backgrounds: {
 			options: {
-				paper: { name: 'Paper', value: '#e9e2d5' },
+				paper: { name: 'Paper', value: '#ebdccb' },
 				surface: { name: 'Surface', value: '#fbf9f5' },
 			},
 		},

--- a/src/client/articles/BoardView.tsx
+++ b/src/client/articles/BoardView.tsx
@@ -47,7 +47,7 @@ export function BoardView({ articles, failure = null, onNew }: BoardViewProps) {
 					// A sunk fill, so four columns read as four rather than as one field
 					// of cards. The tiles stay white and lift off it.
 					<div
-						className="flex w-[12rem] shrink-0 flex-col gap-2 rounded-lg border border-rule bg-sunk p-2"
+						className="flex w-[12rem] shrink-0 flex-col gap-2 rounded-lg border border-rule bg-sage p-2"
 						key={column.status}
 					>
 						<MetaLabel className="shrink-0 px-0.5" count={column.articles.length}>

--- a/src/client/components/ArticleBar.tsx
+++ b/src/client/components/ArticleBar.tsx
@@ -25,9 +25,10 @@ export interface ArticleBarProps {
 }
 
 /**
- * The article window's own bar — quieter than {@link TitleBar} because it sits
- * above a writing surface. Title and status recede; the Panel rail is the only
- * thing with any weight.
+ * The article window's own bar. It takes the same sage as {@link TitleBar}, so
+ * the chrome reads as one band across every screen, but the type inside it is
+ * quieter: it sits above a writing surface, so title and status recede and the
+ * Panel rail is the only thing with any weight.
  */
 export function ArticleBar({
 	back,
@@ -44,7 +45,7 @@ export function ArticleBar({
 	return (
 		<header
 			className={cx(
-				'flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2',
+				'flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1.5 bg-sage px-3 py-2',
 				divided && 'border-b border-rule',
 				className,
 			)}

--- a/src/client/components/Frame.tsx
+++ b/src/client/components/Frame.tsx
@@ -60,7 +60,7 @@ export interface ScreenProps {
  */
 export function Screen({ children, className }: ScreenProps) {
 	return (
-		<div className={cx('flex h-dvh flex-col bg-surface text-ink', className)}>
+		<div className={cx('flex h-dvh flex-col bg-paper text-ink', className)}>
 			{children}
 		</div>
 	)

--- a/src/client/components/TitleBar.tsx
+++ b/src/client/components/TitleBar.tsx
@@ -23,7 +23,7 @@ export function TitleBar({ back, title, subtitle, actions, className }: TitleBar
 	return (
 		<header
 			className={cx(
-				'flex shrink-0 items-center gap-2.5 border-b border-edge bg-sunk px-4 py-2.5',
+				'flex shrink-0 items-center gap-2.5 border-b border-edge bg-sage px-4 py-2.5',
 				className,
 			)}
 		>

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -5,8 +5,9 @@ import { Meta } from '@storybook/addon-docs/blocks'
 # The accent
 
 The page is earth, ink and three soft neutrals, tinted off a Deccan winter: dry
-brown ground, pale scrub green in the secondary panes, dusty mauve in the meta.
-Those hues are scenery — they say nothing about the screen they are on.
+brown ground, sunlit granite in the secondary panes, scrub green in the
+secondary copy, dusty mauve in the meta. Those hues are scenery — they say
+nothing about the screen they are on.
 
 Two colours do carry meaning, and they answer different questions.
 `--color-green`, a deep scrub green, `#4c6141`, says **where you are**.
@@ -62,9 +63,8 @@ on**, or **the one item that has changed and you might not have noticed**.
 
 - **Which Panels, tabs or filters are selected.** The `PanelRail`'s active pill,
   `Chip variant="solid"` and a pressed `Button` take `--color-green`, a deep
-  scrub green — `--color-sunk` saturated and inverted, so a selected pill reads
-  as the deep of the pale green it sits on. Where you are is state, not a
-  request, and state does not need the accent.
+  scrub green. Where you are is state, not a request, and state does not need
+  the accent.
 - **Progress.** Bars are ink at 30% — a shape, not an alarm. The exception is
   going _over_ target, which flips to `accent-edge` because it is genuinely news.
 - **Ordinary emphasis.** Headings are weight and size. Metadata is `--color-faint`.
@@ -84,7 +84,7 @@ one of the two is not really asking for a decision.
   {[
     ['--color-paper', '#e9e2d5'],
     ['--color-surface', '#fbf9f5'],
-    ['--color-sunk', '#e5ead3'],
+    ['--color-sunk', '#f2eade'],
     ['--color-hush', '#e7dfe3'],
     ['--color-ink', '#2b2229'],
     ['--color-muted', '#5c6050'],

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -4,10 +4,16 @@ import { Meta } from '@storybook/addon-docs/blocks'
 
 # The accent
 
-The page is earth, ink and three soft neutrals, tinted off a Deccan winter: dry
-brown ground, sunlit granite in the secondary panes, scrub green in the
-secondary copy, dusty mauve in the meta. Those hues are scenery — they say
-nothing about the screen they are on.
+The page is earth, ink and three soft neutrals, tinted off a Deccan winter:
+red-brown ground, pale sage in the secondary panes, scrub green in the secondary
+copy, dusty mauve in the meta. Those hues are scenery — they say nothing about
+the screen they are on.
+
+**The ground is redder than the panes on purpose.** `--color-paper` sits at hue
+32° and `--color-sunk` at 84°, and the 52° between them is what makes the sage
+read as sage. Closing that gap does not make the palette calmer, it makes both
+colours read as the same tired beige — which is what a 34° gap did. If you warm
+`sunk` or cool `paper`, you lose the sage on every screen at once.
 
 Two colours do carry meaning, and they answer different questions.
 `--color-green`, a deep scrub green, `#4c6141`, says **where you are**.
@@ -82,9 +88,9 @@ one of the two is not really asking for a decision.
 
 <div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
   {[
-    ['--color-paper', '#e9e2d5'],
+    ['--color-paper', '#ebdccb'],
     ['--color-surface', '#fbf9f5'],
-    ['--color-sunk', '#f2eade'],
+    ['--color-sunk', '#e0ebd0'],
     ['--color-hush', '#e7dfe3'],
     ['--color-ink', '#2b2229'],
     ['--color-muted', '#5c6050'],

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -5,15 +5,20 @@ import { Meta } from '@storybook/addon-docs/blocks'
 # The accent
 
 The page is earth, ink and three soft neutrals, tinted off a Deccan winter:
-red-brown ground, pale sage in the secondary panes, scrub green in the secondary
-copy, dusty mauve in the meta. Those hues are scenery — they say nothing about
-the screen they are on.
+red-brown ground, pale sage in the chrome, scrub green in the secondary copy,
+dusty mauve in the meta. Those hues are scenery — they say nothing about the
+screen they are on.
 
-**The ground is redder than the panes on purpose.** `--color-paper` sits at hue
-32° and `--color-sunk` at 115°, and the 83° between them is what makes the sage
+**The ground is redder than the sage on purpose.** `--color-paper` sits at hue
+32° and `--color-sage` at 115°, and the 83° between them is what makes the sage
 read as sage. Closing that gap does not make the palette calmer, it makes both
 colours read as the same tired beige — which is what a 34° gap did. If you warm
-`sunk` or cool `paper`, you lose the sage on every screen at once.
+`sage` or cool `paper`, you lose it on every screen at once.
+
+**Sage is chrome, never a large pane.** Title bars and the Board's columns take
+it. A pane beside the writing surface — the Plan, the notes — takes
+`--color-sunk`, which is a neutral: a big field of sage next to prose stops
+reading as a colour and starts reading as a tint someone forgot to remove.
 
 Two colours do carry meaning, and they answer different questions.
 `--color-green`, a deep scrub green, `#4c6141`, says **where you are**.
@@ -88,9 +93,10 @@ one of the two is not really asking for a decision.
 
 <div style={{ display: 'flex', gap: '0.75rem', margin: '1.5rem 0', flexWrap: 'wrap' }}>
   {[
-    ['--color-paper', '#ebdccb'],
+    ['--color-paper', '#fbecdb'],
     ['--color-surface', '#fbf9f5'],
-    ['--color-sunk', '#d5ead3'],
+    ['--color-sunk', '#f7f2ea'],
+    ['--color-sage', '#d5ead3'],
     ['--color-hush', '#e7dfe3'],
     ['--color-ink', '#2b2229'],
     ['--color-muted', '#5c6050'],

--- a/src/client/foundations/Accent.mdx
+++ b/src/client/foundations/Accent.mdx
@@ -10,7 +10,7 @@ copy, dusty mauve in the meta. Those hues are scenery — they say nothing about
 the screen they are on.
 
 **The ground is redder than the panes on purpose.** `--color-paper` sits at hue
-32° and `--color-sunk` at 84°, and the 52° between them is what makes the sage
+32° and `--color-sunk` at 115°, and the 83° between them is what makes the sage
 read as sage. Closing that gap does not make the palette calmer, it makes both
 colours read as the same tired beige — which is what a 34° gap did. If you warm
 `sunk` or cool `paper`, you lose the sage on every screen at once.
@@ -90,7 +90,7 @@ one of the two is not really asking for a decision.
   {[
     ['--color-paper', '#ebdccb'],
     ['--color-surface', '#fbf9f5'],
-    ['--color-sunk', '#e0ebd0'],
+    ['--color-sunk', '#d5ead3'],
     ['--color-hush', '#e7dfe3'],
     ['--color-ink', '#2b2229'],
     ['--color-muted', '#5c6050'],

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -6,17 +6,18 @@
  * Joarness design tokens.
  *
  * The page is deliberately quiet: earth, ink, and three soft neutrals, tinted
- * off a Deccan winter — dry brown ground, sunlit granite panes, scrub green in
- * the secondary copy, dusty mauve in the meta.
- * `accent` is the one colour that asks for attention, and it is rationed — see
- * the "Accent" docs page in Storybook. If a screen has two rose things on it,
- * one of them is probably wrong.
+ * off a Deccan winter — red-brown ground, pale sage panes, scrub green in the
+ * secondary copy, dusty mauve in the meta. `accent` is the one colour that asks
+ * for attention, and it is rationed. Both rules — why the ground is redder than
+ * the panes, and what earns the accent — are on the "Accent" docs page in
+ * Storybook. If a screen has two rose things on it, one of them is probably
+ * wrong.
  */
 @theme {
 	/* Surfaces */
-	--color-paper: #e9e2d5; /* the desk the app sits on: sun-dried earth */
+	--color-paper: #ebdccb; /* the desk the app sits on: red-brown earth */
 	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
-	--color-sunk: #f2eade; /* secondary panes: plan, notes, sidebars: granite */
+	--color-sunk: #e0ebd0; /* secondary panes: plan, notes, sidebars: pale sage */
 	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -6,7 +6,8 @@
  * Joarness design tokens.
  *
  * The page is deliberately quiet: earth, ink, and three soft neutrals, tinted
- * off a Deccan winter — dry brown ground, dried-scrub green, dusty mauve.
+ * off a Deccan winter — dry brown ground, sunlit granite panes, scrub green in
+ * the secondary copy, dusty mauve in the meta.
  * `accent` is the one colour that asks for attention, and it is rationed — see
  * the "Accent" docs page in Storybook. If a screen has two rose things on it,
  * one of them is probably wrong.
@@ -15,7 +16,7 @@
 	/* Surfaces */
 	--color-paper: #e9e2d5; /* the desk the app sits on: sun-dried earth */
 	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
-	--color-sunk: #e5ead3; /* secondary panes: plan, notes, sidebars */
+	--color-sunk: #f2eade; /* secondary panes: plan, notes, sidebars: granite */
 	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -6,18 +6,20 @@
  * Joarness design tokens.
  *
  * The page is deliberately quiet: earth, ink, and three soft neutrals, tinted
- * off a Deccan winter — red-brown ground, pale sage panes, scrub green in the
- * secondary copy, dusty mauve in the meta. `accent` is the one colour that asks
- * for attention, and it is rationed. Both rules — why the ground is redder than
- * the panes, and what earns the accent — are on the "Accent" docs page in
- * Storybook. If a screen has two rose things on it, one of them is probably
- * wrong.
+ * off a Deccan winter — red-brown ground, pale sage chrome, scrub green in the
+ * secondary copy, dusty mauve in the meta. Sage is chrome and never a large
+ * pane; a pane beside the writing surface takes `sunk`, a neutral. `accent` is
+ * the one colour that asks for attention, and it is rationed. Both rules — why
+ * the ground is redder than the sage, and what earns the accent — are on the
+ * "Accent" docs page in Storybook. If a screen has two rose things on it, one
+ * of them is probably wrong.
  */
 @theme {
 	/* Surfaces */
-	--color-paper: #ebdccb; /* the desk the app sits on: red-brown earth */
+	--color-paper: #fbecdb; /* the desk the app sits on: red-brown earth */
 	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
-	--color-sunk: #d5ead3; /* secondary panes: plan, notes, sidebars: pale sage */
+	--color-sunk: #f7f2ea; /* secondary panes: plan, notes, sidebars */
+	--color-sage: #d5ead3; /* chrome: title bars, Board columns */
 	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -17,7 +17,7 @@
 	/* Surfaces */
 	--color-paper: #ebdccb; /* the desk the app sits on: red-brown earth */
 	--color-surface: #fbf9f5; /* cards, panes, the writing surface */
-	--color-sunk: #e0ebd0; /* secondary panes: plan, notes, sidebars: pale sage */
+	--color-sunk: #d5ead3; /* secondary panes: plan, notes, sidebars: pale sage */
 	--color-hush: #e7dfe3; /* your own chat messages, inert fills */
 
 	/* Ink */


### PR DESCRIPTION
A second pass over the palette that #59 landed. The colours there read as one tired beige in the deployed app, and this fixes the two reasons why.

## The bug worth reviewing first

`Screen` painted `bg-surface` (`src/client/components/Frame.tsx:63`), so the running app sat on the near-white writing surface and `--color-paper` never appeared anywhere. Storybook draws its stories on `paper`, so the same tokens looked supported there and stranded in the app. `Screen` now takes `bg-paper`, which is the token's stated job.

`ArticleBar` had no background at all, so the article screen's chrome disagreed with the Board's. It now takes the same sage as `TitleBar`.

## The colours

| Token | Was | Now | |
| --- | --- | --- | --- |
| `--color-paper` | `#e5ead3` | `#fbecdb` | The ground, hue 32° |
| `--color-sunk` | `#e5ead3` | `#f7f2ea` | Neutral, for panes beside the writing surface |
| `--color-sage` | — | `#d5ead3` | New. Chrome: title bars, Board columns |

`--color-sunk` was doing two jobs — the title bars and the Plan Panel — so the sage could not be in one without being in the other. Splitting them lets the chrome carry the colour while the largest field on the article screen, the one right beside the prose, goes neutral.

The two hues are 83° apart. That gap is what makes the sage read as sage rather than as a green that did not commit; at 34° both colours read as the same beige. The rule is on the Accent docs page, because closing the gap is the tidy-up someone would make in good faith.

## Contrast

Every pair holds, and the meta text improves on the new ground.

| Pair | Before | After |
| --- | --- | --- |
| ink on paper | 11.96 | 13.29 |
| secondary copy on paper | 5.03 | 5.59 |
| meta on paper | 2.78 | 3.09 |
| ink on the sage | — | 12.13 |
| ink on a pane | 12.50 | 13.82 |

`sunk` at `#f7f2ea` is the only value tried that separates from both `surface` (1.06) and `paper` (1.04); the alternatives collided with one or the other.

## Also here

The interface font is Atkinson Hyperlegible Next, self-hosted from Fontsource as one variable file. The serif writing surface and the mono labels are unchanged.

## Checks

`pnpm test` passes — 318 tests across 28 files, including the browser story projects. `pnpm lint`, `pnpm typecheck` and `pnpm format:check` are clean.

One caveat worth watching in CI rather than treating as settled: one full run failed with a single test that I could not identify before it passed again, and nine subsequent runs were clean. Given the history on this branch my guess is the composer story, which is timing-sensitive.

## Follow-up

#63 covers the chrome duplication this work surfaced — the Articles list's title is written in four places. It is not a colour problem and is better done on its own terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fdinDazCaea8uTE5WiDwf

---
_Generated by [Claude Code](https://claude.ai/code/session_017fdinDazCaea8uTE5WiDwf)_