### PR TITLE
Make Draft editor clickable across entire panel

### DIFF
--- a/.storybook/panels/Draft.stories.tsx
+++ b/.storybook/panels/Draft.stories.tsx
@@ -173,3 +173,41 @@ export const UndoKeepsIds: Story = {
 		await waitFor(() => expect(blockIds(canvasElement)).toEqual(before))
 	},
 }
+
+export const ClickAnywhere: Story = {
+	name: 'Clicking anywhere on an empty Draft',
+	render: () => <DraftScreen store={memoryDraftStore()} />,
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+		await waitFor(() => expect(surface(canvasElement)).toBeInTheDocument())
+		const editable = surface(canvasElement)
+
+		// A drafting surface takes the caret wherever the writer clicks in it, so
+		// the whole Panel below the toolbar has to be the editable — the gutter
+		// beside the first line and the empty space far under it included.
+		const box = editable.getBoundingClientRect()
+		const corners = [
+			[box.left + 4, box.top + 4],
+			[box.right - 4, box.top + 4],
+			[box.left + 4, box.bottom - 4],
+			[box.right - 4, box.bottom - 4],
+		] as const
+
+		for (const [x, y] of corners) {
+			await expect(editable.contains(document.elementFromPoint(x, y))).toBe(true)
+		}
+
+		// And the editable reaches the foot of the Panel it sits in.
+		const panel = canvasElement.querySelector('[data-panel]') as HTMLElement
+		await expect(box.bottom).toBeCloseTo(panel.getBoundingClientRect().bottom, 0)
+
+		// Clicking that far-down space writes into the Draft.
+		await userEvent.pointer({
+			target: editable,
+			coords: { clientX: box.left + 8, clientY: box.bottom - 8 },
+			keys: '[MouseLeft]',
+		})
+		await userEvent.keyboard('Clicked low, typed anyway.')
+		await expect(canvas.getByText('Clicked low, typed anyway.')).toBeVisible()
+	},
+}

--- a/src/client/draft/DraftPanel.tsx
+++ b/src/client/draft/DraftPanel.tsx
@@ -63,10 +63,17 @@ export function DraftPanel({
 			</div>
 
 			{/* Heading, subheading, and section-break styling is `.prose-draft` in
-			    theme.css, so a Draft preview is set the same way as the editor. */}
-			<div className="prose-draft min-w-0 flex-auto px-8 py-4 [&_.ProseMirror]:min-h-full [&_.ProseMirror]:outline-none">
-				<EditorContent editor={editor} />
-			</div>
+			    theme.css, so a Draft preview is set the same way as the editor.
+
+			    The measure is padding on `.ProseMirror` rather than on anything
+			    around it, and the editable grows to the foot of the Panel: every
+			    point below the toolbar is then inside the editable, so a click in
+			    the gutter or in the space under the last line puts the caret in
+			    the prose instead of landing on a dead wrapper. */}
+			<EditorContent
+				className="prose-draft flex min-w-0 flex-auto flex-col [&_.ProseMirror]:flex-auto [&_.ProseMirror]:px-8 [&_.ProseMirror]:py-4 [&_.ProseMirror]:outline-none"
+				editor={editor}
+			/>
 		</Panel>
 	)
 }


### PR DESCRIPTION
The Draft editor's editable surface now extends to fill the entire panel below the toolbar, allowing users to click anywhere in that space to position the caret and begin typing.

**Changes made:**

- Restructured the DraftPanel layout to make the ProseMirror editor flex to fill available vertical space, rather than wrapping it in a fixed-height container
- Moved padding from the wrapper div onto the `.ProseMirror` element itself to maintain the intended measure while allowing the editable to expand
- Updated the EditorContent component to use flexbox layout, ensuring the editor grows to the panel's bottom edge

**Implementation details:**

Previously, clicks in the gutter beside the first line or in empty space below the last line would land outside the editable area. Now the entire panel below the toolbar is part of the editable surface, matching user expectations for a drafting interface where any click should position the caret.

The measure (horizontal padding) is preserved by applying `px-8 py-4` directly to `.ProseMirror` rather than to a wrapper, while the flex layout ensures the editor expands vertically to fill the panel.

https://claude.ai/code/session_01Q84Q64NK2a4KFQBoGYXs29