### PR TITLE
Misc draft panel UX feedback

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -31,11 +31,29 @@ const withRouter: Decorator = (Story) => {
 	return <RouterProvider router={router} />
 }
 
+/**
+ * The target screen — docs/ui.md. Every story is drawn and measured here, so
+ * `lg:` utilities are the ones under test.
+ *
+ * It has to be a Storybook viewport rather than `browser.viewport` in
+ * vitest.config.ts: `@storybook/addon-vitest` resizes the page before each
+ * story, so whatever Vitest was configured with is overwritten by the addon's
+ * own 1200×900 default. Naming one here is what makes the two agree.
+ */
+export const TARGET_SCREEN_WIDTH = 1298
+
+const targetScreen = {
+	name: 'Target screen',
+	styles: { width: `${TARGET_SCREEN_WIDTH}px`, height: '1024px' },
+	type: 'desktop' as const,
+}
+
 const preview: Preview = {
 	decorators: [withRouter],
 	parameters: {
 		layout: 'centered',
 		controls: { expanded: true },
+		viewport: { options: { target: targetScreen } },
 		backgrounds: {
 			options: {
 				paper: { name: 'Paper', value: '#fbecdb' },
@@ -63,6 +81,7 @@ const preview: Preview = {
 	},
 	initialGlobals: {
 		backgrounds: { value: 'paper' },
+		viewport: { value: 'target' },
 	},
 	tags: ['autodocs'],
 }

--- a/.storybook/vitest.setup.ts
+++ b/.storybook/vitest.setup.ts
@@ -19,6 +19,7 @@ import { setProjectAnnotations } from '@storybook/react-vite'
 import { beforeAll, expect } from 'vitest'
 
 import * as previewAnnotations from './preview'
+import { TARGET_SCREEN_WIDTH } from './preview'
 
 /** Subpixel layout rounding, in px. */
 const TOLERANCE = 1
@@ -50,6 +51,15 @@ function describe(element: Element): string {
 }
 
 function checkLayout(canvasElement: HTMLElement) {
+	// The width every screen is designed against — docs/ui.md. It is set as a
+	// Storybook viewport, which `@storybook/addon-vitest` applies per story and
+	// which overrides anything vitest.config.ts asks for. That override is silent,
+	// so it is asserted rather than assumed: a story measured at some other width
+	// is a story measured against the wrong `lg:` utilities.
+	expect
+		.soft(window.innerWidth, 'Story drawn at the wrong screen width')
+		.toBe(TARGET_SCREEN_WIDTH)
+
 	for (const frame of canvasElement.querySelectorAll('[data-frame]')) {
 		// A collapsed Frame is a screen with nothing on it, which has never been
 		// what a story meant to show.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,12 @@ The `Clear Technical` output style in `.claude/output-styles/clear-technical.md`
 governs every string a human reads — chat, commit messages, PR bodies, code
 comments, UI copy. The `prose-clarity` skill applies the same rules as a rewrite
 pass over text that already exists.
+
+## The screen we design for
+
+**The target screen is a 1298px-wide window.** Judge a layout there: if a choice
+between two layouts comes down to how each one looks, 1298px settles it. That
+width is `--breakpoint-lg` in `src/client/styles/theme.css`, so the `lg:`
+utilities are the ones the target screen gets. Narrower windows still have to
+work, and they are not what a design is tuned against. `docs/ui.md` carries the
+longer note.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,4 @@ pass over text that already exists.
 
 ## The screen we design for
 
-**The target screen is a 1298px-wide window.** Judge a layout there: if a choice
-between two layouts comes down to how each one looks, 1298px settles it. That
-width is `--breakpoint-lg` in `src/client/styles/theme.css`, so the `lg:`
-utilities are the ones the target screen gets. Narrower windows still have to
-work, and they are not what a design is tuned against. `docs/ui.md` carries the
-longer note.
+We design for a laptop with a 1298px wide screen.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -435,7 +435,9 @@ already reactive through Article Agent state and, at 1b, party-db's TanStack DB 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen, and which are all more or less their own little interfaces, with very specific
 and explicit, user-gated interactions between them. `usePanels` holds which are open, keeps
-them in the one order, drawn by a `Rail` component in the navbar.
+them in the one order, drawn by a `Rail` component in the navbar. It also sets how wide each
+one gets: Notes takes a fixed slice as the margin rail, and the Draft takes twice what a
+supporting Panel does out of what is left, so the prose keeps the room whatever is beside it.
 
 **Use Loading states instead of drawing empty values.** An empty title, a zero count and four
 empty columns are answers, and a screen that puts one on the page before it has read anything

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -6,26 +6,8 @@ architectural decisions that go in the other doc.
 
 ## The screen we design for
 
-**The target screen is a 1298px-wide window.** That is the width a layout is judged at, and
-the width a screenshot should be taken at. Where two layouts are both defensible, the one
-that reads better at 1298px wins.
-
-The number is `--breakpoint-lg` in `src/client/styles/theme.css`, so a `lg:` utility is one
-the target screen gets and a `md:` utility is one it has had for a while. There are two
-breakpoints and no more: `md` at 768px and `lg` at 1298px. Both are in px because both name
-a window width. A component is free to set its own max-width in rem — `usePanels` collapses
-the Panels to tabs at 56rem — and that is a different question from where the screen turns.
-
-Everything narrower still has to work — `usePanels` collapses the four Panels to tabs under
-56rem, and the Board View scrolls its columns sideways rather than shrinking them — but a
-design is tuned against 1298px rather than against the narrow end.
-
-Every story is drawn there too. The width is the `target` viewport in
-`.storybook/preview.tsx`, which Storybook applies in the showcase and
-`@storybook/addon-vitest` applies to each story test. Setting it in `vitest.config.ts`
-does not work: the addon resizes the page before every story, so a size set there is
-overwritten before anything is measured. `.storybook/vitest.setup.ts` asserts the width
-each story actually got, because that override is otherwise silent.
+Our target screen is 1298px wide. That is the starting value for the `lg` breakpoint, and
+wherever possible we configure Storybook to use this width.
 
 ## The UI showcase
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -4,6 +4,20 @@ This document is a sibling to [`architecture.md`](./architecture.md), a place to
 decisions we make about the UI and design, as opposed to technical, cross-module
 architectural decisions that go in the other doc.
 
+## The screen we design for
+
+**The target screen is a 1298px-wide window.** That is the width a layout is judged at, and
+the width a screenshot should be taken at. Where two layouts are both defensible, the one
+that reads better at 1298px wins.
+
+The number is `--breakpoint-lg` in `src/client/styles/theme.css`, so a `lg:` utility is one
+the target screen gets and a `md:` utility is one it has had for a while. There are two
+breakpoints and no more: `md` at 48rem and `lg` at 1298px.
+
+Everything narrower still has to work — `usePanels` collapses the four Panels to tabs under
+56rem, and the Board View scrolls its columns sideways rather than shrinking them — but a
+design is tuned against 1298px rather than against the narrow end.
+
 ## The UI showcase
 
 We are generally a very "Storybook First" project, so every wireframe and component is

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -18,6 +18,13 @@ Everything narrower still has to work — `usePanels` collapses the four Panels 
 56rem, and the Board View scrolls its columns sideways rather than shrinking them — but a
 design is tuned against 1298px rather than against the narrow end.
 
+Every story is drawn there too. The width is the `target` viewport in
+`.storybook/preview.tsx`, which Storybook applies in the showcase and
+`@storybook/addon-vitest` applies to each story test. Setting it in `vitest.config.ts`
+does not work: the addon resizes the page before every story, so a size set there is
+overwritten before anything is measured. `.storybook/vitest.setup.ts` asserts the width
+each story actually got, because that override is otherwise silent.
+
 ## The UI showcase
 
 We are generally a very "Storybook First" project, so every wireframe and component is

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -12,7 +12,9 @@ that reads better at 1298px wins.
 
 The number is `--breakpoint-lg` in `src/client/styles/theme.css`, so a `lg:` utility is one
 the target screen gets and a `md:` utility is one it has had for a while. There are two
-breakpoints and no more: `md` at 48rem and `lg` at 1298px.
+breakpoints and no more: `md` at 768px and `lg` at 1298px. Both are in px because both name
+a window width. A component is free to set its own max-width in rem — `usePanels` collapses
+the Panels to tabs at 56rem — and that is a different question from where the screen turns.
 
 Everything narrower still has to work — `usePanels` collapses the four Panels to tabs under
 56rem, and the Board View scrolls its columns sideways rather than shrinking them — but a

--- a/src/client/article/ArticlePanels.tsx
+++ b/src/client/article/ArticlePanels.tsx
@@ -6,11 +6,15 @@ import { PANELS, type PanelId } from '../components/PanelRail'
 import { ArticleDraftPanel } from '../draft/ArticleDraftPanel'
 import type { ArticleSocket } from '../lib/useArticleAgent'
 import { ArticlePlanPanel } from '../plan/ArticlePlanPanel'
+import { panelShare } from './usePanels'
 
 /**
  * The four Panels of the Article screen — architecture.md §8. Chat, Plan, and
  * Draft are live; Notes is here and empty until phase 2. This row is what gives
  * them a height to scroll their own Y within.
+ *
+ * How wide each one gets is `panelShare`, which reads the whole open set: the
+ * Draft's share depends on what is beside it.
  */
 
 export interface ArticlePanelsProps {
@@ -29,7 +33,12 @@ export function ArticlePanels({ agent, open }: ArticlePanelsProps) {
 
 				return (
 					<Activity key={panel} mode={at === -1 ? 'hidden' : 'visible'}>
-						<PanelFor agent={agent} divided={at > 0} panel={panel} />
+						<PanelFor
+							agent={agent}
+							divided={at > 0}
+							grow={panelShare(open, panel)}
+							panel={panel}
+						/>
 					</Activity>
 				)
 			})}
@@ -40,28 +49,30 @@ export function ArticlePanels({ agent, open }: ArticlePanelsProps) {
 function PanelFor({
 	agent,
 	divided,
+	grow,
 	panel,
 }: {
 	agent: ArticleSocket
 	divided: boolean
+	/** This Panel's share of the row — `panelShare`. */
+	grow: number
 	panel: PanelId
 }) {
 	const edge = divided ? 'left' : 'none'
 
 	switch (panel) {
 		case 'chat':
-			return <ArticleChatPanel agent={agent} divider={edge} />
+			return <ArticleChatPanel agent={agent} divider={edge} grow={grow} />
 
 		case 'plan':
-			return <ArticlePlanPanel divider={edge} />
+			return <ArticlePlanPanel divider={edge} grow={grow} />
 
 		case 'draft':
-			return <ArticleDraftPanel divider={edge} />
+			return <ArticleDraftPanel divider={edge} grow={grow} />
 
 		case 'notes':
-			// Notes is always the narrow one — screen 4(e).
 			return (
-				<EmptyPanel divider={edge} grow={0.26} title="Notes">
+				<EmptyPanel divider={edge} grow={grow} title="Notes">
 					The Guide's notes arrive with phase 2, alongside the Draft they read.
 				</EmptyPanel>
 			)

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -48,6 +48,50 @@ export function nextOpenPanels(
 	return PANELS.filter((one) => one === panel || held.includes(one))
 }
 
+/** What the Draft's neighbours are worth against each other. The Draft is the
+ * writing surface and everything else supports it, so it takes twice what a
+ * supporting Panel does. */
+const WEIGHTS: Record<Exclude<PanelId, 'notes'>, number> = {
+	chat: 1,
+	plan: 1,
+	draft: 2,
+}
+
+/** Notes is the margin rail — screen 3(e) — so it takes a slice off the top
+ * rather than a share of the split. It gets the wider slice when it is the one
+ * Panel beside another, and the narrow one when it is a fourth column. */
+const NOTES_ALONE = 0.25
+const NOTES_WITH_OTHERS = 0.2
+
+/**
+ * The fraction of the Panel row one open Panel takes. Flex reads these as
+ * ratios against each other, so the fractions can be handed to it directly.
+ *
+ * Notes is fixed first, and the Draft takes twice what a supporting Panel does
+ * out of what is left. That gives 33/67 for Plan + Draft, 25/25/50 for Chat +
+ * Plan + Draft, 20/20/40/20 for all four, and 75/25 for Draft + Notes.
+ *
+ * A hidden Panel gets 0. It is still mounted, but `Activity` has taken it out
+ * of the layout, so nothing reads the number.
+ */
+export function panelShare(open: readonly PanelId[], panel: PanelId): number {
+	if (!open.includes(panel)) return 0
+	if (open.length === 1) return 1
+
+	const notes = open.includes('notes')
+		? open.length === 2
+			? NOTES_ALONE
+			: NOTES_WITH_OTHERS
+		: 0
+
+	if (panel === 'notes') return notes
+
+	const rest = open.filter((one) => one !== 'notes') as Exclude<PanelId, 'notes'>[]
+	const total = rest.reduce((sum, one) => sum + WEIGHTS[one], 0)
+
+	return ((1 - notes) * WEIGHTS[panel]) / total
+}
+
 function useNarrow(query: string): boolean {
 	const [narrow, setNarrow] = useState(() => window.matchMedia(query).matches)
 

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -16,6 +16,8 @@ export interface ArticleChatPanelProps {
 	agent: ArticleSocket
 	placeholder?: string
 	divider?: ChatPanelProps['divider']
+	/** This Panel's share of the Panel row — `panelShare`. */
+	grow?: ChatPanelProps['grow']
 	className?: string
 }
 
@@ -23,6 +25,7 @@ export function ArticleChatPanel({
 	agent,
 	placeholder,
 	divider,
+	grow,
 	className,
 }: ArticleChatPanelProps) {
 	const { plan } = useArticle().plan
@@ -35,7 +38,7 @@ export function ArticleChatPanel({
 	// until one arrives.
 	if (plan === null) {
 		return (
-			<Panel className={className} divider={divider}>
+			<Panel className={className} divider={divider} grow={grow}>
 				<p className="text-[0.75rem] text-faint">Opening the Chat…</p>
 			</Panel>
 		)
@@ -53,6 +56,7 @@ export function ArticleChatPanel({
 			divider={divider}
 			drawer={<OfferLedgerDrawer ledger={ledger} onClose={close} open={showLedger} />}
 			failure={chat.failure ?? ledger.failure}
+			grow={grow}
 			leading={
 				<LedgerToggle
 					onToggle={() => (showLedger ? close() : setShowLedger(true))}

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -43,6 +43,8 @@ export interface ChatPanelProps {
 	failure?: string | null
 	/** The rule between this Panel and its neighbour. */
 	divider?: PanelProps['divider']
+	/** This Panel's share of the Panel row — `panelShare`. */
+	grow?: PanelProps['grow']
 	placeholder?: string
 	/** Left of send — the Offer ledger toggle. */
 	leading?: ReactNode
@@ -67,6 +69,7 @@ export function ChatPanel({
 	onDeclineOffer,
 	failure = null,
 	divider,
+	grow,
 	placeholder,
 	leading,
 	drawer,
@@ -76,7 +79,7 @@ export function ChatPanel({
 	const transcript = useFootOfTranscript()
 
 	return (
-		<Panel className={className} divider={divider} padded={false}>
+		<Panel className={className} divider={divider} grow={grow} padded={false}>
 			{/* The transcript and the drawer share this box, so the drawer covers
 			    what the writer is reading and stops at the composer. `overflow-hidden`
 			    is what makes the drawer slide out of sight behind it. */}

--- a/src/client/draft/ArticleDraftPanel.tsx
+++ b/src/client/draft/ArticleDraftPanel.tsx
@@ -8,10 +8,12 @@ import { useDraft } from './useDraft'
 
 export interface ArticleDraftPanelProps {
 	divider?: PanelProps['divider']
+	/** This Panel's share of the Panel row — `panelShare`. */
+	grow?: PanelProps['grow']
 	className?: string
 }
 
-export function ArticleDraftPanel({ divider, className }: ArticleDraftPanelProps) {
+export function ArticleDraftPanel({ divider, grow, className }: ArticleDraftPanelProps) {
 	const { blocks, failure, status, attachEditor, touch } = useDraft(useArticle().draft)
 
 	// The editor is built from the Blocks and reads them once, so it mounts
@@ -20,7 +22,7 @@ export function ArticleDraftPanel({ divider, className }: ArticleDraftPanelProps
 	// what had just been read.
 	if (blocks === null) {
 		return (
-			<Panel className={className} divider={divider}>
+			<Panel className={className} divider={divider} grow={grow}>
 				<PanelHeader title="Draft" />
 				{failure === null ? (
 					<p className="text-[0.75rem] text-faint">Opening the Draft…</p>
@@ -36,6 +38,7 @@ export function ArticleDraftPanel({ divider, className }: ArticleDraftPanelProps
 			blocks={blocks}
 			className={className}
 			divider={divider}
+			grow={grow}
 			onAttach={attachEditor}
 			onChange={touch}
 			status={status}

--- a/src/client/draft/DraftPanel.tsx
+++ b/src/client/draft/DraftPanel.tsx
@@ -15,6 +15,8 @@ export interface DraftPanelProps {
 	onAttach: (editor: Editor) => void
 	onChange: () => void
 	divider?: PanelProps['divider']
+	/** This Panel's share of the Panel row — `panelShare`. */
+	grow?: PanelProps['grow']
 	className?: string
 }
 
@@ -31,6 +33,7 @@ export function DraftPanel({
 	onAttach,
 	onChange,
 	divider,
+	grow,
 	className,
 }: DraftPanelProps) {
 	const editor = useEditor({
@@ -49,14 +52,19 @@ export function DraftPanel({
 	}, [editor, onAttach])
 
 	return (
-		<Panel className={className} divider={divider} padded={false}>
-			<div className="flex flex-col gap-2.5 p-3.5 pb-2">
+		<Panel className={className} divider={divider} grow={grow} padded={false}>
+			{/* Sticky, so the controls stay in reach however far down the Draft the
+			    writer has scrolled — and so does whether the last save landed. The
+			    Panel is the scroller, which is what this sticks against. */}
+			<div className="sticky top-0 z-10 flex flex-col gap-2.5 border-b border-rule bg-surface px-3.5 pt-3.5 pb-2.5">
 				<PanelHeader meta={<SaveState status={status} />} title="Draft" />
 				<Toolbar editor={editor} />
 				{status.state === 'failed' ? <Notice>{status.failure}</Notice> : null}
 			</div>
 
-			<div className="prose-draft min-w-0 flex-auto px-8 py-4 [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none [&_h2]:mt-6 [&_h2]:text-[1.05rem] [&_h2]:font-semibold [&_h3]:mt-5 [&_h3]:font-semibold [&_hr]:my-6 [&_hr]:border-t [&_hr]:border-edge">
+			{/* Heading, subheading, and section-break styling is `.prose-draft` in
+			    theme.css, so a Draft preview is set the same way as the editor. */}
+			<div className="prose-draft min-w-0 flex-auto px-8 py-4 [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none">
 				<EditorContent editor={editor} />
 			</div>
 		</Panel>

--- a/src/client/plan/ArticlePlanPanel.tsx
+++ b/src/client/plan/ArticlePlanPanel.tsx
@@ -6,17 +6,19 @@ import { PlanPanel, type PlanPanelProps } from './PlanPanel'
 
 export interface ArticlePlanPanelProps {
 	divider?: PlanPanelProps['divider']
+	/** This Panel's share of the Panel row — `panelShare`. */
+	grow?: PlanPanelProps['grow']
 	className?: string
 }
 
-export function ArticlePlanPanel({ divider, className }: ArticlePlanPanelProps) {
+export function ArticlePlanPanel({ divider, grow, className }: ArticlePlanPanelProps) {
 	const { plan, edit, refusal, rejected } = useArticle().plan
 
 	// Says what it waits on rather than drawing a skeleton, since the socket
 	// settles well inside a second.
 	if (plan === null) {
 		return (
-			<Panel className={className} divider={divider} variant="sunk">
+			<Panel className={className} divider={divider} grow={grow} variant="sunk">
 				<p className="text-[0.75rem] text-faint">Opening the Plan…</p>
 			</Panel>
 		)
@@ -27,6 +29,7 @@ export function ArticlePlanPanel({ divider, className }: ArticlePlanPanelProps) 
 			className={className}
 			divider={divider}
 			edit={edit}
+			grow={grow}
 			plan={plan}
 			refusal={refusal}
 			rejected={rejected}

--- a/src/client/plan/PlanPanel.tsx
+++ b/src/client/plan/PlanPanel.tsx
@@ -31,6 +31,8 @@ export interface PlanPanelProps {
 	edit: (ops: ProposalInput | null) => void
 	/** The rule between this Panel and its neighbour. */
 	divider?: PanelProps['divider']
+	/** This Panel's share of the Panel row — `panelShare`. */
+	grow?: PanelProps['grow']
 	/** Why the last edit did not land. */
 	refusal?: Refusal | null
 	/** What the Article Agent said when a write did not parse. */
@@ -42,6 +44,7 @@ export function PlanPanel({
 	plan,
 	edit,
 	divider,
+	grow,
 	refusal = null,
 	rejected = null,
 	className,
@@ -85,7 +88,7 @@ export function PlanPanel({
 	}
 
 	return (
-		<Panel className={className} divider={divider} variant="sunk">
+		<Panel className={className} divider={divider} grow={grow} variant="sunk">
 			{refusal === null ? null : <Notice>{refusalText(plan, refusal)}</Notice>}
 			{rejected === null ? null : (
 				<Notice>The Article Agent refused the write. {rejected}</Notice>

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -57,8 +57,10 @@
 
 	--radius-frame: 0.625rem;
 
+	/* Two breakpoints and no more, both in px because both name a window width.
+	   `lg` is the target screen — docs/ui.md. */
 	--breakpoint-*: initial;
-	--breakpoint-md: 48rem; /* 768px */
+	--breakpoint-md: 768px;
 	--breakpoint-lg: 1298px;
 
 	/* One depth, cast in whichever direction the thing lifts: the outermost

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -115,6 +115,48 @@
 		margin-top: 1.1em;
 	}
 
+	/* A heading is a different voice from the prose, not a louder one. Bold
+	   serif reads as a stressed sentence, so the sans face carries the headings
+	   instead: the reader sees the structure before they read the words. */
+	.prose-draft :is(h1, h2, h3, h4) {
+		font-family: var(--font-sans);
+		font-weight: 600;
+		line-height: 1.3;
+		/* Closer to what it opens than to what it closes, so a heading reads as
+		   the top of the passage under it. */
+		margin-bottom: 0.4em;
+		color: var(--color-ink);
+	}
+
+	.prose-draft h2 {
+		margin-top: 1.75em;
+		font-size: 1.0625rem;
+		letter-spacing: -0.01em;
+	}
+
+	/* Smaller than the prose rather than larger, and spaced out: a subheading
+	   ranks under its heading, and the sans face still separates it from the
+	   sentences around it. */
+	.prose-draft h3 {
+		margin-top: 1.5em;
+		font-size: 0.9375rem;
+		letter-spacing: 0.02em;
+	}
+
+	/* A heading opening the Draft sits against the top of the surface, not a
+	   line and a half below it. The editor puts its own wrapper between the two,
+	   so the rule has to reach through it. */
+	.prose-draft > :first-child,
+	.prose-draft .ProseMirror > :first-child {
+		margin-top: 0;
+	}
+
+	/* The section break the writer places — §10. */
+	.prose-draft hr {
+		margin: 1.75em 0;
+		border-top: 1px solid var(--color-edge);
+	}
+
 	/* A list is one Block, so it is one thing on the page: the marker and the
 	   indent are what say so, and the items inside it sit closer than
 	   paragraphs do. */

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -57,8 +57,6 @@
 
 	--radius-frame: 0.625rem;
 
-	/* Two breakpoints and no more, both in px because both name a window width.
-	   `lg` is the target screen — docs/ui.md. */
 	--breakpoint-*: initial;
 	--breakpoint-md: 768px;
 	--breakpoint-lg: 1298px;

--- a/test/client/article-index.test.ts
+++ b/test/client/article-index.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { nextOpenPanels } from '../../src/client/article/usePanels'
+import { nextOpenPanels, panelShare } from '../../src/client/article/usePanels'
 import {
 	archivedArticles,
 	boardColumns,
 	recentArticles,
 	unarchivedArticles,
 } from '../../src/client/articles/grouping'
+import type { PanelId } from '../../src/client/components/PanelRail'
 import { shortDate } from '../../src/client/lib/when'
 import {
 	type ArticleEntry,
@@ -163,6 +164,39 @@ describe('the Panel rail', () => {
 
 	it('keeps the last Panel open rather than leaving nothing on screen', () => {
 		expect(nextOpenPanels(['plan'], 'plan', false)).toEqual(['plan'])
+	})
+})
+
+describe('how wide each Panel gets', () => {
+	/** Reads the whole row at once, which is what the shares are about. */
+	const shares = (open: PanelId[]) => open.map((panel) => panelShare(open, panel))
+
+	it('gives one Panel the whole row', () => {
+		expect(shares(['draft'])).toEqual([1])
+		expect(shares(['notes'])).toEqual([1])
+	})
+
+	it('gives the Draft twice what a supporting Panel gets', () => {
+		expect(shares(['plan', 'draft'])).toEqual([1 / 3, 2 / 3])
+		expect(shares(['chat', 'plan', 'draft'])).toEqual([0.25, 0.25, 0.5])
+	})
+
+	it('keeps Notes narrow and splits what is left', () => {
+		expect(shares(['draft', 'notes'])).toEqual([0.75, 0.25])
+		expect(shares(['chat', 'plan', 'draft', 'notes'])).toEqual([0.2, 0.2, 0.4, 0.2])
+	})
+
+	it('adds up to the whole row', () => {
+		const total = shares(['chat', 'plan', 'draft', 'notes']).reduce(
+			(sum, share) => sum + share,
+			0,
+		)
+
+		expect(total).toBeCloseTo(1)
+	})
+
+	it('gives a hidden Panel nothing, since nothing reads it', () => {
+		expect(panelShare(['chat', 'draft'], 'notes')).toBe(0)
 	})
 })
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -85,9 +85,10 @@ export default defineConfig({
 						headless: true,
 						provider: playwright(),
 						instances: [{ browser: 'chromium' }],
-						// Wider and taller than the largest Frame any screen draws, so no
-						// story is measured against a squeezed viewport.
-						viewport: { width: 1280, height: 1024 },
+						// No `viewport` here. `@storybook/addon-vitest` resizes the page
+						// before each story, so a size set here is overwritten before
+						// anything is measured. The one every story is drawn at is the
+						// `target` viewport in .storybook/preview.tsx.
 					},
 				},
 			},


### PR DESCRIPTION
The Article screen's four Panels now size themselves according to their function: the Draft takes twice the width of supporting Panels (Chat and Plan), and Notes holds a fixed margin slice. This replaces hardcoded widths with a calculated share that adapts to which Panels are open.

**Key changes:**

- Added `panelShare()` function to calculate each Panel's width fraction based on which Panels are open. Notes takes a fixed 25% when alone with the Draft, 20% when with others, or 0 when hidden. The Draft gets twice the weight of Chat or Plan out of the remaining space.
- Threaded the `grow` prop through the Panel component hierarchy (ArticlePanels → PanelFor → individual Panel components) so each Panel receives its calculated share.
- Updated `.prose-draft` styles in theme.css to move heading and section-break rules from inline Tailwind to the stylesheet, making them consistent between the editor and previews.
- Established 1298px as the target screen width for design and testing. Updated Storybook viewport configuration and vitest setup to enforce this consistently, with documentation in `docs/ui.md` and `CLAUDE.md`.
- Fixed `--breakpoint-md` from `48rem` to `768px` for clarity (both breakpoints now use px to name window widths).
- Made Draft panel controls sticky so they remain accessible while scrolling.

The layout now responds to the open Panel set rather than using fixed proportions, keeping the Draft prominent while adapting to what else is visible.

https://claude.ai/code/session_01QiSWVsyNTxkGU16ARU7ss6