### PR TITLE
Bigger type, with the Panel row scaling by how many Panels are open

### DIFF
--- a/.storybook/Primitives.stories.tsx
+++ b/.storybook/Primitives.stories.tsx
@@ -81,7 +81,7 @@ export const PanelToggle: Story = {
 						)
 					}
 				/>
-				<p className="text-[0.8125rem] text-muted">
+				<p className="text-(length:--text-13) text-muted">
 					Open:{' '}
 					{open.length ? open.join(' · ') : 'nothing — the app would keep the draft up'}
 				</p>
@@ -106,7 +106,7 @@ export const Composer: Story = {
 					{sent.map((text, index) => (
 						<li
 							key={index}
-							className="rounded-md bg-hush px-3 py-2 text-[0.8125rem] leading-relaxed whitespace-pre-wrap text-ink"
+							className="rounded-md bg-hush px-3 py-2 text-(length:--text-13) leading-relaxed whitespace-pre-wrap text-ink"
 						>
 							{text}
 						</li>
@@ -171,7 +171,7 @@ export const Research: Story = {
 			<ReferenceCard offer={offers[4]} variant="ledger" compact />
 			<ReferenceCard offer={offers[6]} variant="ledger" compact />
 			<Divider />
-			<p className="max-w-[28rem] text-[0.75rem] leading-relaxed text-muted">
+			<p className="max-w-[28rem] text-(length:--text-12) leading-relaxed text-muted">
 				<strong>The QuoteRow component (2 examples below) is unused.</strong> It was added
 				to show a read-only summary of the Plan Panel, which we stopped using, but may go
 				back to in Phase 2.

--- a/.storybook/Primitives.stories.tsx
+++ b/.storybook/Primitives.stories.tsx
@@ -81,7 +81,7 @@ export const PanelToggle: Story = {
 						)
 					}
 				/>
-				<p className="text-(length:--text-13) text-muted">
+				<p className="text-13 text-muted">
 					Open:{' '}
 					{open.length ? open.join(' · ') : 'nothing — the app would keep the draft up'}
 				</p>
@@ -106,7 +106,7 @@ export const Composer: Story = {
 					{sent.map((text, index) => (
 						<li
 							key={index}
-							className="rounded-md bg-hush px-3 py-2 text-(length:--text-13) leading-relaxed whitespace-pre-wrap text-ink"
+							className="rounded-md bg-hush px-3 py-2 text-13 leading-relaxed whitespace-pre-wrap text-ink"
 						>
 							{text}
 						</li>
@@ -171,7 +171,7 @@ export const Research: Story = {
 			<ReferenceCard offer={offers[4]} variant="ledger" compact />
 			<ReferenceCard offer={offers[6]} variant="ledger" compact />
 			<Divider />
-			<p className="max-w-[28rem] text-(length:--text-12) leading-relaxed text-muted">
+			<p className="max-w-[28rem] text-12 leading-relaxed text-muted">
 				<strong>The QuoteRow component (2 examples below) is unused.</strong> It was added
 				to show a read-only summary of the Plan Panel, which we stopped using, but may go
 				back to in Phase 2.

--- a/.storybook/screens/article/BlankPlanScreen.tsx
+++ b/.storybook/screens/article/BlankPlanScreen.tsx
@@ -39,7 +39,7 @@ export function BlankPlanScreen() {
 					<PlanBlock title="References" meta="0">
 						<EmptySlot>Tick a reference in the chat, or paste your own</EmptySlot>
 					</PlanBlock>
-					<p className="mt-auto text-[0.6875rem] text-faint">
+					<p className="mt-auto text-(length:--text-meta) text-faint">
 						Scrolls. Nothing here is locked, and nothing has to be finished before you
 						write.
 					</p>

--- a/.storybook/screens/article/BlankPlanScreen.tsx
+++ b/.storybook/screens/article/BlankPlanScreen.tsx
@@ -39,7 +39,7 @@ export function BlankPlanScreen() {
 					<PlanBlock title="References" meta="0">
 						<EmptySlot>Tick a reference in the chat, or paste your own</EmptySlot>
 					</PlanBlock>
-					<p className="mt-auto text-(length:--text-meta) text-faint">
+					<p className="mt-auto text-11 text-faint">
 						Scrolls. Nothing here is locked, and nothing has to be finished before you
 						write.
 					</p>

--- a/.storybook/screens/article/LedgerPopoverScreen.tsx
+++ b/.storybook/screens/article/LedgerPopoverScreen.tsx
@@ -25,11 +25,11 @@ export function LedgerPopoverScreen() {
 	return (
 		<Frame width={340}>
 			<div className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
-				<h3 className="text-[0.875rem] font-semibold text-ink">Offer ledger</h3>
-				<span className="text-[0.75rem] text-faint">{ledger.counts.all}</span>
+				<h3 className="text-(length:--text-14) font-semibold text-ink">Offer ledger</h3>
+				<span className="text-(length:--text-12) text-faint">{ledger.counts.all}</span>
 				<button
 					type="button"
-					className="ml-auto text-[0.75rem] text-faint hover:text-ink"
+					className="ml-auto text-(length:--text-12) text-faint hover:text-ink"
 				>
 					⌄
 				</button>
@@ -49,7 +49,10 @@ export function LedgerPopoverScreen() {
 								{group.label}
 							</MetaLabel>
 							{ledger.byDisposition[group.disposition].map((offer) => (
-								<p key={offer.id} className="min-w-0 truncate text-[0.75rem] text-muted">
+								<p
+									key={offer.id}
+									className="min-w-0 truncate text-(length:--text-12) text-muted"
+								>
 									{referenceName(offer)}
 								</p>
 							))}

--- a/.storybook/screens/article/LedgerPopoverScreen.tsx
+++ b/.storybook/screens/article/LedgerPopoverScreen.tsx
@@ -25,12 +25,9 @@ export function LedgerPopoverScreen() {
 	return (
 		<Frame width={340}>
 			<div className="flex items-center gap-2.5 border-b border-edge bg-sunk px-3.5 py-2.5">
-				<h3 className="text-(length:--text-14) font-semibold text-ink">Offer ledger</h3>
-				<span className="text-(length:--text-12) text-faint">{ledger.counts.all}</span>
-				<button
-					type="button"
-					className="ml-auto text-(length:--text-12) text-faint hover:text-ink"
-				>
+				<h3 className="text-14 font-semibold text-ink">Offer ledger</h3>
+				<span className="text-12 text-faint">{ledger.counts.all}</span>
+				<button type="button" className="ml-auto text-12 text-faint hover:text-ink">
 					⌄
 				</button>
 			</div>
@@ -49,10 +46,7 @@ export function LedgerPopoverScreen() {
 								{group.label}
 							</MetaLabel>
 							{ledger.byDisposition[group.disposition].map((offer) => (
-								<p
-									key={offer.id}
-									className="min-w-0 truncate text-(length:--text-12) text-muted"
-								>
+								<p key={offer.id} className="min-w-0 truncate text-12 text-muted">
 									{referenceName(offer)}
 								</p>
 							))}

--- a/.storybook/screens/article/MarginNotesScreen.tsx
+++ b/.storybook/screens/article/MarginNotesScreen.tsx
@@ -16,14 +16,14 @@ export function MarginNotesScreen() {
 			<FrameBody className="h-[19rem] gap-5 px-5 py-5">
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1">
-						<p className="text-(length:--text-15)">{draftParagraphs[0]}</p>
+						<p className="text-15">{draftParagraphs[0]}</p>
 					</div>
 					<div className="w-[11rem] shrink-0" />
 				</div>
 
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1 border-l-2 border-accent-edge pl-4">
-						<p className="text-(length:--text-15)">{draftParagraphs[1]}</p>
+						<p className="text-15">{draftParagraphs[1]}</p>
 					</div>
 					<GuidanceNote
 						anchor="§3"
@@ -47,9 +47,9 @@ export function MarginNotesScreen() {
 
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1">
-						<p className="text-(length:--text-15)">{draftParagraphs[2]}</p>
+						<p className="text-15">{draftParagraphs[2]}</p>
 					</div>
-					<p className="flex w-[11rem] shrink-0 items-center text-(length:--text-meta) text-faint">
+					<p className="flex w-[11rem] shrink-0 items-center text-11 text-faint">
 						Notes hold their place beside the paragraph they're about, and scroll with it.
 					</p>
 				</div>

--- a/.storybook/screens/article/MarginNotesScreen.tsx
+++ b/.storybook/screens/article/MarginNotesScreen.tsx
@@ -16,14 +16,14 @@ export function MarginNotesScreen() {
 			<FrameBody className="h-[19rem] gap-5 px-5 py-5">
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1">
-						<p className="text-[0.9375rem]">{draftParagraphs[0]}</p>
+						<p className="text-(length:--text-15)">{draftParagraphs[0]}</p>
 					</div>
 					<div className="w-[11rem] shrink-0" />
 				</div>
 
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1 border-l-2 border-accent-edge pl-4">
-						<p className="text-[0.9375rem]">{draftParagraphs[1]}</p>
+						<p className="text-(length:--text-15)">{draftParagraphs[1]}</p>
 					</div>
 					<GuidanceNote
 						anchor="§3"
@@ -47,9 +47,9 @@ export function MarginNotesScreen() {
 
 				<div className="flex gap-5">
 					<div className="prose-draft min-w-0 flex-1">
-						<p className="text-[0.9375rem]">{draftParagraphs[2]}</p>
+						<p className="text-(length:--text-15)">{draftParagraphs[2]}</p>
 					</div>
-					<p className="flex w-[11rem] shrink-0 items-center text-[0.6875rem] text-faint">
+					<p className="flex w-[11rem] shrink-0 items-center text-(length:--text-meta) text-faint">
 						Notes hold their place beside the paragraph they're about, and scroll with it.
 					</p>
 				</div>

--- a/.storybook/screens/article/NotesRailScreen.tsx
+++ b/.storybook/screens/article/NotesRailScreen.tsx
@@ -49,13 +49,13 @@ export function NotesRailScreen() {
 					<ul className="flex flex-col gap-2">
 						<li className="flex items-start gap-2">
 							<Check />
-							<span className="text-(length:--text-12) leading-snug text-ink">
+							<span className="text-12 leading-snug text-ink">
 								Cut the second crane-index callback
 							</span>
 						</li>
 						<li className="flex items-start gap-2 opacity-55">
 							<Check checked />
-							<span className="text-(length:--text-12) leading-snug text-ink line-through">
+							<span className="text-12 leading-snug text-ink line-through">
 								Attribute the £4,100 figure in-sentence
 							</span>
 						</li>

--- a/.storybook/screens/article/NotesRailScreen.tsx
+++ b/.storybook/screens/article/NotesRailScreen.tsx
@@ -49,13 +49,13 @@ export function NotesRailScreen() {
 					<ul className="flex flex-col gap-2">
 						<li className="flex items-start gap-2">
 							<Check />
-							<span className="text-[0.75rem] leading-snug text-ink">
+							<span className="text-(length:--text-12) leading-snug text-ink">
 								Cut the second crane-index callback
 							</span>
 						</li>
 						<li className="flex items-start gap-2 opacity-55">
 							<Check checked />
-							<span className="text-[0.75rem] leading-snug text-ink line-through">
+							<span className="text-(length:--text-12) leading-snug text-ink line-through">
 								Attribute the £4,100 figure in-sentence
 							</span>
 						</li>

--- a/.storybook/screens/article/PlanBlocks.tsx
+++ b/.storybook/screens/article/PlanBlocks.tsx
@@ -87,18 +87,18 @@ export function PlanOutline({
 			))}
 			{typing ? (
 				<div className="flex items-start gap-2.5">
-					<span className="mt-px w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
+					<span className="mt-px w-3 shrink-0 font-mono text-(length:--text-meta) text-faint">
 						{entries.length + 1}
 					</span>
 					<div className="flex min-w-0 flex-1 flex-col gap-1">
-						<div className="rounded-md border border-edge bg-surface px-2 py-1 text-[0.8125rem] text-ink">
+						<div className="rounded-md border border-edge bg-surface px-2 py-1 text-(length:--text-13) text-ink">
 							{typing}
 							<span
 								aria-hidden
 								className="ml-0.5 inline-block h-[1em] w-px translate-y-[0.15em] bg-ink"
 							/>
 						</div>
-						<p className="text-[0.6875rem] text-faint">typing here yourself</p>
+						<p className="text-(length:--text-meta) text-faint">typing here yourself</p>
 					</div>
 				</div>
 			) : null}
@@ -141,16 +141,16 @@ export function PlanReferences({
 						<p className="label-meta">★ just added</p>
 					) : null}
 					{reference.source?.title ? (
-						<p className="text-[0.75rem] leading-snug font-medium text-ink">
+						<p className="text-(length:--text-12) leading-snug font-medium text-ink">
 							{reference.source.title}
 						</p>
 					) : null}
 					{reference.text ? (
-						<blockquote className="border-l-2 border-rule pl-2 text-[0.8125rem] leading-relaxed text-ink">
+						<blockquote className="border-l-2 border-rule pl-2 text-(length:--text-13) leading-relaxed text-ink">
 							“{reference.text}”
 						</blockquote>
 					) : null}
-					<p className="text-[0.6875rem] text-faint">
+					<p className="text-(length:--text-meta) text-faint">
 						{[
 							reference.type,
 							reference.source?.publication,

--- a/.storybook/screens/article/PlanBlocks.tsx
+++ b/.storybook/screens/article/PlanBlocks.tsx
@@ -87,18 +87,18 @@ export function PlanOutline({
 			))}
 			{typing ? (
 				<div className="flex items-start gap-2.5">
-					<span className="mt-px w-3 shrink-0 font-mono text-(length:--text-meta) text-faint">
+					<span className="mt-px w-3 shrink-0 font-mono text-11 text-faint">
 						{entries.length + 1}
 					</span>
 					<div className="flex min-w-0 flex-1 flex-col gap-1">
-						<div className="rounded-md border border-edge bg-surface px-2 py-1 text-(length:--text-13) text-ink">
+						<div className="rounded-md border border-edge bg-surface px-2 py-1 text-13 text-ink">
 							{typing}
 							<span
 								aria-hidden
 								className="ml-0.5 inline-block h-[1em] w-px translate-y-[0.15em] bg-ink"
 							/>
 						</div>
-						<p className="text-(length:--text-meta) text-faint">typing here yourself</p>
+						<p className="text-11 text-faint">typing here yourself</p>
 					</div>
 				</div>
 			) : null}
@@ -141,16 +141,16 @@ export function PlanReferences({
 						<p className="label-meta">★ just added</p>
 					) : null}
 					{reference.source?.title ? (
-						<p className="text-(length:--text-12) leading-snug font-medium text-ink">
+						<p className="text-12 leading-snug font-medium text-ink">
 							{reference.source.title}
 						</p>
 					) : null}
 					{reference.text ? (
-						<blockquote className="border-l-2 border-rule pl-2 text-(length:--text-13) leading-relaxed text-ink">
+						<blockquote className="border-l-2 border-rule pl-2 text-13 leading-relaxed text-ink">
 							“{reference.text}”
 						</blockquote>
 					) : null}
-					<p className="text-(length:--text-meta) text-faint">
+					<p className="text-11 text-faint">
 						{[
 							reference.type,
 							reference.source?.publication,

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -108,7 +108,7 @@ export function PlanMapScreen({ branches = 'references' }: PlanMapScreenProps) {
 						<PlanOutline className="max-w-md" outline={edited.outline} />
 					)}
 
-					<p className="text-[0.6875rem] text-faint">
+					<p className="text-(length:--text-meta) text-faint">
 						{view === 'list'
 							? 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'
 							: branches === 'sections'

--- a/.storybook/screens/article/PlanMapScreen.tsx
+++ b/.storybook/screens/article/PlanMapScreen.tsx
@@ -108,7 +108,7 @@ export function PlanMapScreen({ branches = 'references' }: PlanMapScreenProps) {
 						<PlanOutline className="max-w-md" outline={edited.outline} />
 					)}
 
-					<p className="text-(length:--text-meta) text-faint">
+					<p className="text-11 text-faint">
 						{view === 'list'
 							? 'The same Outline, listed. Both Views read one Plan, so neither can show a Section the other does not.'
 							: branches === 'sections'

--- a/.storybook/screens/article/PlanRail.tsx
+++ b/.storybook/screens/article/PlanRail.tsx
@@ -49,13 +49,15 @@ export function PlanRail({
 						<div className="flex items-baseline gap-1.5">
 							<p
 								className={cx(
-									'min-w-0 flex-1 text-[0.75rem] leading-snug',
+									'min-w-0 flex-1 text-(length:--text-12) leading-snug',
 									current ? 'font-medium text-ink' : 'text-muted',
 								)}
 							>
 								{node.title}
 							</p>
-							{current ? <span className="text-[0.625rem] text-faint">now</span> : null}
+							{current ? (
+								<span className="text-(length:--text-10) text-faint">now</span>
+							) : null}
 						</div>
 						<ProgressBar
 							value={part}
@@ -68,7 +70,7 @@ export function PlanRail({
 
 			<div className="mt-auto flex flex-col gap-1.5">
 				<ProgressBar value={share(done, target)} thickness={5} label="Whole piece" />
-				<p className="text-[0.6875rem] text-faint">whole piece</p>
+				<p className="text-(length:--text-meta) text-faint">whole piece</p>
 			</div>
 
 			{counts?.length ? (

--- a/.storybook/screens/article/PlanRail.tsx
+++ b/.storybook/screens/article/PlanRail.tsx
@@ -49,15 +49,13 @@ export function PlanRail({
 						<div className="flex items-baseline gap-1.5">
 							<p
 								className={cx(
-									'min-w-0 flex-1 text-(length:--text-12) leading-snug',
+									'min-w-0 flex-1 text-12 leading-snug',
 									current ? 'font-medium text-ink' : 'text-muted',
 								)}
 							>
 								{node.title}
 							</p>
-							{current ? (
-								<span className="text-(length:--text-10) text-faint">now</span>
-							) : null}
+							{current ? <span className="text-10 text-faint">now</span> : null}
 						</div>
 						<ProgressBar
 							value={part}
@@ -70,7 +68,7 @@ export function PlanRail({
 
 			<div className="mt-auto flex flex-col gap-1.5">
 				<ProgressBar value={share(done, target)} thickness={5} label="Whole piece" />
-				<p className="text-(length:--text-meta) text-faint">whole piece</p>
+				<p className="text-11 text-faint">whole piece</p>
 			</div>
 
 			{counts?.length ? (

--- a/.storybook/screens/article/PlanSheetScreen.tsx
+++ b/.storybook/screens/article/PlanSheetScreen.tsx
@@ -43,7 +43,7 @@ export function PlanSheetScreen() {
 								height={188}
 							/>
 						</div>
-						<p className="text-(length:--text-meta) text-faint">
+						<p className="text-11 text-faint">
 							Edit it by hand, or go back to the chat and argue about it — either way the
 							advice you get while drafting changes to match.
 						</p>
@@ -54,7 +54,7 @@ export function PlanSheetScreen() {
 					<section className="flex flex-col gap-3">
 						<PanelHeader title="References" meta="4 · 3 placed" />
 						<PlanReferences references={plan.references} placedAt={placedAt} />
-						<p className="text-(length:--text-meta) text-faint">
+						<p className="text-11 text-faint">
 							Every Reference is a Link or a Quote, so one list holds both — drag one onto
 							a Section to place it.
 						</p>

--- a/.storybook/screens/article/PlanSheetScreen.tsx
+++ b/.storybook/screens/article/PlanSheetScreen.tsx
@@ -43,7 +43,7 @@ export function PlanSheetScreen() {
 								height={188}
 							/>
 						</div>
-						<p className="text-[0.6875rem] text-faint">
+						<p className="text-(length:--text-meta) text-faint">
 							Edit it by hand, or go back to the chat and argue about it — either way the
 							advice you get while drafting changes to match.
 						</p>
@@ -54,7 +54,7 @@ export function PlanSheetScreen() {
 					<section className="flex flex-col gap-3">
 						<PanelHeader title="References" meta="4 · 3 placed" />
 						<PlanReferences references={plan.references} placedAt={placedAt} />
-						<p className="text-[0.6875rem] text-faint">
+						<p className="text-(length:--text-meta) text-faint">
 							Every Reference is a Link or a Quote, so one list holds both — drag one onto
 							a Section to place it.
 						</p>

--- a/.storybook/screens/article/ReadyToDraftScreen.tsx
+++ b/.storybook/screens/article/ReadyToDraftScreen.tsx
@@ -17,9 +17,7 @@ export function ReadyToDraftScreen() {
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
 			<FrameBody row className="h-[21rem]">
 				<Panel divider="right" className="gap-3">
-					<p className="text-center text-(length:--text-meta) text-faint">
-						↑ earlier in this chat
-					</p>
+					<p className="text-center text-11 text-faint">↑ earlier in this chat</p>
 					<ChatMessage from="guide">
 						That gives §3 the human cost and keeps the numbers in §2 where they belong.
 					</ChatMessage>
@@ -39,11 +37,11 @@ export function ReadyToDraftScreen() {
 						<PlanBlock title="Outline" meta="4 sections">
 							<PlanOutline outline={plan.outline} dense />
 						</PlanBlock>
-						<p className="text-(length:--text-12) text-muted">13 references · 8 quotes</p>
+						<p className="text-12 text-muted">13 references · 8 quotes</p>
 					</div>
 					<div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
 						<Button variant="accent">start drafting →</Button>
-						<span className="text-(length:--text-12) text-faint">or keep talking</span>
+						<span className="text-12 text-faint">or keep talking</span>
 					</div>
 				</Panel>
 			</FrameBody>

--- a/.storybook/screens/article/ReadyToDraftScreen.tsx
+++ b/.storybook/screens/article/ReadyToDraftScreen.tsx
@@ -17,7 +17,7 @@ export function ReadyToDraftScreen() {
 			<ArticleBar title={ARTICLE_TITLE} open={['chat', 'plan']} status="planning" />
 			<FrameBody row className="h-[21rem]">
 				<Panel divider="right" className="gap-3">
-					<p className="text-center text-[0.6875rem] text-faint">
+					<p className="text-center text-(length:--text-meta) text-faint">
 						↑ earlier in this chat
 					</p>
 					<ChatMessage from="guide">
@@ -39,11 +39,11 @@ export function ReadyToDraftScreen() {
 						<PlanBlock title="Outline" meta="4 sections">
 							<PlanOutline outline={plan.outline} dense />
 						</PlanBlock>
-						<p className="text-[0.75rem] text-muted">13 references · 8 quotes</p>
+						<p className="text-(length:--text-12) text-muted">13 references · 8 quotes</p>
 					</div>
 					<div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
 						<Button variant="accent">start drafting →</Button>
-						<span className="text-[0.75rem] text-faint">or keep talking</span>
+						<span className="text-(length:--text-12) text-faint">or keep talking</span>
 					</div>
 				</Panel>
 			</FrameBody>

--- a/.storybook/screens/finish/ArchiveScreen.tsx
+++ b/.storybook/screens/finish/ArchiveScreen.tsx
@@ -16,17 +16,17 @@ export function ArchiveScreen() {
 			<TitleBar
 				back={<BackLink to="/">Articles</BackLink>}
 				title="Submitted & published"
-				actions={<span className="text-[0.75rem] text-faint">9 published</span>}
+				actions={<span className="text-(length:--text-12) text-faint">9 published</span>}
 			/>
 			<FrameBody className="gap-4 p-4">
 				<section className="flex flex-col gap-2.5">
 					<GroupHeading count={2}>Submitted</GroupHeading>
 					<div className="flex flex-col gap-2.5 rounded-lg border border-edge p-3">
 						<div className="flex items-baseline gap-2.5">
-							<h3 className="text-[0.875rem] font-semibold text-ink">
+							<h3 className="text-(length:--text-14) font-semibold text-ink">
 								Why Cities Stopped Building
 							</h3>
-							<span className="text-[0.6875rem] text-faint">
+							<span className="text-(length:--text-meta) text-faint">
 								sent 12 jul · chase due in 2 days
 							</span>
 						</div>
@@ -36,7 +36,7 @@ export function ArchiveScreen() {
 							</Button>
 							<Field size="sm" placeholder="where it ran (url)" className="flex-1" />
 						</div>
-						<p className="text-[0.6875rem] leading-relaxed text-faint">
+						<p className="text-(length:--text-meta) leading-relaxed text-faint">
 							Marking it published asks for the text as it ran, which is what the
 							comparison below reads from.
 						</p>
@@ -55,10 +55,10 @@ export function ArchiveScreen() {
 									aria-hidden
 									className="h-11 rounded-md border border-dashed border-edge bg-hush"
 								/>
-								<h3 className="text-[0.8125rem] leading-snug font-semibold text-ink">
+								<h3 className="text-(length:--text-13) leading-snug font-semibold text-ink">
 									{article.title}
 								</h3>
-								<p className="text-[0.6875rem] text-faint">
+								<p className="text-(length:--text-meta) text-faint">
 									{article.outlet} · {article.date} ↗
 								</p>
 							</article>
@@ -68,22 +68,22 @@ export function ArchiveScreen() {
 
 				<section className="flex flex-col gap-2.5 rounded-lg border border-edge bg-sunk p-3">
 					<div className="flex items-baseline gap-2.5">
-						<h3 className="text-[0.875rem] font-semibold text-ink">
+						<h3 className="text-(length:--text-14) font-semibold text-ink">
 							Self-edit final vs published
 						</h3>
-						<span className="text-[0.6875rem] text-faint">stub</span>
+						<span className="text-(length:--text-meta) text-faint">stub</span>
 					</div>
 					<div className="grid grid-cols-2 gap-3">
 						<div className="flex flex-col gap-1.5">
 							<MetaLabel>Mine</MetaLabel>
-							<p className="text-[0.75rem] leading-relaxed text-muted">
+							<p className="text-(length:--text-12) leading-relaxed text-muted">
 								“Nobody voted to stop building. It happened one reasonable amendment at a
 								time.”
 							</p>
 						</div>
 						<div className="flex flex-col gap-1.5">
 							<MetaLabel>As published</MetaLabel>
-							<p className="text-[0.75rem] leading-relaxed text-muted">
+							<p className="text-(length:--text-12) leading-relaxed text-muted">
 								“Nobody voted to stop building.{' '}
 								<mark className="bg-accent text-accent-ink">
 									It happened by increments.

--- a/.storybook/screens/finish/ArchiveScreen.tsx
+++ b/.storybook/screens/finish/ArchiveScreen.tsx
@@ -16,17 +16,17 @@ export function ArchiveScreen() {
 			<TitleBar
 				back={<BackLink to="/">Articles</BackLink>}
 				title="Submitted & published"
-				actions={<span className="text-(length:--text-12) text-faint">9 published</span>}
+				actions={<span className="text-12 text-faint">9 published</span>}
 			/>
 			<FrameBody className="gap-4 p-4">
 				<section className="flex flex-col gap-2.5">
 					<GroupHeading count={2}>Submitted</GroupHeading>
 					<div className="flex flex-col gap-2.5 rounded-lg border border-edge p-3">
 						<div className="flex items-baseline gap-2.5">
-							<h3 className="text-(length:--text-14) font-semibold text-ink">
+							<h3 className="text-14 font-semibold text-ink">
 								Why Cities Stopped Building
 							</h3>
-							<span className="text-(length:--text-meta) text-faint">
+							<span className="text-11 text-faint">
 								sent 12 jul · chase due in 2 days
 							</span>
 						</div>
@@ -36,7 +36,7 @@ export function ArchiveScreen() {
 							</Button>
 							<Field size="sm" placeholder="where it ran (url)" className="flex-1" />
 						</div>
-						<p className="text-(length:--text-meta) leading-relaxed text-faint">
+						<p className="text-11 leading-relaxed text-faint">
 							Marking it published asks for the text as it ran, which is what the
 							comparison below reads from.
 						</p>
@@ -55,10 +55,10 @@ export function ArchiveScreen() {
 									aria-hidden
 									className="h-11 rounded-md border border-dashed border-edge bg-hush"
 								/>
-								<h3 className="text-(length:--text-13) leading-snug font-semibold text-ink">
+								<h3 className="text-13 leading-snug font-semibold text-ink">
 									{article.title}
 								</h3>
-								<p className="text-(length:--text-meta) text-faint">
+								<p className="text-11 text-faint">
 									{article.outlet} · {article.date} ↗
 								</p>
 							</article>
@@ -68,22 +68,22 @@ export function ArchiveScreen() {
 
 				<section className="flex flex-col gap-2.5 rounded-lg border border-edge bg-sunk p-3">
 					<div className="flex items-baseline gap-2.5">
-						<h3 className="text-(length:--text-14) font-semibold text-ink">
+						<h3 className="text-14 font-semibold text-ink">
 							Self-edit final vs published
 						</h3>
-						<span className="text-(length:--text-meta) text-faint">stub</span>
+						<span className="text-11 text-faint">stub</span>
 					</div>
 					<div className="grid grid-cols-2 gap-3">
 						<div className="flex flex-col gap-1.5">
 							<MetaLabel>Mine</MetaLabel>
-							<p className="text-(length:--text-12) leading-relaxed text-muted">
+							<p className="text-12 leading-relaxed text-muted">
 								“Nobody voted to stop building. It happened one reasonable amendment at a
 								time.”
 							</p>
 						</div>
 						<div className="flex flex-col gap-1.5">
 							<MetaLabel>As published</MetaLabel>
-							<p className="text-(length:--text-12) leading-relaxed text-muted">
+							<p className="text-12 leading-relaxed text-muted">
 								“Nobody voted to stop building.{' '}
 								<mark className="bg-accent text-accent-ink">
 									It happened by increments.

--- a/.storybook/screens/finish/FinishScreen.tsx
+++ b/.storybook/screens/finish/FinishScreen.tsx
@@ -28,7 +28,9 @@ export function FinishScreen() {
 						<Chip variant="outline" interactive>
 							docx
 						</Chip>
-						<span className="ml-1 text-[0.75rem] text-faint">footnotes included</span>
+						<span className="ml-1 text-(length:--text-12) text-faint">
+							footnotes included
+						</span>
 					</div>
 
 					<section className="flex flex-col gap-2">
@@ -36,16 +38,16 @@ export function FinishScreen() {
 						<div className="flex flex-col gap-2 rounded-md border border-edge bg-sunk p-2.5">
 							<div className="flex flex-wrap items-center gap-1.5">
 								<Chip variant="default">author</Chip>
-								<span className="text-[0.75rem] text-muted">,</span>
+								<span className="text-(length:--text-12) text-muted">,</span>
 								<Chip variant="default">title</Chip>
-								<span className="text-[0.75rem] text-muted">,</span>
+								<span className="text-(length:--text-12) text-muted">,</span>
 								<Chip variant="default">publication</Chip>
-								<span className="text-[0.75rem] text-muted">(</span>
+								<span className="text-(length:--text-12) text-muted">(</span>
 								<Chip variant="default">date</Chip>
-								<span className="text-[0.75rem] text-muted">),</span>
+								<span className="text-(length:--text-12) text-muted">),</span>
 								<Chip variant="default">url</Chip>
 							</div>
-							<p className="text-[0.6875rem] text-faint">
+							<p className="text-(length:--text-meta) text-faint">
 								Drag the fields into order; type literal text between them.
 							</p>
 						</div>
@@ -53,7 +55,7 @@ export function FinishScreen() {
 
 					<section className="flex flex-col gap-2">
 						<MetaLabel>Preview</MetaLabel>
-						<ol className="flex flex-col gap-1.5 text-[0.75rem] leading-relaxed text-muted">
+						<ol className="flex flex-col gap-1.5 text-(length:--text-12) leading-relaxed text-muted">
 							<li>
 								1. R. Okonkwo, “Permit throughput in six mid-sized cities”, the Quarterly
 								(2023), quarterly.example/permit-throughput

--- a/.storybook/screens/finish/FinishScreen.tsx
+++ b/.storybook/screens/finish/FinishScreen.tsx
@@ -28,9 +28,7 @@ export function FinishScreen() {
 						<Chip variant="outline" interactive>
 							docx
 						</Chip>
-						<span className="ml-1 text-(length:--text-12) text-faint">
-							footnotes included
-						</span>
+						<span className="ml-1 text-12 text-faint">footnotes included</span>
 					</div>
 
 					<section className="flex flex-col gap-2">
@@ -38,16 +36,16 @@ export function FinishScreen() {
 						<div className="flex flex-col gap-2 rounded-md border border-edge bg-sunk p-2.5">
 							<div className="flex flex-wrap items-center gap-1.5">
 								<Chip variant="default">author</Chip>
-								<span className="text-(length:--text-12) text-muted">,</span>
+								<span className="text-12 text-muted">,</span>
 								<Chip variant="default">title</Chip>
-								<span className="text-(length:--text-12) text-muted">,</span>
+								<span className="text-12 text-muted">,</span>
 								<Chip variant="default">publication</Chip>
-								<span className="text-(length:--text-12) text-muted">(</span>
+								<span className="text-12 text-muted">(</span>
 								<Chip variant="default">date</Chip>
-								<span className="text-(length:--text-12) text-muted">),</span>
+								<span className="text-12 text-muted">),</span>
 								<Chip variant="default">url</Chip>
 							</div>
-							<p className="text-(length:--text-meta) text-faint">
+							<p className="text-11 text-faint">
 								Drag the fields into order; type literal text between them.
 							</p>
 						</div>
@@ -55,7 +53,7 @@ export function FinishScreen() {
 
 					<section className="flex flex-col gap-2">
 						<MetaLabel>Preview</MetaLabel>
-						<ol className="flex flex-col gap-1.5 text-(length:--text-12) leading-relaxed text-muted">
+						<ol className="flex flex-col gap-1.5 text-12 leading-relaxed text-muted">
 							<li>
 								1. R. Okonkwo, “Permit throughput in six mid-sized cities”, the Quarterly
 								(2023), quarterly.example/permit-throughput

--- a/.storybook/screens/finish/ShowcaseScreen.tsx
+++ b/.storybook/screens/finish/ShowcaseScreen.tsx
@@ -14,7 +14,7 @@ export function ShowcaseScreen() {
 				<h1 className="font-serif text-[1.75rem] leading-tight text-paper">
 					Emmy Joarness
 				</h1>
-				<p className="max-w-[22rem] text-[0.8125rem] leading-relaxed text-paper/60">
+				<p className="max-w-[22rem] text-(length:--text-13) leading-relaxed text-paper/60">
 					Reported features and essays on cities, energy and the things that quietly
 					stopped working. Selected work, 2024—2026.
 				</p>
@@ -28,10 +28,10 @@ export function ShowcaseScreen() {
 								aria-hidden
 								className="h-14 rounded-md border border-dashed border-edge bg-hush"
 							/>
-							<h2 className="text-[0.875rem] leading-snug font-semibold text-ink">
+							<h2 className="text-(length:--text-14) leading-snug font-semibold text-ink">
 								{article.title}
 							</h2>
-							<p className="text-[0.6875rem] text-faint">
+							<p className="text-(length:--text-meta) text-faint">
 								{article.outlet} · {article.date} ↗
 							</p>
 						</article>
@@ -44,13 +44,15 @@ export function ShowcaseScreen() {
 							key={item.id}
 							title={item.title}
 							note={item.outlet}
-							trailing={<span className="text-[0.6875rem] text-faint">{item.year}</span>}
+							trailing={
+								<span className="text-(length:--text-meta) text-faint">{item.year}</span>
+							}
 						/>
 					))}
 				</div>
 
 				<div className="flex items-center gap-2.5 border-t border-edge pt-3">
-					<span className="text-[0.75rem] text-muted">joarness.app/em</span>
+					<span className="text-(length:--text-12) text-muted">joarness.app/em</span>
 					<Chip variant="accent" className="ml-auto">
 						public · on
 					</Chip>

--- a/.storybook/screens/finish/ShowcaseScreen.tsx
+++ b/.storybook/screens/finish/ShowcaseScreen.tsx
@@ -14,7 +14,7 @@ export function ShowcaseScreen() {
 				<h1 className="font-serif text-[1.75rem] leading-tight text-paper">
 					Emmy Joarness
 				</h1>
-				<p className="max-w-[22rem] text-(length:--text-13) leading-relaxed text-paper/60">
+				<p className="max-w-[22rem] text-13 leading-relaxed text-paper/60">
 					Reported features and essays on cities, energy and the things that quietly
 					stopped working. Selected work, 2024—2026.
 				</p>
@@ -28,10 +28,10 @@ export function ShowcaseScreen() {
 								aria-hidden
 								className="h-14 rounded-md border border-dashed border-edge bg-hush"
 							/>
-							<h2 className="text-(length:--text-14) leading-snug font-semibold text-ink">
+							<h2 className="text-14 leading-snug font-semibold text-ink">
 								{article.title}
 							</h2>
-							<p className="text-(length:--text-meta) text-faint">
+							<p className="text-11 text-faint">
 								{article.outlet} · {article.date} ↗
 							</p>
 						</article>
@@ -44,15 +44,13 @@ export function ShowcaseScreen() {
 							key={item.id}
 							title={item.title}
 							note={item.outlet}
-							trailing={
-								<span className="text-(length:--text-meta) text-faint">{item.year}</span>
-							}
+							trailing={<span className="text-11 text-faint">{item.year}</span>}
 						/>
 					))}
 				</div>
 
 				<div className="flex items-center gap-2.5 border-t border-edge pt-3">
-					<span className="text-(length:--text-12) text-muted">joarness.app/em</span>
+					<span className="text-12 text-muted">joarness.app/em</span>
 					<Chip variant="accent" className="ml-auto">
 						public · on
 					</Chip>

--- a/.storybook/screens/global/FavouriteSourcesScreen.tsx
+++ b/.storybook/screens/global/FavouriteSourcesScreen.tsx
@@ -55,7 +55,7 @@ export function FavouriteSourcesScreen() {
 				<MetaLabel count="14 times">Pulled in research</MetaLabel>
 				<div className="flex items-center gap-2.5">
 					<Chip variant="accent">★ rank first</Chip>
-					<p className="text-(length:--text-12) text-muted">
+					<p className="text-12 text-muted">
 						Ahead of equally relevant results, never instead of better ones.
 					</p>
 				</div>

--- a/.storybook/screens/global/FavouriteSourcesScreen.tsx
+++ b/.storybook/screens/global/FavouriteSourcesScreen.tsx
@@ -55,7 +55,7 @@ export function FavouriteSourcesScreen() {
 				<MetaLabel count="14 times">Pulled in research</MetaLabel>
 				<div className="flex items-center gap-2.5">
 					<Chip variant="accent">★ rank first</Chip>
-					<p className="text-[0.75rem] text-muted">
+					<p className="text-(length:--text-12) text-muted">
 						Ahead of equally relevant results, never instead of better ones.
 					</p>
 				</div>

--- a/.storybook/screens/global/SettingsShell.tsx
+++ b/.storybook/screens/global/SettingsShell.tsx
@@ -67,7 +67,7 @@ export function SettingsShell({
 								type="button"
 								aria-current={item.id === selectedId ? 'true' : undefined}
 								className={cx(
-									'-mx-1.5 rounded-md px-1.5 py-1 text-left text-[0.8125rem] transition-colors',
+									'-mx-1.5 rounded-md px-1.5 py-1 text-left text-(length:--text-13) transition-colors',
 									item.id === selectedId
 										? 'bg-accent font-medium text-accent-ink'
 										: 'text-muted hover:bg-hush hover:text-ink',
@@ -96,7 +96,7 @@ export function SettingsDetailHeader({ title, usage }: SettingsDetailHeaderProps
 	return (
 		<div className="flex items-baseline gap-2.5">
 			<h3 className="text-[1rem] font-semibold text-ink">{title}</h3>
-			<span className="text-[0.75rem] text-faint">{usage}</span>
+			<span className="text-(length:--text-12) text-faint">{usage}</span>
 		</div>
 	)
 }
@@ -111,7 +111,7 @@ export function RuleBlock({ label, children }: RuleBlockProps) {
 	return (
 		<div className="flex flex-col gap-1.5">
 			<p className="label-meta">{label}</p>
-			<p className="rounded-md border border-edge bg-sunk p-2.5 text-[0.8125rem] leading-relaxed text-ink">
+			<p className="rounded-md border border-edge bg-sunk p-2.5 text-(length:--text-13) leading-relaxed text-ink">
 				{children}
 			</p>
 		</div>
@@ -132,7 +132,7 @@ export function ScoreTest({ score, paragraph }: ScoreTestProps) {
 		<div className="flex items-center gap-3 rounded-md border border-edge bg-sunk p-2.5">
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<p className="label-meta">Paste to test a paragraph</p>
-				<p className="truncate text-[0.75rem] text-muted">{paragraph}</p>
+				<p className="truncate text-(length:--text-12) text-muted">{paragraph}</p>
 			</div>
 			<Chip variant="accent">{score}</Chip>
 		</div>

--- a/.storybook/screens/global/SettingsShell.tsx
+++ b/.storybook/screens/global/SettingsShell.tsx
@@ -67,7 +67,7 @@ export function SettingsShell({
 								type="button"
 								aria-current={item.id === selectedId ? 'true' : undefined}
 								className={cx(
-									'-mx-1.5 rounded-md px-1.5 py-1 text-left text-(length:--text-13) transition-colors',
+									'-mx-1.5 rounded-md px-1.5 py-1 text-left text-13 transition-colors',
 									item.id === selectedId
 										? 'bg-accent font-medium text-accent-ink'
 										: 'text-muted hover:bg-hush hover:text-ink',
@@ -96,7 +96,7 @@ export function SettingsDetailHeader({ title, usage }: SettingsDetailHeaderProps
 	return (
 		<div className="flex items-baseline gap-2.5">
 			<h3 className="text-[1rem] font-semibold text-ink">{title}</h3>
-			<span className="text-(length:--text-12) text-faint">{usage}</span>
+			<span className="text-12 text-faint">{usage}</span>
 		</div>
 	)
 }
@@ -111,7 +111,7 @@ export function RuleBlock({ label, children }: RuleBlockProps) {
 	return (
 		<div className="flex flex-col gap-1.5">
 			<p className="label-meta">{label}</p>
-			<p className="rounded-md border border-edge bg-sunk p-2.5 text-(length:--text-13) leading-relaxed text-ink">
+			<p className="rounded-md border border-edge bg-sunk p-2.5 text-13 leading-relaxed text-ink">
 				{children}
 			</p>
 		</div>
@@ -132,7 +132,7 @@ export function ScoreTest({ score, paragraph }: ScoreTestProps) {
 		<div className="flex items-center gap-3 rounded-md border border-edge bg-sunk p-2.5">
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<p className="label-meta">Paste to test a paragraph</p>
-				<p className="truncate text-(length:--text-12) text-muted">{paragraph}</p>
+				<p className="truncate text-12 text-muted">{paragraph}</p>
 			</div>
 			<Chip variant="accent">{score}</Chip>
 		</div>

--- a/.storybook/screens/global/TableScreen.tsx
+++ b/.storybook/screens/global/TableScreen.tsx
@@ -76,25 +76,25 @@ export function TableScreen() {
 						key={row.title}
 						className="flex items-baseline gap-3 border-b border-rule py-2.5"
 					>
-						<span className="min-w-0 flex-1 truncate text-[0.8125rem] text-ink">
+						<span className="min-w-0 flex-1 truncate text-(length:--text-13) text-ink">
 							{row.title}
 						</span>
 						<span className="w-20">
 							{row.attention ? (
 								<Chip variant="accent">{row.status}</Chip>
 							) : (
-								<span className="text-[0.75rem] text-muted">{row.status}</span>
+								<span className="text-(length:--text-12) text-muted">{row.status}</span>
 							)}
 						</span>
-						<span className="w-14 text-right font-mono text-[0.6875rem] text-faint">
+						<span className="w-14 text-right font-mono text-(length:--text-meta) text-faint">
 							{row.words}
 						</span>
-						<span className="w-10 text-right font-mono text-[0.6875rem] text-faint">
+						<span className="w-10 text-right font-mono text-(length:--text-meta) text-faint">
 							{row.touched}
 						</span>
 					</div>
 				))}
-				<p className="pt-3 text-[0.6875rem] text-faint">
+				<p className="pt-3 text-(length:--text-meta) text-faint">
 					+ 18 more · sorted by last touched
 				</p>
 			</FrameBody>

--- a/.storybook/screens/global/TableScreen.tsx
+++ b/.storybook/screens/global/TableScreen.tsx
@@ -76,27 +76,23 @@ export function TableScreen() {
 						key={row.title}
 						className="flex items-baseline gap-3 border-b border-rule py-2.5"
 					>
-						<span className="min-w-0 flex-1 truncate text-(length:--text-13) text-ink">
-							{row.title}
-						</span>
+						<span className="min-w-0 flex-1 truncate text-13 text-ink">{row.title}</span>
 						<span className="w-20">
 							{row.attention ? (
 								<Chip variant="accent">{row.status}</Chip>
 							) : (
-								<span className="text-(length:--text-12) text-muted">{row.status}</span>
+								<span className="text-12 text-muted">{row.status}</span>
 							)}
 						</span>
-						<span className="w-14 text-right font-mono text-(length:--text-meta) text-faint">
+						<span className="w-14 text-right font-mono text-11 text-faint">
 							{row.words}
 						</span>
-						<span className="w-10 text-right font-mono text-(length:--text-meta) text-faint">
+						<span className="w-10 text-right font-mono text-11 text-faint">
 							{row.touched}
 						</span>
 					</div>
 				))}
-				<p className="pt-3 text-(length:--text-meta) text-faint">
-					+ 18 more · sorted by last touched
-				</p>
+				<p className="pt-3 text-11 text-faint">+ 18 more · sorted by last touched</p>
 			</FrameBody>
 		</Frame>
 	)

--- a/.storybook/screens/review/FullReviewScreen.tsx
+++ b/.storybook/screens/review/FullReviewScreen.tsx
@@ -45,8 +45,8 @@ function NoteRow({ note }: { note: Note }) {
 		<li className="flex items-start gap-2.5">
 			<Check checked={note.accepted} label={`Accept: ${note.text}`} />
 			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-				<p className="text-(length:--text-13) leading-relaxed text-ink">{note.text}</p>
-				<p className="text-(length:--text-meta) text-faint">
+				<p className="text-13 leading-relaxed text-ink">{note.text}</p>
+				<p className="text-11 text-faint">
 					{note.anchor}
 					{note.accepted ? ' · accepted' : ''}
 				</p>
@@ -70,7 +70,7 @@ export function FullReviewScreen() {
 
 					<div className="flex flex-col gap-1.5">
 						<MetaLabel>The shape of it</MetaLabel>
-						<p className="text-(length:--text-13) leading-relaxed text-muted">
+						<p className="text-13 leading-relaxed text-muted">
 							The reporting is doing its job and the middle is the strongest it has been.
 							The piece is 210 words over target and the overrun is entirely in §3, which
 							is also where the plan says the argument should be tightest.

--- a/.storybook/screens/review/FullReviewScreen.tsx
+++ b/.storybook/screens/review/FullReviewScreen.tsx
@@ -45,8 +45,8 @@ function NoteRow({ note }: { note: Note }) {
 		<li className="flex items-start gap-2.5">
 			<Check checked={note.accepted} label={`Accept: ${note.text}`} />
 			<div className="flex min-w-0 flex-1 flex-col gap-0.5">
-				<p className="text-[0.8125rem] leading-relaxed text-ink">{note.text}</p>
-				<p className="text-[0.6875rem] text-faint">
+				<p className="text-(length:--text-13) leading-relaxed text-ink">{note.text}</p>
+				<p className="text-(length:--text-meta) text-faint">
 					{note.anchor}
 					{note.accepted ? ' · accepted' : ''}
 				</p>
@@ -70,7 +70,7 @@ export function FullReviewScreen() {
 
 					<div className="flex flex-col gap-1.5">
 						<MetaLabel>The shape of it</MetaLabel>
-						<p className="text-[0.8125rem] leading-relaxed text-muted">
+						<p className="text-(length:--text-13) leading-relaxed text-muted">
 							The reporting is doing its job and the middle is the strongest it has been.
 							The piece is 210 words over target and the overrun is entirely in §3, which
 							is also where the plan says the argument should be tightest.

--- a/.storybook/screens/review/NotesToChatScreen.tsx
+++ b/.storybook/screens/review/NotesToChatScreen.tsx
@@ -61,14 +61,14 @@ export function NotesToChatScreen() {
 							<MetaLabel>Quotes</MetaLabel>
 							<div className="flex items-center gap-2.5">
 								<Chip variant="accent">3 / 4</Chip>
-								<span className="text-[0.75rem] text-faint">was 3 / 5</span>
+								<span className="text-(length:--text-12) text-faint">was 3 / 5</span>
 							</div>
 							<div className="flex items-start gap-2.5 opacity-55">
-								<span className="text-[0.6875rem] text-faint">dropped</span>
-								<blockquote className="min-w-0 flex-1 border-l-2 border-rule pl-2.5 text-[0.75rem] leading-relaxed text-muted">
+								<span className="text-(length:--text-meta) text-faint">dropped</span>
+								<blockquote className="min-w-0 flex-1 border-l-2 border-rule pl-2.5 text-(length:--text-12) leading-relaxed text-muted">
 									“The meter runs on an empty lot exactly as fast as it runs on a finished
 									one.”
-									<span className="mt-0.5 block text-[0.6875rem] text-faint">
+									<span className="mt-0.5 block text-(length:--text-meta) text-faint">
 										no longer needed in §3
 									</span>
 								</blockquote>
@@ -77,7 +77,7 @@ export function NotesToChatScreen() {
 					</div>
 					<div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
 						<Button>back to the draft →</Button>
-						<span className="text-[0.75rem] text-faint">round 3 whenever</span>
+						<span className="text-(length:--text-12) text-faint">round 3 whenever</span>
 					</div>
 				</Panel>
 			</FrameBody>

--- a/.storybook/screens/review/NotesToChatScreen.tsx
+++ b/.storybook/screens/review/NotesToChatScreen.tsx
@@ -61,14 +61,14 @@ export function NotesToChatScreen() {
 							<MetaLabel>Quotes</MetaLabel>
 							<div className="flex items-center gap-2.5">
 								<Chip variant="accent">3 / 4</Chip>
-								<span className="text-(length:--text-12) text-faint">was 3 / 5</span>
+								<span className="text-12 text-faint">was 3 / 5</span>
 							</div>
 							<div className="flex items-start gap-2.5 opacity-55">
-								<span className="text-(length:--text-meta) text-faint">dropped</span>
-								<blockquote className="min-w-0 flex-1 border-l-2 border-rule pl-2.5 text-(length:--text-12) leading-relaxed text-muted">
+								<span className="text-11 text-faint">dropped</span>
+								<blockquote className="min-w-0 flex-1 border-l-2 border-rule pl-2.5 text-12 leading-relaxed text-muted">
 									“The meter runs on an empty lot exactly as fast as it runs on a finished
 									one.”
-									<span className="mt-0.5 block text-(length:--text-meta) text-faint">
+									<span className="mt-0.5 block text-11 text-faint">
 										no longer needed in §3
 									</span>
 								</blockquote>
@@ -77,7 +77,7 @@ export function NotesToChatScreen() {
 					</div>
 					<div className="flex items-center gap-3 border-t border-edge px-3.5 py-3">
 						<Button>back to the draft →</Button>
-						<span className="text-(length:--text-12) text-faint">round 3 whenever</span>
+						<span className="text-12 text-faint">round 3 whenever</span>
 					</div>
 				</Panel>
 			</FrameBody>

--- a/.storybook/screens/review/PanelCombosScreen.tsx
+++ b/.storybook/screens/review/PanelCombosScreen.tsx
@@ -63,7 +63,7 @@ export function PanelCombosScreen() {
 									key={Panel}
 									style={{ flex }}
 									className={cx(
-										'grid place-items-center text-(length:--text-10) text-faint',
+										'grid place-items-center text-10 text-faint',
 										j > 0 && 'border-l border-edge',
 										Panel === 'draft' ? 'bg-surface' : 'bg-sunk',
 									)}
@@ -74,7 +74,7 @@ export function PanelCombosScreen() {
 						</div>
 					</div>
 				))}
-				<p className="text-(length:--text-meta) leading-relaxed text-faint">
+				<p className="text-11 leading-relaxed text-faint">
 					Notes is always the narrow one. Plan collapses to a rail when the draft is up.
 					Draft alone is the sixth state, and the most common.
 				</p>

--- a/.storybook/screens/review/PanelCombosScreen.tsx
+++ b/.storybook/screens/review/PanelCombosScreen.tsx
@@ -63,7 +63,7 @@ export function PanelCombosScreen() {
 									key={Panel}
 									style={{ flex }}
 									className={cx(
-										'grid place-items-center text-[0.625rem] text-faint',
+										'grid place-items-center text-(length:--text-10) text-faint',
 										j > 0 && 'border-l border-edge',
 										Panel === 'draft' ? 'bg-surface' : 'bg-sunk',
 									)}
@@ -74,7 +74,7 @@ export function PanelCombosScreen() {
 						</div>
 					</div>
 				))}
-				<p className="text-[0.6875rem] leading-relaxed text-faint">
+				<p className="text-(length:--text-meta) leading-relaxed text-faint">
 					Notes is always the narrow one. Plan collapses to a rail when the draft is up.
 					Draft alone is the sixth state, and the most common.
 				</p>

--- a/.storybook/screens/review/PanelsRecapScreen.tsx
+++ b/.storybook/screens/review/PanelsRecapScreen.tsx
@@ -71,7 +71,7 @@ export function PanelsRecapScreen() {
 									<span className="text-center text-[0.5625rem] leading-tight text-faint">
 										{arrows[i - 1]}
 									</span>
-									<span aria-hidden className="text-[0.75rem] text-faint">
+									<span aria-hidden className="text-(length:--text-12) text-faint">
 										→
 									</span>
 								</div>
@@ -85,8 +85,10 @@ export function PanelsRecapScreen() {
 								)}
 							>
 								<MetaLabel>Panel {panel.n}</MetaLabel>
-								<h3 className="text-[0.875rem] font-semibold text-ink">{panel.name}</h3>
-								<p className="text-[0.6875rem] leading-relaxed text-muted">
+								<h3 className="text-(length:--text-14) font-semibold text-ink">
+									{panel.name}
+								</h3>
+								<p className="text-(length:--text-meta) leading-relaxed text-muted">
 									{panel.body}
 								</p>
 							</div>
@@ -110,7 +112,7 @@ export function PanelsRecapScreen() {
 									/>
 								))}
 							</div>
-							<span className="text-[0.75rem] text-muted">{state.label}</span>
+							<span className="text-(length:--text-12) text-muted">{state.label}</span>
 						</div>
 					))}
 				</div>
@@ -119,7 +121,7 @@ export function PanelsRecapScreen() {
 					<Chip variant="outline">Outline</Chip>
 					<Chip variant="outline">Tone</Chip>
 					<Chip variant="outline">References</Chip>
-					<span className="text-[0.6875rem] text-faint">
+					<span className="text-(length:--text-meta) text-faint">
 						everything the Guide knows about this piece lives in Panel 2 — which is why
 						editing it by hand changes the advice
 					</span>

--- a/.storybook/screens/review/PanelsRecapScreen.tsx
+++ b/.storybook/screens/review/PanelsRecapScreen.tsx
@@ -71,7 +71,7 @@ export function PanelsRecapScreen() {
 									<span className="text-center text-[0.5625rem] leading-tight text-faint">
 										{arrows[i - 1]}
 									</span>
-									<span aria-hidden className="text-(length:--text-12) text-faint">
+									<span aria-hidden className="text-12 text-faint">
 										→
 									</span>
 								</div>
@@ -85,12 +85,8 @@ export function PanelsRecapScreen() {
 								)}
 							>
 								<MetaLabel>Panel {panel.n}</MetaLabel>
-								<h3 className="text-(length:--text-14) font-semibold text-ink">
-									{panel.name}
-								</h3>
-								<p className="text-(length:--text-meta) leading-relaxed text-muted">
-									{panel.body}
-								</p>
+								<h3 className="text-14 font-semibold text-ink">{panel.name}</h3>
+								<p className="text-11 leading-relaxed text-muted">{panel.body}</p>
 							</div>
 						</div>
 					))}
@@ -112,7 +108,7 @@ export function PanelsRecapScreen() {
 									/>
 								))}
 							</div>
-							<span className="text-(length:--text-12) text-muted">{state.label}</span>
+							<span className="text-12 text-muted">{state.label}</span>
 						</div>
 					))}
 				</div>
@@ -121,7 +117,7 @@ export function PanelsRecapScreen() {
 					<Chip variant="outline">Outline</Chip>
 					<Chip variant="outline">Tone</Chip>
 					<Chip variant="outline">References</Chip>
-					<span className="text-(length:--text-meta) text-faint">
+					<span className="text-11 text-faint">
 						everything the Guide knows about this piece lives in Panel 2 — which is why
 						editing it by hand changes the advice
 					</span>

--- a/.storybook/screens/review/PhoneNotesScreen.tsx
+++ b/.storybook/screens/review/PhoneNotesScreen.tsx
@@ -12,8 +12,10 @@ export function PhoneNotesScreen() {
 	return (
 		<Frame width={280}>
 			<div className="flex items-baseline justify-between px-3.5 py-2.5">
-				<span className="text-[0.8125rem] text-faint">The Long Tail of Batteries</span>
-				<span className="text-[0.6875rem] text-faint">draft 1</span>
+				<span className="text-(length:--text-13) text-faint">
+					The Long Tail of Batteries
+				</span>
+				<span className="text-(length:--text-meta) text-faint">draft 1</span>
 			</div>
 			<FrameBody className="gap-3.5 px-3.5 pb-4">
 				<div className="flex gap-1.5">
@@ -55,7 +57,12 @@ export function PhoneNotesScreen() {
 					<MetaLabel>Read</MetaLabel>
 					<div className="prose-draft">
 						{draftShort.map((paragraph, i) => (
-							<p key={i} className={i > 0 ? 'mt-3 text-[0.8125rem]' : 'text-[0.8125rem]'}>
+							<p
+								key={i}
+								className={
+									i > 0 ? 'mt-3 text-(length:--text-13)' : 'text-(length:--text-13)'
+								}
+							>
 								{paragraph}
 							</p>
 						))}

--- a/.storybook/screens/review/PhoneNotesScreen.tsx
+++ b/.storybook/screens/review/PhoneNotesScreen.tsx
@@ -12,10 +12,8 @@ export function PhoneNotesScreen() {
 	return (
 		<Frame width={280}>
 			<div className="flex items-baseline justify-between px-3.5 py-2.5">
-				<span className="text-(length:--text-13) text-faint">
-					The Long Tail of Batteries
-				</span>
-				<span className="text-(length:--text-meta) text-faint">draft 1</span>
+				<span className="text-13 text-faint">The Long Tail of Batteries</span>
+				<span className="text-11 text-faint">draft 1</span>
 			</div>
 			<FrameBody className="gap-3.5 px-3.5 pb-4">
 				<div className="flex gap-1.5">
@@ -57,12 +55,7 @@ export function PhoneNotesScreen() {
 					<MetaLabel>Read</MetaLabel>
 					<div className="prose-draft">
 						{draftShort.map((paragraph, i) => (
-							<p
-								key={i}
-								className={
-									i > 0 ? 'mt-3 text-(length:--text-13)' : 'text-(length:--text-13)'
-								}
-							>
+							<p key={i} className={i > 0 ? 'mt-3 text-13' : 'text-13'}>
 								{paragraph}
 							</p>
 						))}

--- a/.storybook/screens/review/ReviewRailScreen.tsx
+++ b/.storybook/screens/review/ReviewRailScreen.tsx
@@ -20,19 +20,19 @@ export function ReviewRailScreen() {
 				<DraftSurface paragraphs={draftParagraphs.slice(0, 3)} measure="narrow" dimmed />
 
 				<aside className="flex w-[14rem] shrink-0 flex-col gap-3.5 border-l border-edge bg-sunk p-3.5">
-					<h3 className="text-(length:--text-14) font-semibold text-ink">Full review</h3>
+					<h3 className="text-14 font-semibold text-ink">Full review</h3>
 
 					<section className="flex flex-col gap-2">
 						<MetaLabel count={2}>Structure</MetaLabel>
 						<div className="flex items-start gap-2">
 							<Check />
-							<p className="text-(length:--text-12) leading-snug text-ink">
+							<p className="text-12 leading-snug text-ink">
 								The crane index carries §1 and §4 both
 							</p>
 						</div>
 						<div className="flex items-start gap-2 opacity-55">
 							<Check checked />
-							<p className="text-(length:--text-12) leading-snug text-ink line-through">
+							<p className="text-12 leading-snug text-ink line-through">
 								Human cost arrives too late
 							</p>
 						</div>
@@ -42,7 +42,7 @@ export function ReviewRailScreen() {
 						<MetaLabel count={1}>Voice</MetaLabel>
 						<div className="flex items-start gap-2">
 							<Check />
-							<p className="text-(length:--text-12) leading-snug text-ink">
+							<p className="text-12 leading-snug text-ink">
 								§3 drifts into Newsletter aside
 							</p>
 						</div>
@@ -52,14 +52,14 @@ export function ReviewRailScreen() {
 						<MetaLabel count={3}>Citations</MetaLabel>
 						<div className="flex items-start gap-2">
 							<Check />
-							<p className="text-(length:--text-12) leading-snug text-ink">
+							<p className="text-12 leading-snug text-ink">
 								£4,100 figure needs attribution
 							</p>
 						</div>
 						<div className="flex items-start gap-2">
 							<Check />
 							<div className="flex min-w-0 flex-1 flex-col gap-1.5">
-								<p className="text-(length:--text-12) leading-snug text-ink">
+								<p className="text-12 leading-snug text-ink">
 									2 of 5 planned quotes unused
 								</p>
 								<div className="flex flex-wrap gap-1.5">

--- a/.storybook/screens/review/ReviewRailScreen.tsx
+++ b/.storybook/screens/review/ReviewRailScreen.tsx
@@ -20,19 +20,19 @@ export function ReviewRailScreen() {
 				<DraftSurface paragraphs={draftParagraphs.slice(0, 3)} measure="narrow" dimmed />
 
 				<aside className="flex w-[14rem] shrink-0 flex-col gap-3.5 border-l border-edge bg-sunk p-3.5">
-					<h3 className="text-[0.875rem] font-semibold text-ink">Full review</h3>
+					<h3 className="text-(length:--text-14) font-semibold text-ink">Full review</h3>
 
 					<section className="flex flex-col gap-2">
 						<MetaLabel count={2}>Structure</MetaLabel>
 						<div className="flex items-start gap-2">
 							<Check />
-							<p className="text-[0.75rem] leading-snug text-ink">
+							<p className="text-(length:--text-12) leading-snug text-ink">
 								The crane index carries §1 and §4 both
 							</p>
 						</div>
 						<div className="flex items-start gap-2 opacity-55">
 							<Check checked />
-							<p className="text-[0.75rem] leading-snug text-ink line-through">
+							<p className="text-(length:--text-12) leading-snug text-ink line-through">
 								Human cost arrives too late
 							</p>
 						</div>
@@ -42,7 +42,7 @@ export function ReviewRailScreen() {
 						<MetaLabel count={1}>Voice</MetaLabel>
 						<div className="flex items-start gap-2">
 							<Check />
-							<p className="text-[0.75rem] leading-snug text-ink">
+							<p className="text-(length:--text-12) leading-snug text-ink">
 								§3 drifts into Newsletter aside
 							</p>
 						</div>
@@ -52,14 +52,14 @@ export function ReviewRailScreen() {
 						<MetaLabel count={3}>Citations</MetaLabel>
 						<div className="flex items-start gap-2">
 							<Check />
-							<p className="text-[0.75rem] leading-snug text-ink">
+							<p className="text-(length:--text-12) leading-snug text-ink">
 								£4,100 figure needs attribution
 							</p>
 						</div>
 						<div className="flex items-start gap-2">
 							<Check />
 							<div className="flex min-w-0 flex-1 flex-col gap-1.5">
-								<p className="text-[0.75rem] leading-snug text-ink">
+								<p className="text-(length:--text-12) leading-snug text-ink">
 									2 of 5 planned quotes unused
 								</p>
 								<div className="flex flex-wrap gap-1.5">

--- a/src/client/article/ArticlePanels.tsx
+++ b/src/client/article/ArticlePanels.tsx
@@ -1,4 +1,4 @@
-import { Activity, type ReactNode } from 'react'
+import { Activity, type CSSProperties, type ReactNode } from 'react'
 
 import { ArticleChatPanel } from '../chat/ArticleChatPanel'
 import { Panel, PanelHeader, type PanelProps } from '../components/Panel'
@@ -21,11 +21,16 @@ export interface ArticlePanelsProps {
 	agent: ArticleSocket
 	/** Already in chat → plan → draft → notes order; `usePanels` keeps it there. */
 	open: readonly PanelId[]
+	/** The row's type-and-spacing scale — `panelScale` in usePanels. */
+	scale: number
 }
 
-export function ArticlePanels({ agent, open }: ArticlePanelsProps) {
+export function ArticlePanels({ agent, open, scale }: ArticlePanelsProps) {
 	return (
-		<div className="flex min-h-0 flex-auto">
+		<div
+			className="panel-scale flex min-h-0 flex-auto"
+			style={{ '--panel-scale': scale } as CSSProperties}
+		>
 			{PANELS.map((panel) => {
 				// `open` is in rail order, so anything past the first has a Panel on
 				// its left to draw a rule against.
@@ -93,7 +98,7 @@ function EmptyPanel({
 	return (
 		<Panel divider={divider} grow={grow} variant="sunk">
 			<PanelHeader title={title} />
-			<p className="text-[0.75rem] leading-relaxed text-faint">{children}</p>
+			<p className="text-(length:--text-12) leading-relaxed text-faint">{children}</p>
 		</Panel>
 	)
 }

--- a/src/client/article/ArticlePanels.tsx
+++ b/src/client/article/ArticlePanels.tsx
@@ -98,7 +98,7 @@ function EmptyPanel({
 	return (
 		<Panel divider={divider} grow={grow} variant="sunk">
 			<PanelHeader title={title} />
-			<p className="text-(length:--text-12) leading-relaxed text-faint">{children}</p>
+			<p className="text-12 leading-relaxed text-faint">{children}</p>
 		</Panel>
 	)
 }

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -26,13 +26,15 @@ export function usePanels(): PanelState {
 	}, [narrow])
 
 	// theme.css reads this count into the root font-size: fewer open Panels
-	// leave more room, so the type and the spacing grow.
+	// leave more room, so the type and the spacing grow. A narrow window is
+	// stamped 'narrow' rather than a count — it shows one Panel out of
+	// necessity, not room, and must not read as the generous one-Panel scale.
 	useEffect(() => {
-		document.documentElement.dataset.panels = String(open.length)
+		document.documentElement.dataset.panels = narrow ? 'narrow' : String(open.length)
 		return () => {
 			delete document.documentElement.dataset.panels
 		}
-	}, [open.length])
+	}, [narrow, open.length])
 
 	return {
 		open,

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -14,6 +14,8 @@ export type PanelState = {
 	open: PanelId[]
 	/** The rail is a set of tabs rather than a set of toggles. */
 	narrow: boolean
+	/** The Panel row's type-and-spacing scale — `panelScale`. */
+	scale: number
 	toggle: (panel: PanelId) => void
 }
 
@@ -27,22 +29,22 @@ export function usePanels(): PanelState {
 		if (narrow) setOpen((held) => (held.length > 1 ? [held[0]] : held))
 	}, [narrow])
 
-	// theme.css reads this count into the root font-size: fewer open Panels
-	// leave more room, so the type and the spacing grow. A narrow window is
-	// stamped 'narrow' rather than a count — it shows one Panel out of
-	// necessity, not room, and must not read as the generous one-Panel scale.
-	useEffect(() => {
-		document.documentElement.dataset.panels = narrow ? 'narrow' : String(open.length)
-		return () => {
-			delete document.documentElement.dataset.panels
-		}
-	}, [narrow, open.length])
-
 	return {
 		open,
 		narrow,
+		scale: panelScale(open, narrow),
 		toggle: (panel) => setOpen((held) => nextOpenPanels(held, panel, narrow)),
 	}
+}
+
+/** How the Panel row's type and spacing scale with room — the `.panel-scale`
+ * class in theme.css reads this as `--panel-scale`. Fewer open Panels leave
+ * more room: one Panel is generous, two a step down, three or four compact. A
+ * narrow window shows one Panel out of necessity, not room, so it stays
+ * compact. */
+export function panelScale(open: readonly PanelId[], narrow: boolean): number {
+	if (narrow || open.length > 2) return 1
+	return open.length === 1 ? 1.25 : 1.125
 }
 
 /** Narrow selects; wide toggles, never down to nothing, and always back into the

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -4,9 +4,8 @@ import { PANELS, type PanelId } from '../components/PanelRail'
 
 /** Which Panels the Article screen shows, and the tabs a narrow one gets — §8. */
 
-/** Below the md breakpoint the rail shows one Panel at a time. The px value is
- * `--breakpoint-md` (theme.css), and the query is the complement of `md:` —
- * what Tailwind's `max-md:` variant compiles to. */
+/** Below the md breakpoint (`--breakpoint-md`, theme.css) the rail shows one
+ * Panel at a time. The query is the complement of Tailwind's `md:`. */
 const narrowQuery = '(width < 768px)'
 
 export type PanelState = {
@@ -37,11 +36,9 @@ export function usePanels(): PanelState {
 	}
 }
 
-/** How the Panel row's type and spacing scale with room — the `.panel-scale`
- * class in theme.css reads this as `--panel-scale`. Fewer open Panels leave
- * more room: one Panel is generous, two a step down, three or four compact. A
- * narrow window shows one Panel out of necessity, not room, so it stays
- * compact. */
+/** The Panel row's type-and-spacing scale — `.panel-scale` in theme.css reads
+ * it as `--panel-scale`. Fewer open Panels leave more room; a narrow window
+ * shows one Panel out of necessity, not room, so it stays compact. */
 export function panelScale(open: readonly PanelId[], narrow: boolean): number {
 	if (narrow || open.length > 2) return 1
 	return open.length === 1 ? 1.25 : 1.125

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -25,6 +25,15 @@ export function usePanels(): PanelState {
 		if (narrow) setOpen((held) => (held.length > 1 ? [held[0]] : held))
 	}, [narrow])
 
+	// theme.css reads this count into the root font-size: fewer open Panels
+	// leave more room, so the type and the spacing grow.
+	useEffect(() => {
+		document.documentElement.dataset.panels = String(open.length)
+		return () => {
+			delete document.documentElement.dataset.panels
+		}
+	}, [open.length])
+
 	return {
 		open,
 		narrow,

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -4,8 +4,10 @@ import { PANELS, type PanelId } from '../components/PanelRail'
 
 /** Which Panels the Article screen shows, and the tabs a narrow one gets — §8. */
 
-/** Two Panels of any use need about this much. Below it, one at a time. */
-const narrowQuery = '(max-width: 56rem)'
+/** Below the md breakpoint the rail shows one Panel at a time. The px value is
+ * `--breakpoint-md` (theme.css), and the query is the complement of `md:` —
+ * what Tailwind's `max-md:` variant compiles to. */
+const narrowQuery = '(width < 768px)'
 
 export type PanelState = {
 	/** Which Panels are visible. All four stay mounted. */

--- a/src/client/articles/ArticleList.tsx
+++ b/src/client/articles/ArticleList.tsx
@@ -153,7 +153,7 @@ function ArticleRow({
 			>
 				<span
 					className={cx(
-						'block truncate text-(length:--text-14)',
+						'block truncate text-14',
 						isUntitled(article.title) ? 'text-faint' : 'text-ink',
 					)}
 				>
@@ -162,7 +162,7 @@ function ArticleRow({
 			</Link>
 			<Chip variant="outline">{statusLabel[article.status]}</Chip>
 			{/* Fixed width, so dates of different lengths leave the chips in line. */}
-			<span className="w-12 shrink-0 text-right text-(length:--text-meta) text-faint">
+			<span className="w-12 shrink-0 text-right text-11 text-faint">
 				{shortDate(when)}
 			</span>
 			{action ? <span className="relative shrink-0">{action}</span> : null}

--- a/src/client/articles/ArticleList.tsx
+++ b/src/client/articles/ArticleList.tsx
@@ -153,7 +153,7 @@ function ArticleRow({
 			>
 				<span
 					className={cx(
-						'block truncate text-[0.875rem]',
+						'block truncate text-(length:--text-14)',
 						isUntitled(article.title) ? 'text-faint' : 'text-ink',
 					)}
 				>
@@ -162,7 +162,7 @@ function ArticleRow({
 			</Link>
 			<Chip variant="outline">{statusLabel[article.status]}</Chip>
 			{/* Fixed width, so dates of different lengths leave the chips in line. */}
-			<span className="w-12 shrink-0 text-right text-[0.6875rem] text-faint">
+			<span className="w-12 shrink-0 text-right text-(length:--text-meta) text-faint">
 				{shortDate(when)}
 			</span>
 			{action ? <span className="relative shrink-0">{action}</span> : null}

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -39,7 +39,7 @@ export function ArticleChatPanel({
 	if (plan === null) {
 		return (
 			<Panel className={className} divider={divider} grow={grow}>
-				<p className="text-(length:--text-12) text-faint">Opening the Chat…</p>
+				<p className="text-12 text-faint">Opening the Chat…</p>
 			</Panel>
 		)
 	}

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -39,7 +39,7 @@ export function ArticleChatPanel({
 	if (plan === null) {
 		return (
 			<Panel className={className} divider={divider} grow={grow}>
-				<p className="text-[0.75rem] text-faint">Opening the Chat…</p>
+				<p className="text-(length:--text-12) text-faint">Opening the Chat…</p>
 			</Panel>
 		)
 	}

--- a/src/client/chat/OfferLedgerDrawer.tsx
+++ b/src/client/chat/OfferLedgerDrawer.tsx
@@ -80,7 +80,7 @@ export function OfferLedgerDrawer({
 				actions={
 					<button
 						type="button"
-						className="text-(length:--text-12) text-faint hover:text-ink"
+						className="text-12 text-faint hover:text-ink"
 						onClick={onClose}
 					>
 						close ×
@@ -104,7 +104,7 @@ export function OfferLedgerDrawer({
 					))}
 				</div>
 				{failure === null ? null : <Notice>{failure}</Notice>}
-				{loading ? <p className="text-(length:--text-12) text-faint">Reading…</p> : null}
+				{loading ? <p className="text-12 text-faint">Reading…</p> : null}
 				{shown.map((offer) => (
 					<ReferenceCard
 						key={offer.id}

--- a/src/client/chat/OfferLedgerDrawer.tsx
+++ b/src/client/chat/OfferLedgerDrawer.tsx
@@ -80,7 +80,7 @@ export function OfferLedgerDrawer({
 				actions={
 					<button
 						type="button"
-						className="text-[0.75rem] text-faint hover:text-ink"
+						className="text-(length:--text-12) text-faint hover:text-ink"
 						onClick={onClose}
 					>
 						close ×
@@ -104,7 +104,7 @@ export function OfferLedgerDrawer({
 					))}
 				</div>
 				{failure === null ? null : <Notice>{failure}</Notice>}
-				{loading ? <p className="text-[0.75rem] text-faint">Reading…</p> : null}
+				{loading ? <p className="text-(length:--text-12) text-faint">Reading…</p> : null}
 				{shown.map((offer) => (
 					<ReferenceCard
 						key={offer.id}

--- a/src/client/chat/ProposalChanges.tsx
+++ b/src/client/chat/ProposalChanges.tsx
@@ -19,16 +19,14 @@ export function ProposalChanges({
 }: ProposalChangesProps) {
 	if (unreadable !== null) {
 		return (
-			<p className={cx('text-(length:--text-13) leading-snug text-ink', className)}>
-				{unreadableText}
-			</p>
+			<p className={cx('text-13 leading-snug text-ink', className)}>{unreadableText}</p>
 		)
 	}
 
 	return (
 		<ul className={cx('flex list-none flex-col gap-1', className)}>
 			{changes.map((change) => (
-				<li key={change} className="text-(length:--text-13) leading-snug text-ink">
+				<li key={change} className="text-13 leading-snug text-ink">
 					{change}
 				</li>
 			))}

--- a/src/client/chat/ProposalChanges.tsx
+++ b/src/client/chat/ProposalChanges.tsx
@@ -19,7 +19,7 @@ export function ProposalChanges({
 }: ProposalChangesProps) {
 	if (unreadable !== null) {
 		return (
-			<p className={cx('text-[0.8125rem] leading-snug text-ink', className)}>
+			<p className={cx('text-(length:--text-13) leading-snug text-ink', className)}>
 				{unreadableText}
 			</p>
 		)
@@ -28,7 +28,7 @@ export function ProposalChanges({
 	return (
 		<ul className={cx('flex list-none flex-col gap-1', className)}>
 			{changes.map((change) => (
-				<li key={change} className="text-[0.8125rem] leading-snug text-ink">
+				<li key={change} className="text-(length:--text-13) leading-snug text-ink">
 					{change}
 				</li>
 			))}

--- a/src/client/chat/RuledProposal.tsx
+++ b/src/client/chat/RuledProposal.tsx
@@ -26,7 +26,7 @@ export function RuledProposal({ call, plan, ruling, className }: RuledProposalPr
 	const ruled = ruling === 'accepted' ? 'Proposal Accepted' : 'Proposal Declined'
 
 	return (
-		<details className={cx('text-[0.6875rem] text-faint', className)}>
+		<details className={cx('text-(length:--text-meta) text-faint', className)}>
 			<summary className="cursor-pointer">
 				{call.ops === null ? `${ruled}.` : `${ruled} · ${changeCount(changes)}`}
 			</summary>

--- a/src/client/chat/RuledProposal.tsx
+++ b/src/client/chat/RuledProposal.tsx
@@ -26,7 +26,7 @@ export function RuledProposal({ call, plan, ruling, className }: RuledProposalPr
 	const ruled = ruling === 'accepted' ? 'Proposal Accepted' : 'Proposal Declined'
 
 	return (
-		<details className={cx('text-(length:--text-meta) text-faint', className)}>
+		<details className={cx('text-11 text-faint', className)}>
 			<summary className="cursor-pointer">
 				{call.ops === null ? `${ruled}.` : `${ruled} · ${changeCount(changes)}`}
 			</summary>

--- a/src/client/components/Annotation.tsx
+++ b/src/client/components/Annotation.tsx
@@ -17,7 +17,7 @@ export function Annotation({ children, align = 'left', className }: AnnotationPr
 	return (
 		<p
 			className={cx(
-				'flex max-w-[28rem] gap-2 pt-2.5 text-(length:--text-12) leading-relaxed text-muted',
+				'flex max-w-[28rem] gap-2 pt-2.5 text-12 leading-relaxed text-muted',
 				align === 'right' && 'ml-auto flex-row-reverse text-right',
 				className,
 			)}

--- a/src/client/components/Annotation.tsx
+++ b/src/client/components/Annotation.tsx
@@ -17,7 +17,7 @@ export function Annotation({ children, align = 'left', className }: AnnotationPr
 	return (
 		<p
 			className={cx(
-				'flex max-w-[28rem] gap-2 pt-2.5 text-[0.75rem] leading-relaxed text-muted',
+				'flex max-w-[28rem] gap-2 pt-2.5 text-(length:--text-12) leading-relaxed text-muted',
 				align === 'right' && 'ml-auto flex-row-reverse text-right',
 				className,
 			)}

--- a/src/client/components/ArticleBar.tsx
+++ b/src/client/components/ArticleBar.tsx
@@ -51,7 +51,7 @@ export function ArticleBar({
 			)}
 		>
 			{back}
-			<span className="min-w-0 flex-1 truncate text-[0.8125rem] text-faint">
+			<span className="min-w-0 flex-1 truncate text-(length:--text-13) text-faint">
 				{title === null ? (
 					<Skeleton className="w-40" label="Opening the Article" />
 				) : (
@@ -59,7 +59,7 @@ export function ArticleBar({
 				)}
 			</span>
 			{stacked ? null : rail}
-			<span className="flex min-w-0 flex-1 items-center justify-end gap-2 text-right text-[0.75rem] whitespace-nowrap text-faint">
+			<span className="flex min-w-0 flex-1 items-center justify-end gap-2 text-right text-(length:--text-12) whitespace-nowrap text-faint">
 				{status}
 			</span>
 			{stacked ? (

--- a/src/client/components/ArticleBar.tsx
+++ b/src/client/components/ArticleBar.tsx
@@ -51,7 +51,7 @@ export function ArticleBar({
 			)}
 		>
 			{back}
-			<span className="min-w-0 flex-1 truncate text-(length:--text-13) text-faint">
+			<span className="min-w-0 flex-1 truncate text-13 text-faint">
 				{title === null ? (
 					<Skeleton className="w-40" label="Opening the Article" />
 				) : (
@@ -59,7 +59,7 @@ export function ArticleBar({
 				)}
 			</span>
 			{stacked ? null : rail}
-			<span className="flex min-w-0 flex-1 items-center justify-end gap-2 text-right text-(length:--text-12) whitespace-nowrap text-faint">
+			<span className="flex min-w-0 flex-1 items-center justify-end gap-2 text-right text-12 whitespace-nowrap text-faint">
 				{status}
 			</span>
 			{stacked ? (

--- a/src/client/components/ArticleCard.tsx
+++ b/src/client/components/ArticleCard.tsx
@@ -45,7 +45,7 @@ export function ArticleCard({ article, variant = 'card', className }: ArticleCar
 			<h3
 				className={cx(
 					'leading-snug break-words',
-					compact ? 'text-(length:--text-13)' : 'line-clamp-3 text-(length:--text-15)',
+					compact ? 'text-13' : 'line-clamp-3 text-15',
 					isUntitled(article.title) ? 'text-faint' : 'font-semibold text-ink',
 				)}
 			>
@@ -61,9 +61,7 @@ export function ArticleCard({ article, variant = 'card', className }: ArticleCar
 
 			<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
 				{compact ? null : <Chip variant="outline">{statusLabel[article.status]}</Chip>}
-				<span className="text-(length:--text-meta) text-faint">
-					started {shortDate(article.createdAt)}
-				</span>
+				<span className="text-11 text-faint">started {shortDate(article.createdAt)}</span>
 			</div>
 		</Link>
 	)

--- a/src/client/components/ArticleCard.tsx
+++ b/src/client/components/ArticleCard.tsx
@@ -45,7 +45,7 @@ export function ArticleCard({ article, variant = 'card', className }: ArticleCar
 			<h3
 				className={cx(
 					'leading-snug break-words',
-					compact ? 'text-[0.8125rem]' : 'line-clamp-3 text-[0.9375rem]',
+					compact ? 'text-(length:--text-13)' : 'line-clamp-3 text-(length:--text-15)',
 					isUntitled(article.title) ? 'text-faint' : 'font-semibold text-ink',
 				)}
 			>
@@ -61,7 +61,7 @@ export function ArticleCard({ article, variant = 'card', className }: ArticleCar
 
 			<div className="flex flex-wrap items-center gap-x-2 gap-y-1">
 				{compact ? null : <Chip variant="outline">{statusLabel[article.status]}</Chip>}
-				<span className="text-[0.6875rem] text-faint">
+				<span className="text-(length:--text-meta) text-faint">
 					started {shortDate(article.createdAt)}
 				</span>
 			</div>

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -40,8 +40,8 @@ const variantClass: Record<ButtonVariant, string> = {
 }
 
 const sizeClass: Record<ButtonSize, string> = {
-	sm: 'h-6 gap-1.5 rounded-full px-2.5 text-[0.75rem]',
-	md: 'h-8 gap-2 rounded-full px-3.5 text-[0.8125rem]',
+	sm: 'h-6 gap-1.5 rounded-full px-2.5 text-(length:--text-12)',
+	md: 'h-8 gap-2 rounded-full px-3.5 text-(length:--text-13)',
 }
 
 /** The look on its own, for a `Link` that has to sit in a row of Buttons. A
@@ -54,7 +54,7 @@ export function buttonClass({
 }: Pick<ButtonProps, 'variant' | 'size' | 'pressed' | 'className'> = {}): string {
 	return cx(
 		'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter] disabled:pointer-events-none disabled:opacity-40',
-		variant === 'link' ? 'h-auto text-[0.8125rem]' : sizeClass[size],
+		variant === 'link' ? 'h-auto text-(length:--text-13)' : sizeClass[size],
 		pressed ? pressedClass : variantClass[variant],
 		className,
 	)

--- a/src/client/components/Button.tsx
+++ b/src/client/components/Button.tsx
@@ -40,8 +40,8 @@ const variantClass: Record<ButtonVariant, string> = {
 }
 
 const sizeClass: Record<ButtonSize, string> = {
-	sm: 'h-6 gap-1.5 rounded-full px-2.5 text-(length:--text-12)',
-	md: 'h-8 gap-2 rounded-full px-3.5 text-(length:--text-13)',
+	sm: 'h-6 gap-1.5 rounded-full px-2.5 text-12',
+	md: 'h-8 gap-2 rounded-full px-3.5 text-13',
 }
 
 /** The look on its own, for a `Link` that has to sit in a row of Buttons. A
@@ -54,7 +54,7 @@ export function buttonClass({
 }: Pick<ButtonProps, 'variant' | 'size' | 'pressed' | 'className'> = {}): string {
 	return cx(
 		'inline-flex shrink-0 items-center justify-center font-medium whitespace-nowrap transition-[background-color,border-color,color,filter] disabled:pointer-events-none disabled:opacity-40',
-		variant === 'link' ? 'h-auto text-(length:--text-13)' : sizeClass[size],
+		variant === 'link' ? 'h-auto text-13' : sizeClass[size],
 		pressed ? pressedClass : variantClass[variant],
 		className,
 	)

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -26,7 +26,7 @@ export function ChatMessage({ from, children, className }: ChatMessageProps) {
 		return (
 			<div
 				className={cx(
-					'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-[0.8125rem] leading-relaxed whitespace-pre-wrap text-ink',
+					'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-(length:--text-13) leading-relaxed whitespace-pre-wrap text-ink',
 					className,
 				)}
 			>
@@ -37,7 +37,7 @@ export function ChatMessage({ from, children, className }: ChatMessageProps) {
 	return (
 		<div
 			className={cx(
-				'max-w-[95%] text-[0.8125rem] leading-relaxed whitespace-pre-wrap text-ink',
+				'max-w-[95%] text-(length:--text-13) leading-relaxed whitespace-pre-wrap text-ink',
 				className,
 			)}
 		>
@@ -129,7 +129,7 @@ export function ChatComposer({
 					<textarea
 						ref={field}
 						aria-label="Message the guide"
-						className="max-h-[8lh] min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-[0.8125rem] leading-relaxed text-ink outline-none placeholder:text-faint"
+						className="max-h-[8lh] min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-(length:--text-13) leading-relaxed text-ink outline-none placeholder:text-faint"
 						disabled={onSend === undefined}
 						onChange={(event) => setSaid(event.target.value)}
 						onKeyDown={onKeyDown}
@@ -169,7 +169,12 @@ export function ChatWorking({ children, className }: ChatWorkingProps) {
 	}, [])
 
 	return (
-		<p className={cx('flex items-center gap-1.5 text-[0.6875rem] text-faint', className)}>
+		<p
+			className={cx(
+				'flex items-center gap-1.5 text-(length:--text-meta) text-faint',
+				className,
+			)}
+		>
 			<span aria-hidden className="size-1.5 animate-pulse rounded-full bg-faint" />
 			{children}
 			{seconds > 0 ? <span className="font-mono">{seconds}s</span> : null}
@@ -195,5 +200,7 @@ export interface ChatNoteProps {
 /** What the Chat did rather than what it said: a Proposal ruled on, a turn
  * looking something up. Quiet, because it is a record and not a turn. */
 export function ChatNote({ children, className }: ChatNoteProps) {
-	return <p className={cx('text-[0.6875rem] text-faint', className)}>{children}</p>
+	return (
+		<p className={cx('text-(length:--text-meta) text-faint', className)}>{children}</p>
+	)
 }

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -26,7 +26,7 @@ export function ChatMessage({ from, children, className }: ChatMessageProps) {
 		return (
 			<div
 				className={cx(
-					'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-(length:--text-13) leading-relaxed whitespace-pre-wrap text-ink',
+					'ml-auto max-w-[85%] rounded-lg rounded-br-sm bg-hush px-3 py-2 text-13 leading-relaxed whitespace-pre-wrap text-ink',
 					className,
 				)}
 			>
@@ -37,7 +37,7 @@ export function ChatMessage({ from, children, className }: ChatMessageProps) {
 	return (
 		<div
 			className={cx(
-				'max-w-[95%] text-(length:--text-13) leading-relaxed whitespace-pre-wrap text-ink',
+				'max-w-[95%] text-13 leading-relaxed whitespace-pre-wrap text-ink',
 				className,
 			)}
 		>
@@ -129,7 +129,7 @@ export function ChatComposer({
 					<textarea
 						ref={field}
 						aria-label="Message the guide"
-						className="max-h-[8lh] min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-(length:--text-13) leading-relaxed text-ink outline-none placeholder:text-faint"
+						className="max-h-[8lh] min-w-0 flex-1 resize-none overflow-y-auto bg-transparent text-13 leading-relaxed text-ink outline-none placeholder:text-faint"
 						disabled={onSend === undefined}
 						onChange={(event) => setSaid(event.target.value)}
 						onKeyDown={onKeyDown}
@@ -169,12 +169,7 @@ export function ChatWorking({ children, className }: ChatWorkingProps) {
 	}, [])
 
 	return (
-		<p
-			className={cx(
-				'flex items-center gap-1.5 text-(length:--text-meta) text-faint',
-				className,
-			)}
-		>
+		<p className={cx('flex items-center gap-1.5 text-11 text-faint', className)}>
 			<span aria-hidden className="size-1.5 animate-pulse rounded-full bg-faint" />
 			{children}
 			{seconds > 0 ? <span className="font-mono">{seconds}s</span> : null}
@@ -200,7 +195,5 @@ export interface ChatNoteProps {
 /** What the Chat did rather than what it said: a Proposal ruled on, a turn
  * looking something up. Quiet, because it is a record and not a turn. */
 export function ChatNote({ children, className }: ChatNoteProps) {
-	return (
-		<p className={cx('text-(length:--text-meta) text-faint', className)}>{children}</p>
-	)
+	return <p className={cx('text-11 text-faint', className)}>{children}</p>
 }

--- a/src/client/components/Chip.tsx
+++ b/src/client/components/Chip.tsx
@@ -27,7 +27,7 @@ const variantClass: Record<ChipVariant, string> = {
  * the status `<select>` in the ArticleBar sits beside real ones. */
 export function chipClass(variant: ChipVariant, interactive = false): string {
 	return cx(
-		'inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-[0.1875rem] text-(length:--text-meta) leading-none font-medium whitespace-nowrap',
+		'inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-[0.1875rem] text-11 leading-none font-medium whitespace-nowrap',
 		variantClass[variant],
 		interactive && 'transition-colors hover:border-ink/30 hover:text-ink',
 	)

--- a/src/client/components/Chip.tsx
+++ b/src/client/components/Chip.tsx
@@ -27,7 +27,7 @@ const variantClass: Record<ChipVariant, string> = {
  * the status `<select>` in the ArticleBar sits beside real ones. */
 export function chipClass(variant: ChipVariant, interactive = false): string {
 	return cx(
-		'inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-[0.1875rem] text-[0.6875rem] leading-none font-medium whitespace-nowrap',
+		'inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-[0.1875rem] text-(length:--text-meta) leading-none font-medium whitespace-nowrap',
 		variantClass[variant],
 		interactive && 'transition-colors hover:border-ink/30 hover:text-ink',
 	)

--- a/src/client/components/CitedLine.tsx
+++ b/src/client/components/CitedLine.tsx
@@ -19,7 +19,7 @@ export function CitedLine({ parts, className }: CitedLineProps) {
 	return (
 		<p
 			className={cx(
-				'flex flex-wrap items-center gap-x-1.5 text-[0.6875rem] text-faint',
+				'flex flex-wrap items-center gap-x-1.5 text-(length:--text-meta) text-faint',
 				className,
 			)}
 		>

--- a/src/client/components/CitedLine.tsx
+++ b/src/client/components/CitedLine.tsx
@@ -19,7 +19,7 @@ export function CitedLine({ parts, className }: CitedLineProps) {
 	return (
 		<p
 			className={cx(
-				'flex flex-wrap items-center gap-x-1.5 text-(length:--text-meta) text-faint',
+				'flex flex-wrap items-center gap-x-1.5 text-11 text-faint',
 				className,
 			)}
 		>

--- a/src/client/components/Dialog.tsx
+++ b/src/client/components/Dialog.tsx
@@ -55,13 +55,9 @@ export function Dialog({
 		>
 			<div className="flex flex-col gap-3.5 p-4">
 				<div className="flex flex-col gap-1">
-					<h2 className="text-(length:--text-15) leading-tight font-medium text-ink">
-						{title}
-					</h2>
+					<h2 className="text-15 leading-tight font-medium text-ink">{title}</h2>
 					{subtitle ? (
-						<p className="text-(length:--text-12) leading-relaxed text-faint">
-							{subtitle}
-						</p>
+						<p className="text-12 leading-relaxed text-faint">{subtitle}</p>
 					) : null}
 				</div>
 				{children}

--- a/src/client/components/Dialog.tsx
+++ b/src/client/components/Dialog.tsx
@@ -55,9 +55,13 @@ export function Dialog({
 		>
 			<div className="flex flex-col gap-3.5 p-4">
 				<div className="flex flex-col gap-1">
-					<h2 className="text-[0.9375rem] leading-tight font-medium text-ink">{title}</h2>
+					<h2 className="text-(length:--text-15) leading-tight font-medium text-ink">
+						{title}
+					</h2>
 					{subtitle ? (
-						<p className="text-[0.75rem] leading-relaxed text-faint">{subtitle}</p>
+						<p className="text-(length:--text-12) leading-relaxed text-faint">
+							{subtitle}
+						</p>
 					) : null}
 				</div>
 				{children}

--- a/src/client/components/DraftSurface.tsx
+++ b/src/client/components/DraftSurface.tsx
@@ -44,7 +44,7 @@ export function DraftSurface({
 				<p
 					key={i}
 					className={cx(
-						'text-[0.9375rem]',
+						'text-(length:--text-15)',
 						i > 0 && 'mt-4',
 						i === anchoredIndex && '-ml-3 border-l-2 border-accent-edge pl-3',
 					)}

--- a/src/client/components/DraftSurface.tsx
+++ b/src/client/components/DraftSurface.tsx
@@ -44,7 +44,7 @@ export function DraftSurface({
 				<p
 					key={i}
 					className={cx(
-						'text-(length:--text-15)',
+						'text-15',
 						i > 0 && 'mt-4',
 						i === anchoredIndex && '-ml-3 border-l-2 border-accent-edge pl-3',
 					)}

--- a/src/client/components/ExampleBlock.tsx
+++ b/src/client/components/ExampleBlock.tsx
@@ -32,10 +32,10 @@ export function ExampleBlock({
 				className,
 			)}
 		>
-			<blockquote className="text-[0.75rem] leading-relaxed text-ink">
+			<blockquote className="text-(length:--text-12) leading-relaxed text-ink">
 				“{text}”
 			</blockquote>
-			<figcaption className="flex flex-wrap items-center gap-x-1.5 text-[0.6875rem] text-faint">
+			<figcaption className="flex flex-wrap items-center gap-x-1.5 text-(length:--text-meta) text-faint">
 				{source ? <cite className="not-italic">{source}</cite> : null}
 				{source && reason ? <span aria-hidden>·</span> : null}
 				{reason ? <span>{reason}</span> : null}

--- a/src/client/components/ExampleBlock.tsx
+++ b/src/client/components/ExampleBlock.tsx
@@ -32,10 +32,8 @@ export function ExampleBlock({
 				className,
 			)}
 		>
-			<blockquote className="text-(length:--text-12) leading-relaxed text-ink">
-				“{text}”
-			</blockquote>
-			<figcaption className="flex flex-wrap items-center gap-x-1.5 text-(length:--text-meta) text-faint">
+			<blockquote className="text-12 leading-relaxed text-ink">“{text}”</blockquote>
+			<figcaption className="flex flex-wrap items-center gap-x-1.5 text-11 text-faint">
 				{source ? <cite className="not-italic">{source}</cite> : null}
 				{source && reason ? <span aria-hidden>·</span> : null}
 				{reason ? <span>{reason}</span> : null}

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -13,8 +13,8 @@ const frameClass =
 	'flex min-w-0 flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5'
 
 const sizeClass = {
-	sm: 'h-7 text-(length:--text-12)',
-	md: 'h-8 text-(length:--text-13)',
+	sm: 'h-7 text-12',
+	md: 'h-8 text-13',
 }
 
 /** One label style for every field, and it is the same mono label a list gets.
@@ -101,12 +101,7 @@ export function TextField({
 			{label ? (
 				<span className={cx(labelClass, rows > 1 && 'pt-1.5')}>{label}</span>
 			) : null}
-			<div
-				className={cx(
-					frameClass,
-					rows > 1 ? 'py-1.5 text-(length:--text-12)' : sizeClass[size],
-				)}
-			>
+			<div className={cx(frameClass, rows > 1 ? 'py-1.5 text-12' : sizeClass[size])}>
 				{rows > 1 ? (
 					<textarea
 						aria-label={hiddenLabel}
@@ -191,7 +186,7 @@ export function EmptySlot({ children, className }: EmptySlotProps) {
 	return (
 		<div
 			className={cx(
-				'flex items-center justify-center rounded-md border border-dashed border-edge px-3 py-2.5 text-center text-(length:--text-12) text-faint',
+				'flex items-center justify-center rounded-md border border-dashed border-edge px-3 py-2.5 text-center text-12 text-faint',
 				className,
 			)}
 		>

--- a/src/client/components/Field.tsx
+++ b/src/client/components/Field.tsx
@@ -13,8 +13,8 @@ const frameClass =
 	'flex min-w-0 flex-1 items-center gap-2 rounded-md border border-edge bg-surface px-2.5'
 
 const sizeClass = {
-	sm: 'h-7 text-[0.75rem]',
-	md: 'h-8 text-[0.8125rem]',
+	sm: 'h-7 text-(length:--text-12)',
+	md: 'h-8 text-(length:--text-13)',
 }
 
 /** One label style for every field, and it is the same mono label a list gets.
@@ -102,7 +102,10 @@ export function TextField({
 				<span className={cx(labelClass, rows > 1 && 'pt-1.5')}>{label}</span>
 			) : null}
 			<div
-				className={cx(frameClass, rows > 1 ? 'py-1.5 text-[0.75rem]' : sizeClass[size])}
+				className={cx(
+					frameClass,
+					rows > 1 ? 'py-1.5 text-(length:--text-12)' : sizeClass[size],
+				)}
 			>
 				{rows > 1 ? (
 					<textarea
@@ -188,7 +191,7 @@ export function EmptySlot({ children, className }: EmptySlotProps) {
 	return (
 		<div
 			className={cx(
-				'flex items-center justify-center rounded-md border border-dashed border-edge px-3 py-2.5 text-center text-[0.75rem] text-faint',
+				'flex items-center justify-center rounded-md border border-dashed border-edge px-3 py-2.5 text-center text-(length:--text-12) text-faint',
 				className,
 			)}
 		>

--- a/src/client/components/GuidanceNote.tsx
+++ b/src/client/components/GuidanceNote.tsx
@@ -44,8 +44,12 @@ export function GuidanceNote({
 			{anchor || confidence ? (
 				<p className="label-meta">{[anchor, confidence].filter(Boolean).join(' · ')}</p>
 			) : null}
-			<h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">{title}</h4>
-			{body ? <p className="text-[0.75rem] leading-relaxed text-muted">{body}</p> : null}
+			<h4 className="text-(length:--text-13) leading-snug font-semibold text-ink">
+				{title}
+			</h4>
+			{body ? (
+				<p className="text-(length:--text-12) leading-relaxed text-muted">{body}</p>
+			) : null}
 			{actions ? <div className="mt-0.5 flex flex-wrap gap-1.5">{actions}</div> : null}
 			{accepted ? (
 				<Chip variant="outline" className="self-start">
@@ -74,7 +78,7 @@ export function NoteDot({ count, className, onClick }: NoteDotProps) {
 			onClick={onClick}
 			aria-label={count ? `${count} notes waiting` : 'Notes waiting'}
 			className={cx(
-				'inline-flex items-center gap-1.5 rounded-full border border-accent-edge bg-accent px-2 py-1 text-[0.6875rem] leading-none font-medium text-accent-ink',
+				'inline-flex items-center gap-1.5 rounded-full border border-accent-edge bg-accent px-2 py-1 text-(length:--text-meta) leading-none font-medium text-accent-ink',
 				className,
 			)}
 		>

--- a/src/client/components/GuidanceNote.tsx
+++ b/src/client/components/GuidanceNote.tsx
@@ -44,12 +44,8 @@ export function GuidanceNote({
 			{anchor || confidence ? (
 				<p className="label-meta">{[anchor, confidence].filter(Boolean).join(' · ')}</p>
 			) : null}
-			<h4 className="text-(length:--text-13) leading-snug font-semibold text-ink">
-				{title}
-			</h4>
-			{body ? (
-				<p className="text-(length:--text-12) leading-relaxed text-muted">{body}</p>
-			) : null}
+			<h4 className="text-13 leading-snug font-semibold text-ink">{title}</h4>
+			{body ? <p className="text-12 leading-relaxed text-muted">{body}</p> : null}
 			{actions ? <div className="mt-0.5 flex flex-wrap gap-1.5">{actions}</div> : null}
 			{accepted ? (
 				<Chip variant="outline" className="self-start">
@@ -78,7 +74,7 @@ export function NoteDot({ count, className, onClick }: NoteDotProps) {
 			onClick={onClick}
 			aria-label={count ? `${count} notes waiting` : 'Notes waiting'}
 			className={cx(
-				'inline-flex items-center gap-1.5 rounded-full border border-accent-edge bg-accent px-2 py-1 text-(length:--text-meta) leading-none font-medium text-accent-ink',
+				'inline-flex items-center gap-1.5 rounded-full border border-accent-edge bg-accent px-2 py-1 text-11 leading-none font-medium text-accent-ink',
 				className,
 			)}
 		>

--- a/src/client/components/LengthBar.tsx
+++ b/src/client/components/LengthBar.tsx
@@ -57,7 +57,7 @@ export function LengthBar({
 					{segments.map((segment, i) => (
 						<span
 							key={i}
-							className="font-mono text-[0.6875rem] leading-none text-faint"
+							className="font-mono text-(length:--text-meta) leading-none text-faint"
 							style={{ flex: segment.words, display: 'flex', alignItems: 'center' }}
 						>
 							{segment.words.toLocaleString()}

--- a/src/client/components/LengthBar.tsx
+++ b/src/client/components/LengthBar.tsx
@@ -57,7 +57,7 @@ export function LengthBar({
 					{segments.map((segment, i) => (
 						<span
 							key={i}
-							className="font-mono text-(length:--text-meta) leading-none text-faint"
+							className="font-mono text-11 leading-none text-faint"
 							style={{ flex: segment.words, display: 'flex', alignItems: 'center' }}
 						>
 							{segment.words.toLocaleString()}

--- a/src/client/components/ListRow.tsx
+++ b/src/client/components/ListRow.tsx
@@ -27,9 +27,11 @@ export function ListRow({
 				className,
 			)}
 		>
-			<span className="min-w-0 truncate text-[0.8125rem] text-ink">{title}</span>
+			<span className="min-w-0 truncate text-(length:--text-13) text-ink">{title}</span>
 			{note ? (
-				<span className="min-w-0 truncate text-[0.75rem] text-faint">{note}</span>
+				<span className="min-w-0 truncate text-(length:--text-12) text-faint">
+					{note}
+				</span>
 			) : null}
 			<span className="ml-auto flex shrink-0 items-baseline gap-3">{trailing}</span>
 		</div>

--- a/src/client/components/ListRow.tsx
+++ b/src/client/components/ListRow.tsx
@@ -27,12 +27,8 @@ export function ListRow({
 				className,
 			)}
 		>
-			<span className="min-w-0 truncate text-(length:--text-13) text-ink">{title}</span>
-			{note ? (
-				<span className="min-w-0 truncate text-(length:--text-12) text-faint">
-					{note}
-				</span>
-			) : null}
+			<span className="min-w-0 truncate text-13 text-ink">{title}</span>
+			{note ? <span className="min-w-0 truncate text-12 text-faint">{note}</span> : null}
 			<span className="ml-auto flex shrink-0 items-baseline gap-3">{trailing}</span>
 		</div>
 	)

--- a/src/client/components/Loading.tsx
+++ b/src/client/components/Loading.tsx
@@ -11,7 +11,7 @@ export function Loading({ children, className }: LoadingProps) {
 	return (
 		<p
 			className={cx(
-				'flex flex-auto items-center justify-center gap-2 p-6 text-[0.75rem] text-faint',
+				'flex flex-auto items-center justify-center gap-2 p-6 text-(length:--text-12) text-faint',
 				className,
 			)}
 		>

--- a/src/client/components/Loading.tsx
+++ b/src/client/components/Loading.tsx
@@ -11,7 +11,7 @@ export function Loading({ children, className }: LoadingProps) {
 	return (
 		<p
 			className={cx(
-				'flex flex-auto items-center justify-center gap-2 p-6 text-(length:--text-12) text-faint',
+				'flex flex-auto items-center justify-center gap-2 p-6 text-12 text-faint',
 				className,
 			)}
 		>

--- a/src/client/components/Notice.tsx
+++ b/src/client/components/Notice.tsx
@@ -13,7 +13,7 @@ export function Notice({ children, className }: NoticeProps) {
 	return (
 		<p
 			className={cx(
-				'rounded-md border border-accent-edge bg-accent-soft p-2 text-[0.75rem] text-accent-ink',
+				'rounded-md border border-accent-edge bg-accent-soft p-2 text-(length:--text-12) text-accent-ink',
 				className,
 			)}
 		>

--- a/src/client/components/Notice.tsx
+++ b/src/client/components/Notice.tsx
@@ -13,7 +13,7 @@ export function Notice({ children, className }: NoticeProps) {
 	return (
 		<p
 			className={cx(
-				'rounded-md border border-accent-edge bg-accent-soft p-2 text-(length:--text-12) text-accent-ink',
+				'rounded-md border border-accent-edge bg-accent-soft p-2 text-12 text-accent-ink',
 				className,
 			)}
 		>

--- a/src/client/components/OutlineRow.tsx
+++ b/src/client/components/OutlineRow.tsx
@@ -31,23 +31,19 @@ export function OutlineRow({
 
 	return (
 		<div className={cx('flex items-start gap-2.5', className)}>
-			<span className="mt-px w-3 shrink-0 font-mono text-(length:--text-meta) text-faint">
-				{ordinal}
-			</span>
+			<span className="mt-px w-3 shrink-0 font-mono text-11 text-faint">{ordinal}</span>
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<div className="flex items-baseline gap-2">
 					<span
 						className={cx(
-							'min-w-0 flex-1 text-(length:--text-13) leading-snug',
+							'min-w-0 flex-1 text-13 leading-snug',
 							current ? 'font-medium text-ink' : 'text-ink',
 							dense && 'truncate',
 						)}
 					>
 						{node.title}
 					</span>
-					{current ? (
-						<span className="shrink-0 text-(length:--text-meta) text-faint">now</span>
-					) : null}
+					{current ? <span className="shrink-0 text-11 text-faint">now</span> : null}
 					{/* The count sits on the title line, where the eye can run down a
 					    column of them rather than hunting each row for it. */}
 					{target !== null ? (

--- a/src/client/components/OutlineRow.tsx
+++ b/src/client/components/OutlineRow.tsx
@@ -31,14 +31,14 @@ export function OutlineRow({
 
 	return (
 		<div className={cx('flex items-start gap-2.5', className)}>
-			<span className="mt-px w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
+			<span className="mt-px w-3 shrink-0 font-mono text-(length:--text-meta) text-faint">
 				{ordinal}
 			</span>
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				<div className="flex items-baseline gap-2">
 					<span
 						className={cx(
-							'min-w-0 flex-1 text-[0.8125rem] leading-snug',
+							'min-w-0 flex-1 text-(length:--text-13) leading-snug',
 							current ? 'font-medium text-ink' : 'text-ink',
 							dense && 'truncate',
 						)}
@@ -46,7 +46,7 @@ export function OutlineRow({
 						{node.title}
 					</span>
 					{current ? (
-						<span className="shrink-0 text-[0.6875rem] text-faint">now</span>
+						<span className="shrink-0 text-(length:--text-meta) text-faint">now</span>
 					) : null}
 					{/* The count sits on the title line, where the eye can run down a
 					    column of them rather than hunting each row for it. */}

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -66,8 +66,8 @@ export interface PanelHeaderProps {
 export function PanelHeader({ title, meta, actions, className }: PanelHeaderProps) {
 	return (
 		<div className={cx('flex items-baseline gap-2.5', className)}>
-			<h3 className="text-(length:--text-14) font-semibold text-ink">{title}</h3>
-			{meta ? <span className="text-(length:--text-12) text-faint">{meta}</span> : null}
+			<h3 className="text-14 font-semibold text-ink">{title}</h3>
+			{meta ? <span className="text-12 text-faint">{meta}</span> : null}
 			{actions ? <div className="ml-auto flex items-center gap-2">{actions}</div> : null}
 		</div>
 	)

--- a/src/client/components/Panel.tsx
+++ b/src/client/components/Panel.tsx
@@ -66,8 +66,8 @@ export interface PanelHeaderProps {
 export function PanelHeader({ title, meta, actions, className }: PanelHeaderProps) {
 	return (
 		<div className={cx('flex items-baseline gap-2.5', className)}>
-			<h3 className="text-[0.875rem] font-semibold text-ink">{title}</h3>
-			{meta ? <span className="text-[0.75rem] text-faint">{meta}</span> : null}
+			<h3 className="text-(length:--text-14) font-semibold text-ink">{title}</h3>
+			{meta ? <span className="text-(length:--text-12) text-faint">{meta}</span> : null}
 			{actions ? <div className="ml-auto flex items-center gap-2">{actions}</div> : null}
 		</div>
 	)

--- a/src/client/components/QuoteRow.tsx
+++ b/src/client/components/QuoteRow.tsx
@@ -44,11 +44,11 @@ export function QuoteRow({
 					used ? 'border-accent-edge' : 'border-rule',
 				)}
 			>
-				<p className="text-[0.8125rem] leading-relaxed text-ink">
+				<p className="text-(length:--text-13) leading-relaxed text-ink">
 					{referenceName(reference)}
 				</p>
 				{cite === '' && !showUsage ? null : (
-					<footer className="mt-1 flex items-center gap-2 text-[0.6875rem] text-faint">
+					<footer className="mt-1 flex items-center gap-2 text-(length:--text-meta) text-faint">
 						{cite === '' ? null : <cite className="not-italic">{cite}</cite>}
 						{showUsage ? (
 							<span className={used ? 'text-accent-ink' : undefined}>

--- a/src/client/components/QuoteRow.tsx
+++ b/src/client/components/QuoteRow.tsx
@@ -44,11 +44,9 @@ export function QuoteRow({
 					used ? 'border-accent-edge' : 'border-rule',
 				)}
 			>
-				<p className="text-(length:--text-13) leading-relaxed text-ink">
-					{referenceName(reference)}
-				</p>
+				<p className="text-13 leading-relaxed text-ink">{referenceName(reference)}</p>
 				{cite === '' && !showUsage ? null : (
-					<footer className="mt-1 flex items-center gap-2 text-(length:--text-meta) text-faint">
+					<footer className="mt-1 flex items-center gap-2 text-11 text-faint">
 						{cite === '' ? null : <cite className="not-italic">{cite}</cite>}
 						{showUsage ? (
 							<span className={used ? 'text-accent-ink' : undefined}>

--- a/src/client/components/Rail.tsx
+++ b/src/client/components/Rail.tsx
@@ -48,7 +48,7 @@ export function Rail<Item extends string>({
 								}
 							: {})}
 						className={cx(
-							'rounded-full px-2.5 py-1 text-[0.6875rem] leading-none font-medium transition-colors',
+							'rounded-full px-2.5 py-1 text-(length:--text-meta) leading-none font-medium transition-colors',
 							isOn ? 'bg-green text-green-ink' : 'text-faint',
 							onPick && !isOn && 'hover:bg-surface hover:text-muted',
 						)}

--- a/src/client/components/Rail.tsx
+++ b/src/client/components/Rail.tsx
@@ -48,7 +48,7 @@ export function Rail<Item extends string>({
 								}
 							: {})}
 						className={cx(
-							'rounded-full px-2.5 py-1 text-(length:--text-meta) leading-none font-medium transition-colors',
+							'rounded-full px-2.5 py-1 text-11 leading-none font-medium transition-colors',
 							isOn ? 'bg-green text-green-ink' : 'text-faint',
 							onPick && !isOn && 'hover:bg-surface hover:text-muted',
 						)}

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -78,7 +78,7 @@ export function ReferenceCard({
 
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				{headingText === undefined ? null : (
-					<h4 className="text-(length:--text-13) leading-snug font-semibold text-ink">
+					<h4 className="text-13 leading-snug font-semibold text-ink">
 						{headingLinks ? (
 							<SourceLink url={url}>{headingText}</SourceLink>
 						) : (
@@ -87,20 +87,18 @@ export function ReferenceCard({
 					</h4>
 				)}
 				{offer.text === undefined ? null : (
-					<blockquote className="border-l-2 border-rule pl-2.5 text-(length:--text-13) leading-relaxed text-ink">
+					<blockquote className="border-l-2 border-rule pl-2.5 text-13 leading-relaxed text-ink">
 						“{offer.text}”
 					</blockquote>
 				)}
 				<CitedLine className="break-all" parts={cited} />
 				{!compact && offer.note !== undefined ? (
-					<p className="text-(length:--text-12) leading-relaxed text-muted">
-						{offer.note}
-					</p>
+					<p className="text-12 leading-relaxed text-muted">{offer.note}</p>
 				) : null}
 				<div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 					{offer.type === 'quote' ? <Chip variant="outline">quote</Chip> : null}
 					{variant === 'ledger' && offer.disposition === 'undecided' ? (
-						<span className="text-(length:--text-meta) text-faint">undecided</span>
+						<span className="text-11 text-faint">undecided</span>
 					) : null}
 				</div>
 			</div>

--- a/src/client/components/ReferenceCard.tsx
+++ b/src/client/components/ReferenceCard.tsx
@@ -78,7 +78,7 @@ export function ReferenceCard({
 
 			<div className="flex min-w-0 flex-1 flex-col gap-1">
 				{headingText === undefined ? null : (
-					<h4 className="text-[0.8125rem] leading-snug font-semibold text-ink">
+					<h4 className="text-(length:--text-13) leading-snug font-semibold text-ink">
 						{headingLinks ? (
 							<SourceLink url={url}>{headingText}</SourceLink>
 						) : (
@@ -87,18 +87,20 @@ export function ReferenceCard({
 					</h4>
 				)}
 				{offer.text === undefined ? null : (
-					<blockquote className="border-l-2 border-rule pl-2.5 text-[0.8125rem] leading-relaxed text-ink">
+					<blockquote className="border-l-2 border-rule pl-2.5 text-(length:--text-13) leading-relaxed text-ink">
 						“{offer.text}”
 					</blockquote>
 				)}
 				<CitedLine className="break-all" parts={cited} />
 				{!compact && offer.note !== undefined ? (
-					<p className="text-[0.75rem] leading-relaxed text-muted">{offer.note}</p>
+					<p className="text-(length:--text-12) leading-relaxed text-muted">
+						{offer.note}
+					</p>
 				) : null}
 				<div className="mt-0.5 flex flex-wrap items-center gap-1.5">
 					{offer.type === 'quote' ? <Chip variant="outline">quote</Chip> : null}
 					{variant === 'ledger' && offer.disposition === 'undecided' ? (
-						<span className="text-[0.6875rem] text-faint">undecided</span>
+						<span className="text-(length:--text-meta) text-faint">undecided</span>
 					) : null}
 				</div>
 			</div>

--- a/src/client/components/TitleBar.tsx
+++ b/src/client/components/TitleBar.tsx
@@ -28,19 +28,15 @@ export function TitleBar({ back, title, subtitle, actions, className }: TitleBar
 			)}
 		>
 			{back}
-			<h2 className="truncate text-(length:--text-15) leading-tight font-medium text-ink">
-				{title}
-			</h2>
-			{subtitle ? (
-				<span className="truncate text-(length:--text-13) text-faint">{subtitle}</span>
-			) : null}
+			<h2 className="truncate text-15 leading-tight font-medium text-ink">{title}</h2>
+			{subtitle ? <span className="truncate text-13 text-faint">{subtitle}</span> : null}
 			<div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>
 		</header>
 	)
 }
 
 const backClass =
-	'-ml-1 flex shrink-0 items-center gap-1.5 rounded px-1 py-0.5 text-(length:--text-13) text-muted transition-colors hover:text-ink'
+	'-ml-1 flex shrink-0 items-center gap-1.5 rounded px-1 py-0.5 text-13 text-muted transition-colors hover:text-ink'
 
 function BackArrow({ children }: { children: ReactNode }) {
 	return (

--- a/src/client/components/TitleBar.tsx
+++ b/src/client/components/TitleBar.tsx
@@ -28,11 +28,11 @@ export function TitleBar({ back, title, subtitle, actions, className }: TitleBar
 			)}
 		>
 			{back}
-			<h2 className="truncate text-[0.9375rem] leading-tight font-medium text-ink">
+			<h2 className="truncate text-(length:--text-15) leading-tight font-medium text-ink">
 				{title}
 			</h2>
 			{subtitle ? (
-				<span className="truncate text-[0.8125rem] text-faint">{subtitle}</span>
+				<span className="truncate text-(length:--text-13) text-faint">{subtitle}</span>
 			) : null}
 			<div className="ml-auto flex shrink-0 items-center gap-2">{actions}</div>
 		</header>
@@ -40,7 +40,7 @@ export function TitleBar({ back, title, subtitle, actions, className }: TitleBar
 }
 
 const backClass =
-	'-ml-1 flex shrink-0 items-center gap-1.5 rounded px-1 py-0.5 text-[0.8125rem] text-muted transition-colors hover:text-ink'
+	'-ml-1 flex shrink-0 items-center gap-1.5 rounded px-1 py-0.5 text-(length:--text-13) text-muted transition-colors hover:text-ink'
 
 function BackArrow({ children }: { children: ReactNode }) {
 	return (

--- a/src/client/draft/ArticleDraftPanel.tsx
+++ b/src/client/draft/ArticleDraftPanel.tsx
@@ -25,7 +25,7 @@ export function ArticleDraftPanel({ divider, grow, className }: ArticleDraftPane
 			<Panel className={className} divider={divider} grow={grow}>
 				<PanelHeader title="Draft" />
 				{failure === null ? (
-					<p className="text-(length:--text-12) text-faint">Opening the Draft…</p>
+					<p className="text-12 text-faint">Opening the Draft…</p>
 				) : (
 					<Notice>{failure}</Notice>
 				)}

--- a/src/client/draft/ArticleDraftPanel.tsx
+++ b/src/client/draft/ArticleDraftPanel.tsx
@@ -25,7 +25,7 @@ export function ArticleDraftPanel({ divider, grow, className }: ArticleDraftPane
 			<Panel className={className} divider={divider} grow={grow}>
 				<PanelHeader title="Draft" />
 				{failure === null ? (
-					<p className="text-[0.75rem] text-faint">Opening the Draft…</p>
+					<p className="text-(length:--text-12) text-faint">Opening the Draft…</p>
 				) : (
 					<Notice>{failure}</Notice>
 				)}

--- a/src/client/draft/DraftPanel.tsx
+++ b/src/client/draft/DraftPanel.tsx
@@ -145,7 +145,7 @@ function Control({
 	return (
 		<button
 			aria-pressed={active}
-			className={`rounded-md border px-2 py-0.5 text-(length:--text-12) ${
+			className={`rounded-md border px-2 py-0.5 text-12 ${
 				active
 					? 'border-accent-edge bg-accent-soft text-accent-ink'
 					: 'border-edge text-muted'

--- a/src/client/draft/DraftPanel.tsx
+++ b/src/client/draft/DraftPanel.tsx
@@ -145,7 +145,7 @@ function Control({
 	return (
 		<button
 			aria-pressed={active}
-			className={`rounded-md border px-2 py-0.5 text-[0.75rem] ${
+			className={`rounded-md border px-2 py-0.5 text-(length:--text-12) ${
 				active
 					? 'border-accent-edge bg-accent-soft text-accent-ink'
 					: 'border-edge text-muted'

--- a/src/client/plan/AddSection.tsx
+++ b/src/client/plan/AddSection.tsx
@@ -65,7 +65,7 @@ export function AddSection({ outline, onAdd }: AddSectionProps) {
 			{outline.slice(0, -1).map((node, index) => (
 				<button
 					key={node.id}
-					className="w-full truncate rounded-md border border-edge bg-surface px-2.5 py-1.5 text-left text-(length:--text-12) text-ink hover:border-ink/40 hover:bg-hush"
+					className="w-full truncate rounded-md border border-edge bg-surface px-2.5 py-1.5 text-left text-12 text-ink hover:border-ink/40 hover:bg-hush"
 					onClick={() => add({ parentId: null, afterId: node.id })}
 					type="button"
 				>

--- a/src/client/plan/AddSection.tsx
+++ b/src/client/plan/AddSection.tsx
@@ -65,7 +65,7 @@ export function AddSection({ outline, onAdd }: AddSectionProps) {
 			{outline.slice(0, -1).map((node, index) => (
 				<button
 					key={node.id}
-					className="w-full truncate rounded-md border border-edge bg-surface px-2.5 py-1.5 text-left text-[0.75rem] text-ink hover:border-ink/40 hover:bg-hush"
+					className="w-full truncate rounded-md border border-edge bg-surface px-2.5 py-1.5 text-left text-(length:--text-12) text-ink hover:border-ink/40 hover:bg-hush"
 					onClick={() => add({ parentId: null, afterId: node.id })}
 					type="button"
 				>

--- a/src/client/plan/ArticlePlanPanel.tsx
+++ b/src/client/plan/ArticlePlanPanel.tsx
@@ -19,7 +19,7 @@ export function ArticlePlanPanel({ divider, grow, className }: ArticlePlanPanelP
 	if (plan === null) {
 		return (
 			<Panel className={className} divider={divider} grow={grow} variant="sunk">
-				<p className="text-(length:--text-12) text-faint">Opening the Plan…</p>
+				<p className="text-12 text-faint">Opening the Plan…</p>
 			</Panel>
 		)
 	}

--- a/src/client/plan/ArticlePlanPanel.tsx
+++ b/src/client/plan/ArticlePlanPanel.tsx
@@ -19,7 +19,7 @@ export function ArticlePlanPanel({ divider, grow, className }: ArticlePlanPanelP
 	if (plan === null) {
 		return (
 			<Panel className={className} divider={divider} grow={grow} variant="sunk">
-				<p className="text-[0.75rem] text-faint">Opening the Plan…</p>
+				<p className="text-(length:--text-12) text-faint">Opening the Plan…</p>
 			</Panel>
 		)
 	}

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -313,7 +313,7 @@ function Box({
 			onMouseLeave={onLeave}
 		>
 			{node.ordinal === '' ? null : (
-				<span className="mt-px shrink-0 font-mono text-(length:--text-meta) text-faint">
+				<span className="mt-px shrink-0 font-mono text-11 text-faint">
 					{node.ordinal}
 				</span>
 			)}
@@ -322,7 +322,7 @@ function Box({
 				{onOpen === undefined ? (
 					<span
 						className={cx(
-							'line-clamp-2 text-(length:--text-13) leading-snug',
+							'line-clamp-2 text-13 leading-snug',
 							subject.kind === 'article' && 'font-medium',
 							subject.kind === 'reference' ? 'text-muted' : 'text-ink',
 						)}
@@ -333,7 +333,7 @@ function Box({
 					<button
 						aria-expanded={open}
 						className={cx(
-							'line-clamp-2 text-left text-(length:--text-13) leading-snug',
+							'line-clamp-2 text-left text-13 leading-snug',
 							untitled ? 'text-faint italic' : 'text-ink',
 						)}
 						onClick={(event) => {
@@ -351,7 +351,7 @@ function Box({
 				) : null}
 
 				{target === undefined && intent === undefined ? null : (
-					<span className="flex min-w-0 items-baseline gap-1.5 text-(length:--text-meta) text-muted">
+					<span className="flex min-w-0 items-baseline gap-1.5 text-11 text-muted">
 						{target === undefined ? null : (
 							<span className="shrink-0 font-mono text-faint">{target}w</span>
 						)}
@@ -361,7 +361,7 @@ function Box({
 
 				{/* Only drawn where References are not boxes of their own. */}
 				{node.referenceNumbers.length === 0 ? null : (
-					<span className="truncate font-mono text-(length:--text-10) text-faint">
+					<span className="truncate font-mono text-10 text-faint">
 						{`refs ${node.referenceNumbers.map((number) => `[${number}]`).join(' ')}`}
 					</span>
 				)}
@@ -409,4 +409,4 @@ function Box({
 }
 
 const CONTROL =
-	'shrink-0 rounded-full border border-edge px-1 font-mono text-(length:--text-10) leading-[1.05rem] text-muted transition-colors hover:border-ink hover:text-ink'
+	'shrink-0 rounded-full border border-edge px-1 font-mono text-10 leading-[1.05rem] text-muted transition-colors hover:border-ink hover:text-ink'

--- a/src/client/plan/PlanMap.tsx
+++ b/src/client/plan/PlanMap.tsx
@@ -313,7 +313,7 @@ function Box({
 			onMouseLeave={onLeave}
 		>
 			{node.ordinal === '' ? null : (
-				<span className="mt-px shrink-0 font-mono text-[0.6875rem] text-faint">
+				<span className="mt-px shrink-0 font-mono text-(length:--text-meta) text-faint">
 					{node.ordinal}
 				</span>
 			)}
@@ -322,7 +322,7 @@ function Box({
 				{onOpen === undefined ? (
 					<span
 						className={cx(
-							'line-clamp-2 text-[0.8125rem] leading-snug',
+							'line-clamp-2 text-(length:--text-13) leading-snug',
 							subject.kind === 'article' && 'font-medium',
 							subject.kind === 'reference' ? 'text-muted' : 'text-ink',
 						)}
@@ -333,7 +333,7 @@ function Box({
 					<button
 						aria-expanded={open}
 						className={cx(
-							'line-clamp-2 text-left text-[0.8125rem] leading-snug',
+							'line-clamp-2 text-left text-(length:--text-13) leading-snug',
 							untitled ? 'text-faint italic' : 'text-ink',
 						)}
 						onClick={(event) => {
@@ -351,7 +351,7 @@ function Box({
 				) : null}
 
 				{target === undefined && intent === undefined ? null : (
-					<span className="flex min-w-0 items-baseline gap-1.5 text-[0.6875rem] text-muted">
+					<span className="flex min-w-0 items-baseline gap-1.5 text-(length:--text-meta) text-muted">
 						{target === undefined ? null : (
 							<span className="shrink-0 font-mono text-faint">{target}w</span>
 						)}
@@ -361,7 +361,7 @@ function Box({
 
 				{/* Only drawn where References are not boxes of their own. */}
 				{node.referenceNumbers.length === 0 ? null : (
-					<span className="truncate font-mono text-[0.625rem] text-faint">
+					<span className="truncate font-mono text-(length:--text-10) text-faint">
 						{`refs ${node.referenceNumbers.map((number) => `[${number}]`).join(' ')}`}
 					</span>
 				)}
@@ -409,4 +409,4 @@ function Box({
 }
 
 const CONTROL =
-	'shrink-0 rounded-full border border-edge px-1 font-mono text-[0.625rem] leading-[1.05rem] text-muted transition-colors hover:border-ink hover:text-ink'
+	'shrink-0 rounded-full border border-edge px-1 font-mono text-(length:--text-10) leading-[1.05rem] text-muted transition-colors hover:border-ink hover:text-ink'

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -153,7 +153,7 @@ function ReferenceRow({
 					{referenceMark(entry)}
 				</Chip>
 				{source?.title ? (
-					<p className="min-w-0 flex-1 text-[0.75rem] leading-snug font-medium text-ink">
+					<p className="min-w-0 flex-1 text-(length:--text-12) leading-snug font-medium text-ink">
 						{url === undefined ? (
 							source.title
 						) : (
@@ -169,19 +169,19 @@ function ReferenceRow({
 			</div>
 
 			{reference.text ? (
-				<blockquote className="border-l-2 border-rule pl-2.5 text-[0.8125rem] leading-relaxed text-ink">
+				<blockquote className="border-l-2 border-rule pl-2.5 text-(length:--text-13) leading-relaxed text-ink">
 					“{reference.text}”
 				</blockquote>
 			) : null}
 
 			<CitedLine className="break-all" parts={cited} />
 			{reference.note ? (
-				<p className="text-[0.75rem] text-muted">{reference.note}</p>
+				<p className="text-(length:--text-12) text-muted">{reference.note}</p>
 			) : null}
 
 			<select
 				aria-label={`Where ${referenceMark(entry)}, ${referenceName(reference)}, sits`}
-				className="h-7 rounded-md border border-edge bg-surface px-2 text-[0.75rem] text-ink"
+				className="h-7 rounded-md border border-edge bg-surface px-2 text-(length:--text-12) text-ink"
 				onChange={(event) =>
 					onPlace(event.target.value === '' ? null : event.target.value)
 				}

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -153,7 +153,7 @@ function ReferenceRow({
 					{referenceMark(entry)}
 				</Chip>
 				{source?.title ? (
-					<p className="min-w-0 flex-1 text-(length:--text-12) leading-snug font-medium text-ink">
+					<p className="min-w-0 flex-1 text-12 leading-snug font-medium text-ink">
 						{url === undefined ? (
 							source.title
 						) : (
@@ -169,19 +169,17 @@ function ReferenceRow({
 			</div>
 
 			{reference.text ? (
-				<blockquote className="border-l-2 border-rule pl-2.5 text-(length:--text-13) leading-relaxed text-ink">
+				<blockquote className="border-l-2 border-rule pl-2.5 text-13 leading-relaxed text-ink">
 					“{reference.text}”
 				</blockquote>
 			) : null}
 
 			<CitedLine className="break-all" parts={cited} />
-			{reference.note ? (
-				<p className="text-(length:--text-12) text-muted">{reference.note}</p>
-			) : null}
+			{reference.note ? <p className="text-12 text-muted">{reference.note}</p> : null}
 
 			<select
 				aria-label={`Where ${referenceMark(entry)}, ${referenceName(reference)}, sits`}
-				className="h-7 rounded-md border border-edge bg-surface px-2 text-(length:--text-12) text-ink"
+				className="h-7 rounded-md border border-edge bg-surface px-2 text-12 text-ink"
 				onChange={(event) =>
 					onPlace(event.target.value === '' ? null : event.target.value)
 				}

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -105,7 +105,7 @@ export function SectionRow({
 				{placedReferences.map((held) => (
 					<span
 						key={held.reference.id}
-						className="flex w-full items-baseline gap-1.5 text-[0.6875rem] text-muted"
+						className="flex w-full items-baseline gap-1.5 text-(length:--text-meta) text-muted"
 					>
 						<span className="label-meta shrink-0">{referenceMark(held)}</span>
 						{onShowReference === undefined ? (
@@ -153,7 +153,7 @@ export function SectionRow({
 				>
 					<OutlineRow node={node} ordinal={ordinal} />
 					{node.intent ? (
-						<p className="mt-1 truncate pl-[1.375rem] text-[0.75rem] text-muted">
+						<p className="mt-1 truncate pl-[1.375rem] text-(length:--text-12) text-muted">
 							{node.intent}
 						</p>
 					) : null}
@@ -186,7 +186,7 @@ export function SectionRow({
 			}}
 			style={{ marginLeft: depth * 20 }}
 		>
-			<span className="mt-1.5 w-3 shrink-0 font-mono text-[0.6875rem] text-faint">
+			<span className="mt-1.5 w-3 shrink-0 font-mono text-(length:--text-meta) text-faint">
 				{ordinal}
 			</span>
 
@@ -194,7 +194,7 @@ export function SectionRow({
 				<div className="flex items-center gap-2.5">
 					<InlineInput
 						ref={title}
-						className="min-w-0 flex-1 text-[0.8125rem] leading-snug font-medium"
+						className="min-w-0 flex-1 text-(length:--text-13) leading-snug font-medium"
 						label={`Title of ${scopeName}`}
 						onChange={(typed) => edit(setTitle(plan, node.id, typed))}
 						onKeyDown={doneOnEnter}
@@ -214,7 +214,7 @@ export function SectionRow({
 				{node.children.length > 0 ? (
 					<AllocationNote
 						allocation={allocation}
-						className="text-[0.6875rem] text-faint"
+						className="text-(length:--text-meta) text-faint"
 						parts="Subsections"
 					/>
 				) : null}
@@ -333,7 +333,7 @@ function SelectReferenceToPlace({
 		// Styled as `InlineInput` is, to match the Adjective field beside it.
 		<select
 			aria-label={`Place a Reference at ${scopeName}`}
-			className="w-24 appearance-none rounded-sm border-b border-transparent bg-transparent text-[0.6875rem] text-faint outline-none hover:border-edge focus:border-edge"
+			className="w-24 appearance-none rounded-sm border-b border-transparent bg-transparent text-(length:--text-meta) text-faint outline-none hover:border-edge focus:border-edge"
 			onChange={(event) => edit(placeReference(plan, event.target.value, nodeId))}
 			value=""
 		>

--- a/src/client/plan/SectionRow.tsx
+++ b/src/client/plan/SectionRow.tsx
@@ -105,7 +105,7 @@ export function SectionRow({
 				{placedReferences.map((held) => (
 					<span
 						key={held.reference.id}
-						className="flex w-full items-baseline gap-1.5 text-(length:--text-meta) text-muted"
+						className="flex w-full items-baseline gap-1.5 text-11 text-muted"
 					>
 						<span className="label-meta shrink-0">{referenceMark(held)}</span>
 						{onShowReference === undefined ? (
@@ -153,7 +153,7 @@ export function SectionRow({
 				>
 					<OutlineRow node={node} ordinal={ordinal} />
 					{node.intent ? (
-						<p className="mt-1 truncate pl-[1.375rem] text-(length:--text-12) text-muted">
+						<p className="mt-1 truncate pl-[1.375rem] text-12 text-muted">
 							{node.intent}
 						</p>
 					) : null}
@@ -186,15 +186,13 @@ export function SectionRow({
 			}}
 			style={{ marginLeft: depth * 20 }}
 		>
-			<span className="mt-1.5 w-3 shrink-0 font-mono text-(length:--text-meta) text-faint">
-				{ordinal}
-			</span>
+			<span className="mt-1.5 w-3 shrink-0 font-mono text-11 text-faint">{ordinal}</span>
 
 			<div className="flex min-w-0 flex-1 flex-col gap-2">
 				<div className="flex items-center gap-2.5">
 					<InlineInput
 						ref={title}
-						className="min-w-0 flex-1 text-(length:--text-13) leading-snug font-medium"
+						className="min-w-0 flex-1 text-13 leading-snug font-medium"
 						label={`Title of ${scopeName}`}
 						onChange={(typed) => edit(setTitle(plan, node.id, typed))}
 						onKeyDown={doneOnEnter}
@@ -214,7 +212,7 @@ export function SectionRow({
 				{node.children.length > 0 ? (
 					<AllocationNote
 						allocation={allocation}
-						className="text-(length:--text-meta) text-faint"
+						className="text-11 text-faint"
 						parts="Subsections"
 					/>
 				) : null}
@@ -333,7 +331,7 @@ function SelectReferenceToPlace({
 		// Styled as `InlineInput` is, to match the Adjective field beside it.
 		<select
 			aria-label={`Place a Reference at ${scopeName}`}
-			className="w-24 appearance-none rounded-sm border-b border-transparent bg-transparent text-(length:--text-meta) text-faint outline-none hover:border-edge focus:border-edge"
+			className="w-24 appearance-none rounded-sm border-b border-transparent bg-transparent text-11 text-faint outline-none hover:border-edge focus:border-edge"
 			onChange={(event) => edit(placeReference(plan, event.target.value, nodeId))}
 			value=""
 		>

--- a/src/client/plan/ToneFields.tsx
+++ b/src/client/plan/ToneFields.tsx
@@ -86,7 +86,7 @@ export function ToneFields({
 						</Chip>
 					))}
 					<InlineInput
-						className="w-24 text-(length:--text-meta)"
+						className="w-24 text-11"
 						label={`Add an Adjective to ${scopeName}`}
 						onChange={setAdding}
 						onKeyDown={(event) => {

--- a/src/client/plan/ToneFields.tsx
+++ b/src/client/plan/ToneFields.tsx
@@ -86,7 +86,7 @@ export function ToneFields({
 						</Chip>
 					))}
 					<InlineInput
-						className="w-24 text-[0.6875rem]"
+						className="w-24 text-(length:--text-meta)"
 						label={`Add an Adjective to ${scopeName}`}
 						onChange={setAdding}
 						onKeyDown={(event) => {

--- a/src/client/plan/WordCount.tsx
+++ b/src/client/plan/WordCount.tsx
@@ -47,7 +47,9 @@ export function TargetField({
 			onKeyDown={onKeyDown}
 			placeholder={placeholder}
 			size={size}
-			suffix={<span className="shrink-0 text-[0.6875rem] text-faint">words</span>}
+			suffix={
+				<span className="shrink-0 text-(length:--text-meta) text-faint">words</span>
+			}
 			value={target === null ? '' : String(target)}
 		/>
 	)

--- a/src/client/plan/WordCount.tsx
+++ b/src/client/plan/WordCount.tsx
@@ -47,9 +47,7 @@ export function TargetField({
 			onKeyDown={onKeyDown}
 			placeholder={placeholder}
 			size={size}
-			suffix={
-				<span className="shrink-0 text-(length:--text-meta) text-faint">words</span>
-			}
+			suffix={<span className="shrink-0 text-11 text-faint">words</span>}
 			value={target === null ? '' : String(target)}
 		/>
 	)

--- a/src/client/routes/a.$articleId.tsx
+++ b/src/client/routes/a.$articleId.tsx
@@ -102,7 +102,7 @@ function ArticleWindow({
 					<Notice>{failure}</Notice>
 				</div>
 			)}
-			<ArticlePanels agent={agent} open={panels.open} />
+			<ArticlePanels agent={agent} open={panels.open} scale={panels.scale} />
 		</Screen>
 	)
 }

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -159,7 +159,8 @@
 		font-family: var(--font-sans);
 		font-weight: 600;
 		line-height: 1.3;
-		letter-spacing: 1px;
+		/* ≈1px at the compact scale, and it grows with the type. */
+		letter-spacing: 0.045em;
 		/* Closer to what it opens than to what it closes, so a heading reads as
 		   the top of the passage under it. */
 		margin-bottom: 0.4em;

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -94,21 +94,14 @@
 	--spacing: 0.3125rem; /* × 1.25 */
 }
 
+/* 'narrow' is a window under `narrowQuery` (usePanels.ts): it shows one Panel
+   out of necessity, not room, so it keeps the compact scale. The threshold
+   itself lives only there — this file never measures the window. */
 :root[data-panels='3'],
-:root[data-panels='4'] {
+:root[data-panels='4'],
+:root[data-panels='narrow'] {
 	--type-scale: 100%; /* 16px */
 	--spacing: 0.25rem; /* the Tailwind default */
-}
-
-/* A narrow window shows one Panel out of necessity, not room, so it keeps the
-   compact scale. 56rem matches `narrowQuery` in usePanels.ts; in a media query
-   the rem is the browser default, so the html font-size cannot move it. */
-@media (max-width: 56rem) {
-	:root,
-	:root[data-panels] {
-		--type-scale: 100%;
-		--spacing: 0.25rem;
-	}
 }
 
 @layer base {

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -32,7 +32,8 @@
 	--color-edge: #c2bda9; /* card borders, inputs */
 	--color-strong: #2b2229; /* the one heavy divider per frame */
 
-	/* "You are here": a selected tab, filter or pressed button */
+	/* "You are here": a selected tab, filter or pressed button — and the
+	   headings in the Draft's prose, where it marks structure. */
 	--color-green: #4c6141;
 	--color-green-ink: #eef2e2; /* text sitting on green */
 
@@ -154,9 +155,10 @@
 		margin-top: 1.1em;
 	}
 
-	/* A heading is a different voice from the prose, not a louder one. Bold
-	   serif reads as a stressed sentence, so the sans face carries the headings
-	   instead: the reader sees the structure before they read the words. */
+	/* A heading is a different voice from the prose: the sans face and the
+	   green say "structure" before the reader reads the words, so a heading
+	   never scans as a stressed sentence. Size carries the rank — each level a
+	   visible tick over the one below, and the body below them both. */
 	.prose-draft :is(h1, h2, h3, h4) {
 		font-family: var(--font-sans);
 		font-weight: 600;
@@ -164,22 +166,18 @@
 		/* Closer to what it opens than to what it closes, so a heading reads as
 		   the top of the passage under it. */
 		margin-bottom: 0.4em;
-		color: var(--color-ink);
+		color: var(--color-green);
 	}
 
 	.prose-draft h2 {
 		margin-top: 1.75em;
-		font-size: 1.0625em;
+		font-size: 1.25em;
 		letter-spacing: -0.01em;
 	}
 
-	/* Smaller than the prose rather than larger, and spaced out: a subheading
-	   ranks under its heading, and the sans face still separates it from the
-	   sentences around it. */
 	.prose-draft h3 {
 		margin-top: 1.5em;
-		font-size: 0.9375em;
-		letter-spacing: 0.02em;
+		font-size: 1.125em;
 	}
 
 	/* A heading opening the Draft sits against the top of the surface, not a

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -69,46 +69,28 @@
 }
 
 /*
- * The type scale. One knob: the html rule below feeds it into the root
- * font-size, so every rem in the app — the type and the Tailwind spacing
- * utilities together — grows and shrinks in the same proportion.
- *
- * The Article screen stamps the number of open Panels on <html> (usePanels).
- * Fewer Panels leave more room, so the type grows: one Panel is generous, two
- * is a step down, three or four keep the compact scale. A page without the
- * Panel row — the Articles index — reads as two.
- *
- * `--spacing` is Tailwind's spacing unit, and it stacks a second step on top:
- * the rem bump already grows the margins in proportion to the type, and the
- * spacing bump grows them beyond it. At one Panel each spacing utility is
- * 1.25 × 1.25 ≈ 1.56 times its compact size, so the whitespace is the most
- * generous thing on the screen.
+ * The type ladder. Components never write a font-size in rem — they reference
+ * one of these steps (`text-(length:--text-13)`), named by their px height at
+ * the base scale. `.panel-scale` below redeclares every step multiplied by
+ * `--panel-scale`, so the same class renders larger inside a scaled Panel row
+ * and at the base size everywhere else. `--text-meta`, the sixth step, lives
+ * in @theme because `.label-meta` also reads it.
  */
 :root {
-	--type-scale: 112.5%; /* 18px */
-	--spacing: 0.28125rem; /* the 0.25rem default × 1.125 */
-}
-
-:root[data-panels='1'] {
-	--type-scale: 125%; /* 20px */
-	--spacing: 0.3125rem; /* × 1.25 */
-}
-
-/* 'narrow' is a window under `narrowQuery` (usePanels.ts): it shows one Panel
-   out of necessity, not room, so it keeps the compact scale. The threshold
-   itself lives only there — this file never measures the window. */
-:root[data-panels='3'],
-:root[data-panels='4'],
-:root[data-panels='narrow'] {
-	--type-scale: 100%; /* 16px */
-	--spacing: 0.25rem; /* the Tailwind default */
+	--text-10: 0.625rem;
+	--text-12: 0.75rem;
+	--text-13: 0.8125rem;
+	--text-14: 0.875rem;
+	--text-15: 0.9375rem;
 }
 
 @layer base {
 	html {
 		-webkit-font-smoothing: antialiased;
 		text-rendering: optimizeLegibility;
-		font-size: var(--type-scale);
+		/* The base bump: the whole app reads at 18px, chrome included. Room-
+		   dependent scaling is `.panel-scale`, not this. */
+		font-size: 112.5%;
 	}
 
 	body {
@@ -127,6 +109,26 @@
 }
 
 @layer components {
+	/* The Panel row. ArticlePanels sets `--panel-scale` on it from how many
+	   Panels are open: one Panel is generous (1.25), two a step down (1.125),
+	   three or four compact (1). Everything below re-evaluates against the
+	   inherited scale, so the row's type, type ladder, and spacing utilities
+	   all grow together — and nothing outside the row moves.
+
+	   The ladder steps repeat the :root values above on purpose: a custom
+	   property computes where it is declared, so only a declaration here, where
+	   `--panel-scale` is set, can pick the scale up. Keep the two lists equal. */
+	.panel-scale {
+		font-size: calc(1rem * var(--panel-scale, 1));
+		--spacing: calc(0.25rem * var(--panel-scale, 1));
+		--text-10: calc(0.625rem * var(--panel-scale, 1));
+		--text-12: calc(0.75rem * var(--panel-scale, 1));
+		--text-13: calc(0.8125rem * var(--panel-scale, 1));
+		--text-14: calc(0.875rem * var(--panel-scale, 1));
+		--text-15: calc(0.9375rem * var(--panel-scale, 1));
+		--text-meta: calc(0.6875rem * var(--panel-scale, 1));
+	}
+
 	/* The small mono label. Used often enough to earn a class, and it labels
      every field in the app as well as every list.
 
@@ -140,10 +142,11 @@
 		color: var(--color-faint);
 	}
 
-	/* Prose in the writing surface and the draft previews. */
+	/* Prose in the writing surface and the draft previews. Sized in em, so it
+	   follows the Panel row's base when the Draft has room. */
 	.prose-draft {
 		font-family: var(--font-serif);
-		font-size: 1rem;
+		font-size: 1em;
 		line-height: 1.75;
 		color: var(--color-ink);
 	}
@@ -167,7 +170,7 @@
 
 	.prose-draft h2 {
 		margin-top: 1.75em;
-		font-size: 1.0625rem;
+		font-size: 1.0625em;
 		letter-spacing: -0.01em;
 	}
 
@@ -176,7 +179,7 @@
 	   sentences around it. */
 	.prose-draft h3 {
 		margin-top: 1.5em;
-		font-size: 0.9375rem;
+		font-size: 0.9375em;
 		letter-spacing: 0.02em;
 	}
 

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -51,11 +51,9 @@
 		'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif;
 	--font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
-	/* The type ladder: every size the app sets, named by its px height at the
-	   base scale, used as plain utilities (`text-13`). Components never write a
-	   font-size in rem — `.panel-scale` redeclares each step multiplied by
-	   `--panel-scale`, so the same class renders larger inside a scaled Panel
-	   row and at the base size everywhere else. */
+	/* The type ladder, named by px height at the base scale (`text-13`).
+	   Never write a font-size in rem — use a step, so the text follows
+	   `.panel-scale` when a scaled container holds it. */
 	--text-10: 0.625rem;
 	--text-11: 0.6875rem;
 	--text-12: 0.75rem;
@@ -63,9 +61,9 @@
 	--text-14: 0.875rem;
 	--text-15: 0.9375rem;
 
-	/* Meta label: the small mono labels used all over the design. The size is
-	   the 11px step; the token stays separate because it also carries the
-	   label's line-height and tracking (`.label-meta`). */
+	/* Meta label: the small mono labels used all over the design. Separate
+	   from `--text-11` because it also carries the label's line-height and
+	   tracking (`.label-meta`). */
 	--text-meta: 0.6875rem;
 	--text-meta--line-height: 1.4;
 	--text-meta--letter-spacing: 0.02em;
@@ -87,8 +85,8 @@
 	html {
 		-webkit-font-smoothing: antialiased;
 		text-rendering: optimizeLegibility;
-		/* The base bump: the whole app reads at 18px, chrome included. Room-
-		   dependent scaling is `.panel-scale`, not this. */
+		/* 18px everywhere, chrome included. Panel-count scaling is
+		   `.panel-scale`, not this. */
 		font-size: 112.5%;
 	}
 
@@ -108,15 +106,13 @@
 }
 
 @layer components {
-	/* The Panel row. ArticlePanels sets `--panel-scale` on it from how many
-	   Panels are open: one Panel is generous (1.25), two a step down (1.125),
-	   three or four compact (1). Everything below re-evaluates against the
-	   inherited scale, so the row's type, type ladder, and spacing utilities
-	   all grow together — and nothing outside the row moves.
+	/* The Panel row. ArticlePanels sets `--panel-scale` on it (`panelScale`,
+	   usePanels.ts); the row's font-size, the type ladder, and Tailwind's
+	   `--spacing` all follow it, and nothing outside the row does.
 
-	   The ladder steps repeat the @theme values on purpose: a custom property
-	   computes where it is declared, so only a declaration here, where
-	   `--panel-scale` is set, can pick the scale up. Keep the two lists equal. */
+	   The steps repeat the @theme values on purpose: a custom property
+	   computes where it is declared, so only a redeclaration here can pick
+	   the scale up. Keep the two lists equal. */
 	.panel-scale {
 		font-size: calc(1rem * var(--panel-scale, 1));
 		--spacing: calc(0.25rem * var(--panel-scale, 1));

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -50,7 +50,21 @@
 		'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia, ui-serif, serif;
 	--font-mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
 
-	/* Meta label: the small mono labels used all over the design */
+	/* The type ladder: every size the app sets, named by its px height at the
+	   base scale, used as plain utilities (`text-13`). Components never write a
+	   font-size in rem — `.panel-scale` redeclares each step multiplied by
+	   `--panel-scale`, so the same class renders larger inside a scaled Panel
+	   row and at the base size everywhere else. */
+	--text-10: 0.625rem;
+	--text-11: 0.6875rem;
+	--text-12: 0.75rem;
+	--text-13: 0.8125rem;
+	--text-14: 0.875rem;
+	--text-15: 0.9375rem;
+
+	/* Meta label: the small mono labels used all over the design. The size is
+	   the 11px step; the token stays separate because it also carries the
+	   label's line-height and tracking (`.label-meta`). */
 	--text-meta: 0.6875rem;
 	--text-meta--line-height: 1.4;
 	--text-meta--letter-spacing: 0.02em;
@@ -66,22 +80,6 @@
 	--shadow-frame: 0 1px 2px rgb(43 34 41 / 0.05), 0 8px 24px -16px rgb(43 34 41 / 0.25);
 	--shadow-drawer:
 		0 -1px 2px rgb(43 34 41 / 0.05), 0 -8px 24px -16px rgb(43 34 41 / 0.25);
-}
-
-/*
- * The type ladder. Components never write a font-size in rem — they reference
- * one of these steps (`text-(length:--text-13)`), named by their px height at
- * the base scale. `.panel-scale` below redeclares every step multiplied by
- * `--panel-scale`, so the same class renders larger inside a scaled Panel row
- * and at the base size everywhere else. `--text-meta`, the sixth step, lives
- * in @theme because `.label-meta` also reads it.
- */
-:root {
-	--text-10: 0.625rem;
-	--text-12: 0.75rem;
-	--text-13: 0.8125rem;
-	--text-14: 0.875rem;
-	--text-15: 0.9375rem;
 }
 
 @layer base {
@@ -115,13 +113,14 @@
 	   inherited scale, so the row's type, type ladder, and spacing utilities
 	   all grow together — and nothing outside the row moves.
 
-	   The ladder steps repeat the :root values above on purpose: a custom
-	   property computes where it is declared, so only a declaration here, where
+	   The ladder steps repeat the @theme values on purpose: a custom property
+	   computes where it is declared, so only a declaration here, where
 	   `--panel-scale` is set, can pick the scale up. Keep the two lists equal. */
 	.panel-scale {
 		font-size: calc(1rem * var(--panel-scale, 1));
 		--spacing: calc(0.25rem * var(--panel-scale, 1));
 		--text-10: calc(0.625rem * var(--panel-scale, 1));
+		--text-11: calc(0.6875rem * var(--panel-scale, 1));
 		--text-12: calc(0.75rem * var(--panel-scale, 1));
 		--text-13: calc(0.8125rem * var(--panel-scale, 1));
 		--text-14: calc(0.875rem * var(--panel-scale, 1));

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -159,6 +159,7 @@
 		font-family: var(--font-sans);
 		font-weight: 600;
 		line-height: 1.3;
+		letter-spacing: 1px;
 		/* Closer to what it opens than to what it closes, so a heading reads as
 		   the top of the passage under it. */
 		margin-bottom: 0.4em;
@@ -168,7 +169,6 @@
 	.prose-draft h2 {
 		margin-top: 1.75em;
 		font-size: 1.25em;
-		letter-spacing: -0.01em;
 	}
 
 	.prose-draft h3 {

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -68,10 +68,44 @@
 		0 -1px 2px rgb(43 34 41 / 0.05), 0 -8px 24px -16px rgb(43 34 41 / 0.25);
 }
 
+/*
+ * The type scale. One knob: the html rule below feeds it into the root
+ * font-size, so every rem in the app — the type and the Tailwind spacing
+ * utilities together — grows and shrinks in the same proportion.
+ *
+ * The Article screen stamps the number of open Panels on <html> (usePanels).
+ * Fewer Panels leave more room, so the type grows: one Panel is generous, two
+ * is a step down, three or four keep the compact scale. A page without the
+ * Panel row — the Articles index — reads as two.
+ */
+:root {
+	--type-scale: 112.5%; /* 18px */
+}
+
+:root[data-panels='1'] {
+	--type-scale: 125%; /* 20px */
+}
+
+:root[data-panels='3'],
+:root[data-panels='4'] {
+	--type-scale: 100%; /* 16px */
+}
+
+/* A narrow window shows one Panel out of necessity, not room, so it keeps the
+   compact scale. 56rem matches `narrowQuery` in usePanels.ts; in a media query
+   the rem is the browser default, so the html font-size cannot move it. */
+@media (max-width: 56rem) {
+	:root,
+	:root[data-panels] {
+		--type-scale: 100%;
+	}
+}
+
 @layer base {
 	html {
 		-webkit-font-smoothing: antialiased;
 		text-rendering: optimizeLegibility;
+		font-size: var(--type-scale);
 	}
 
 	body {

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -77,18 +77,27 @@
  * Fewer Panels leave more room, so the type grows: one Panel is generous, two
  * is a step down, three or four keep the compact scale. A page without the
  * Panel row — the Articles index — reads as two.
+ *
+ * `--spacing` is Tailwind's spacing unit, and it stacks a second step on top:
+ * the rem bump already grows the margins in proportion to the type, and the
+ * spacing bump grows them beyond it. At one Panel each spacing utility is
+ * 1.25 × 1.25 ≈ 1.56 times its compact size, so the whitespace is the most
+ * generous thing on the screen.
  */
 :root {
 	--type-scale: 112.5%; /* 18px */
+	--spacing: 0.28125rem; /* the 0.25rem default × 1.125 */
 }
 
 :root[data-panels='1'] {
 	--type-scale: 125%; /* 20px */
+	--spacing: 0.3125rem; /* × 1.25 */
 }
 
 :root[data-panels='3'],
 :root[data-panels='4'] {
 	--type-scale: 100%; /* 16px */
+	--spacing: 0.25rem; /* the Tailwind default */
 }
 
 /* A narrow window shows one Panel out of necessity, not room, so it keeps the
@@ -98,6 +107,7 @@
 	:root,
 	:root[data-panels] {
 		--type-scale: 100%;
+		--spacing: 0.25rem;
 	}
 }
 


### PR DESCRIPTION
The base font-size rises to 18px app-wide. On top of that, the Panel row scales its type and spacing by how many Panels are open — 1.25× for one, 1.125× for two, 1× for three, four, or a narrow window — and nothing outside the row moves.

The mechanism: font sizes become a token ladder (`text-10`…`text-15`, plus the existing `--text-meta`), and the `.panel-scale` class redeclares the steps and Tailwind's `--spacing` against `--panel-scale`, which `ArticlePanels` sets from the open count.

Also in here:

- The Panel rail collapses at the md breakpoint (768px) instead of a bespoke 896px.
- The Draft's headings rank by size (1.25em / 1.125em over the body) and take `--color-green`, so they read as structure rather than bolded text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185rvbTqHzsNP5uVpZ5nMNn

---
_Generated by [Claude Code](https://claude.ai/code/session_0185rvbTqHzsNP5uVpZ5nMNn)_