### PR TITLE
Rename the project to Scribble Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scribble
+# Scribble Harness
 
 An AI harness so you can have your own Clippy so good that even you want to use it 🖇️
 
@@ -80,9 +80,10 @@ pnpm db:migrate:remote
 ```
 
 A different account needs a database of its own: `pnpm wrangler d1 create scribble` prints
-a name and an id to paste into `database_name` and `database_id`. The deployed database is
-still named `journo-harness`, because D1 does not rename one — `pnpm db:migrate` names the
-`DB` binding rather than the database, so the two stay independent.
+a name and an id to paste into `database_name` and `database_id`. The id is what binds and
+the name beside it is a label, so the two can disagree —
+[`docs/deploy.md`](./docs/deploy.md) has the case where they do, and the swap that settles
+it.
 
 ```sh
 pnpm deploy     # builds the client, then wrangler deploy
@@ -110,6 +111,10 @@ The Worker is deployed as `scribble` and serves `scribble.msnook.xyz`, which
 `wrangler.jsonc` binds as a custom domain on every deploy. Deploying to a different account
 needs that `routes` entry changed to a hostname on a zone that account holds, or removed so
 the Worker answers on `workers.dev` alone.
+
+Declaring that route takes the `workers.dev` route away, so `wrangler.jsonc` turns
+`preview_urls` back on by hand — `wrangler versions upload` then puts a version on a URL of
+its own without making it production.
 
 The Worker needs the Workers Paid plan for the model, and Cloudflare Access gates it at the
 edge. Nothing in the app reads the `Cf-Access-Jwt-Assertion` header — localhost has no

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Journo Harness
+# Scribble
 
 An AI harness so you can have your own Clippy so good that even you want to use it 🖇️
 
@@ -79,8 +79,10 @@ to it whenever a file lands in `migrations/`:
 pnpm db:migrate:remote
 ```
 
-A different account needs a database of its own: `pnpm wrangler d1 create journo-harness`
-prints an id to paste into `database_id`.
+A different account needs a database of its own: `pnpm wrangler d1 create scribble` prints
+a name and an id to paste into `database_name` and `database_id`. The deployed database is
+still named `journo-harness`, because D1 does not rename one — `pnpm db:migrate` names the
+`DB` binding rather than the database, so the two stay independent.
 
 ```sh
 pnpm deploy     # builds the client, then wrangler deploy
@@ -103,6 +105,11 @@ The search key goes the same way, as a secret rather than a var:
 ```sh
 pnpm wrangler secret put EXA_API_KEY
 ```
+
+The Worker is deployed as `scribble` and serves `scribble.msnook.xyz`, which
+`wrangler.jsonc` binds as a custom domain on every deploy. Deploying to a different account
+needs that `routes` entry changed to a hostname on a zone that account holds, or removed so
+the Worker answers on `workers.dev` alone.
 
 The Worker needs the Workers Paid plan for the model, and Cloudflare Access gates it at the
 edge. Nothing in the app reads the `Cf-Access-Jwt-Assertion` header — localhost has no

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,4 +1,4 @@
-# Scribble
+# Scribble Harness
 
 A writing harness where the writer writes the prose and an AI acts as a guide. What is
 true now is [docs/architecture.md](./architecture.md), and what is deferred is

--- a/docs/context.md
+++ b/docs/context.md
@@ -1,4 +1,4 @@
-# Journo Harness
+# Scribble
 
 A writing harness where the writer writes the prose and an AI acts as a guide. What is
 true now is [docs/architecture.md](./architecture.md), and what is deferred is

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -32,6 +32,30 @@ about leaving the Gateway unauthenticated is unaffected.
 **No key means no search tool**, and the guide is told to answer from memory
 instead — `src/server/llm/search.ts`.
 
+## The database name
+
+**D1 does not rename a database.** `database_name` in `wrangler.jsonc` reads
+`scribble`, and the database the deploy binds was created under the project's
+previous name, so `wrangler d1 list` shows a name the config does not.
+
+**Nothing breaks while the two disagree.** `database_id` is what wrangler
+resolves, and `pnpm db:migrate` names the `DB` binding rather than either one, so
+the label is cosmetic.
+
+**Settling it takes a new database and a copy**, because there is nothing else to
+rename with. The export names the database by the id in `database_id` rather than
+by a name, because the deployed one does not answer to the name beside it:
+
+```sh
+pnpm wrangler d1 export <the database_id in wrangler.jsonc> --remote --output=index.sql
+pnpm wrangler d1 create scribble
+pnpm wrangler d1 execute scribble --remote --file=index.sql
+```
+
+Then paste the id `d1 create` prints into `database_id`, and the config and the
+account agree. The export is one point in time, so run it while nothing is
+writing, and keep the old database until the new one has served.
+
 ## The local database
 
 `pnpm db:migrate` puts the article index's schema into the local D1;

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Journo Harness</title>
+		<title>Scribble</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Scribble</title>
+		<title>Scribble Harness</title>
 	</head>
 	<body>
 		<div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "journo-harness",
+  "name": "scribble-harness",
   "version": "0.1.0",
   "private": true,
   "description": "A writing harness where the writer writes the prose and an AI acts as a guide.",
@@ -11,8 +11,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "deploy": "vite build && wrangler deploy",
-    "db:migrate": "wrangler d1 migrations apply journo-harness --local",
-    "db:migrate:remote": "wrangler d1 migrations apply journo-harness --remote",
+    "db:migrate": "wrangler d1 migrations apply DB --local",
+    "db:migrate:remote": "wrangler d1 migrations apply DB --remote",
     "test": "vite build && vitest run",
     "test:shared": "vitest run --project shared",
     "test:client": "vitest run --project client",

--- a/src/client/notes/skills.ts
+++ b/src/client/notes/skills.ts
@@ -13,7 +13,7 @@ export type Skill = {
 	prompt: string
 }
 
-const KEY = 'journo.review-skills'
+const KEY = 'scribble.review-skills'
 
 /** Storage throws in a few real places — a locked-down browser, a sandboxed
  * frame — and none of them is worth losing the Panel over. A Skill is a

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -6,9 +6,6 @@
   // The Agents SDK needs the Node.js compatibility layer.
   "compatibility_flags": ["nodejs_compat"],
 
-  // The deployed hostname. custom_domain binds the record and the certificate on
-  // deploy, so the DNS record for it is managed by this file rather than by hand
-  // — msnook.xyz has to be a zone on the deploying account.
   "routes": [
     {
       "pattern": "scribble.msnook.xyz",
@@ -16,11 +13,8 @@
     },
   ],
 
-  // Declaring a route turns workers_dev off, and preview_urls follows
-  // workers_dev unless it is set — so leaving this out takes the per-version
-  // preview URL away with the workers.dev route. Set it back on: the route
-  // above is what production answers on, and a version still needs somewhere to
-  // be looked at before it becomes production.
+  // Deleting this takes the preview URLs with it: a route turns workers_dev off,
+  // and preview_urls follows workers_dev.
   "preview_urls": true,
 
   // Static assets with single-page-application fallback, so a deep link like
@@ -52,14 +46,8 @@
 
   // The article index — architecture.md §9. Its schema lives in ./migrations;
   // `pnpm db:migrate` applies it locally and `db:migrate:remote` to the deploy.
-  // A different account needs its own `wrangler d1 create scribble`, and puts the
-  // name and the id it prints into the two fields below.
-  //
-  // database_id is what wrangler resolves and what the local database is stored
-  // under; database_name is a label beside it. D1 does not rename a database, so
-  // the deployed one still carries the name it was created under and
-  // `wrangler d1 list` disagrees with the line below — deploy.md §The database
-  // name has the swap that settles it.
+  // database_id binds and database_name is a label, so the two can disagree —
+  // deploy.md §The database name.
   "d1_databases": [
     {
       "binding": "DB",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,10 +1,20 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
-  "name": "journo-harness",
+  "name": "scribble",
   "main": "./src/server/index.ts",
   "compatibility_date": "2026-08-06",
   // The Agents SDK needs the Node.js compatibility layer.
   "compatibility_flags": ["nodejs_compat"],
+
+  // The deployed hostname. custom_domain binds the record and the certificate on
+  // deploy, so the DNS record for it is managed by this file rather than by hand
+  // — msnook.xyz has to be a zone on the deploying account.
+  "routes": [
+    {
+      "pattern": "scribble.msnook.xyz",
+      "custom_domain": true,
+    },
+  ],
 
   // Static assets with single-page-application fallback, so a deep link like
   // /a/:id returns index.html. Worker paths need run_worker_first, or the
@@ -35,7 +45,13 @@
 
   // The article index — architecture.md §9. Its schema lives in ./migrations;
   // `pnpm db:migrate` applies it locally and `db:migrate:remote` to the deploy.
-  // A different account needs its own `wrangler d1 create journo-harness`.
+  // A different account needs its own `wrangler d1 create scribble`, and puts the
+  // name and the id it prints into the two fields below.
+  //
+  // database_name still reads journo-harness because D1 does not rename a
+  // database — the deployed one keeps the name it was created under. The
+  // binding is what the Worker and `pnpm db:migrate` use, so the stale name is
+  // cosmetic and costs nothing to leave standing.
   "d1_databases": [
     {
       "binding": "DB",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -16,6 +16,13 @@
     },
   ],
 
+  // Declaring a route turns workers_dev off, and preview_urls follows
+  // workers_dev unless it is set — so leaving this out takes the per-version
+  // preview URL away with the workers.dev route. Set it back on: the route
+  // above is what production answers on, and a version still needs somewhere to
+  // be looked at before it becomes production.
+  "preview_urls": true,
+
   // Static assets with single-page-application fallback, so a deep link like
   // /a/:id returns index.html. Worker paths need run_worker_first, or the
   // fallback swallows them before the Worker runs.
@@ -48,14 +55,15 @@
   // A different account needs its own `wrangler d1 create scribble`, and puts the
   // name and the id it prints into the two fields below.
   //
-  // database_name still reads journo-harness because D1 does not rename a
-  // database — the deployed one keeps the name it was created under. The
-  // binding is what the Worker and `pnpm db:migrate` use, so the stale name is
-  // cosmetic and costs nothing to leave standing.
+  // database_id is what wrangler resolves and what the local database is stored
+  // under; database_name is a label beside it. D1 does not rename a database, so
+  // the deployed one still carries the name it was created under and
+  // `wrangler d1 list` disagrees with the line below — deploy.md §The database
+  // name has the swap that settles it.
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "journo-harness",
+      "database_name": "scribble",
       "database_id": "3372f1ea-f9ae-4c52-b918-d1599d5af8f8",
       "migrations_dir": "./migrations",
     },


### PR DESCRIPTION
The app is Scribble Harness, the package and the repo are `scribble-harness`, and the Worker deploys as `scribble` on `scribble.msnook.xyz`. The old name is out of every tracked file.

## What changed

| File | Change |
| --- | --- |
| `package.json` | `name` → `scribble-harness`; both migrate scripts name the `DB` binding |
| `wrangler.jsonc` | Worker `name` → `scribble`; added the custom-domain route and `preview_urls` |
| `index.html`, `README.md`, `docs/context.md` | The app is Scribble Harness |
| `src/client/notes/skills.ts` | The saved Skills move to `scribble.review-skills` |
| `docs/deploy.md` | New §The database name |

## Three decisions worth reviewing

**The migrate scripts name the `DB` binding rather than the database.** D1 does not rename a database, so the deployed one keeps the name it was created under. `database_id` is what wrangler resolves and `database_name` is a label beside it, which means the config and `wrangler d1 list` disagree until the export-and-recreate in `docs/deploy.md` runs. Naming the binding keeps the scripts working either way.

**`preview_urls` is set explicitly.** Declaring the custom-domain route turns `workers_dev` off, and `preview_urls` has followed `workers_dev` since wrangler 4.44 — so the route alone would have taken the per-version preview URL with it.

**The saved Skills do not migrate.** A Skill saved under the old localStorage key is not read.

## What this does not carry across

Renaming the Worker script creates a new Worker on the next deploy. The `ArticleAgent` Durable Objects stay with the old script, so the chat, plan, and draft of every deployed Article do not come across. Copying the D1 brings the article index but not that state, which would list Articles that open empty.

## Checks

444/444 tests pass across `shared`, `client`, and `worker`. `wrangler deploy --dry-run` parses the new keys and resolves the bindings. Typecheck and format are clean.

https://claude.ai/code/session_01T4oEVhrKsYfaNRxUsV7AAL