### PR TITLE
Clear the React Compiler bail-outs, so the interactive Panels are memoised too

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -9,12 +9,7 @@
     // cannot prove pure, without saying so. This is what says so: it reports the
     // Rules of React violations that cause a skip, so a component dropping out
     // of memoisation shows up here rather than as a slow Panel.
-    //
-    // A warning rather than an error, because five modules trip it today —
-    // useDraft, usePlan, useArticleAgent, usePanels, and the scroll hook in
-    // ChatPanel. Rewriting them is its own change; once they are clean this
-    // becomes an error.
-    "react/react-compiler": "warn"
+    "react/react-compiler": "error"
   },
   "env": {
     "builtin": true,

--- a/.storybook/mock/MockArticle.tsx
+++ b/.storybook/mock/MockArticle.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo, useState } from 'react'
+import { type ReactNode, useState } from 'react'
 
 import {
 	ArticleProvider,
@@ -38,7 +38,7 @@ export function MockArticle({ children }: { children: ReactNode }) {
 	const [refusal, setRefusal] = useState<Refusal | null>(null)
 
 	// `send` goes nowhere, so the debounce is the only part that idles.
-	const writer = useMemo(() => {
+	const [writer] = useState(() => {
 		const held = createPlanWriter({
 			send: () => {},
 			onPlan: setPlan,
@@ -47,13 +47,15 @@ export function MockArticle({ children }: { children: ReactNode }) {
 		held.receive(seededPlan)
 
 		return held
-	}, [])
+	})
 
-	// One store per story, since `useOfferLedger` reads rows once per store and
-	// `useDraft` loads once per store.
-	const offers = useMemo(() => memoryOfferStore(seeded), [])
-	const draft = useMemo(() => memoryDraftStore(), [])
-	const notes = useMemo(() => memoryNoteStore(), [])
+	// One store per story, since `useOfferLedger` reads rows once per store,
+	// `useDraft` loads once per store, and `useNotes` reads once per store.
+	// Lazy `useState` and not `useMemo`, for the reason `useArticleAgent` gives:
+	// the identity is the contract, and `useMemo` does not promise one.
+	const [offers] = useState(() => memoryOfferStore(seeded))
+	const [draft] = useState(() => memoryDraftStore())
+	const [notes] = useState(() => memoryNoteStore())
 
 	const edit = (next: Parameters<typeof writer.edit>[0]) => {
 		setRefusal(null)

--- a/.storybook/mock/MockArticle.tsx
+++ b/.storybook/mock/MockArticle.tsx
@@ -49,10 +49,8 @@ export function MockArticle({ children }: { children: ReactNode }) {
 		return held
 	})
 
-	// One store per story, since `useOfferLedger` reads rows once per store,
-	// `useDraft` loads once per store, and `useNotes` reads once per store.
-	// Lazy `useState` and not `useMemo`, for the reason `useArticleAgent` gives:
-	// the identity is the contract, and `useMemo` does not promise one.
+	// One store per story, for the reason `useArticleAgent` gives: the three
+	// readers each load once per store identity.
 	const [offers] = useState(() => memoryOfferStore(seeded))
 	const [draft] = useState(() => memoryDraftStore())
 	const [notes] = useState(() => memoryNoteStore())

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@babel/core": "^8.0.1",
-    "@babel/plugin-transform-runtime": "^8.0.1",
-    "@babel/runtime": "^8.0.0",
+    "@babel/core": "^7.29.7",
+    "@babel/plugin-transform-runtime": "^7.29.7",
+    "@babel/runtime": "^7.29.7",
     "@cloudflare/vite-plugin": "^1.51.0",
     "@cloudflare/vitest-pool-workers": "^0.20.2",
     "@rolldown/plugin-babel": "^0.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,13 +4,16 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@babel/plugin-proposal-decorators': ^7.29.7
+
 importers:
 
   .:
     dependencies:
       '@cloudflare/ai-chat':
         specifier: ^0.10.1
-        version: 0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)
+        version: 0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)
       '@fontsource-variable/atkinson-hyperlegible-next':
         specifier: ^5.3.0
         version: 5.3.0
@@ -37,7 +40,7 @@ importers:
         version: 3.30.0
       agents:
         specifier: ^0.20.1
-        version: 0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
+        version: 0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
       ai:
         specifier: ^7.0.55
         version: 7.0.55(zod@4.4.3)
@@ -61,14 +64,14 @@ importers:
         version: 4.4.3
     devDependencies:
       '@babel/core':
-        specifier: ^8.0.1
-        version: 8.0.1
+        specifier: ^7.29.7
+        version: 7.29.7
       '@babel/plugin-transform-runtime':
-        specifier: ^8.0.1
-        version: 8.0.1(@babel/core@8.0.1)
+        specifier: ^7.29.7
+        version: 7.29.7(@babel/core@7.29.7)
       '@babel/runtime':
-        specifier: ^8.0.0
-        version: 8.0.0
+        specifier: ^7.29.7
+        version: 7.29.7
       '@cloudflare/vite-plugin':
         specifier: ^1.51.0
         version: 1.51.0(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(wrangler@4.119.0(@cloudflare/workers-types@5.20260804.1))
@@ -77,7 +80,7 @@ importers:
         version: 0.20.2(@cloudflare/workers-types@5.20260804.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
-        version: 0.2.3(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@storybook/addon-a11y':
         specifier: ^10.5.7
         version: 10.5.7(storybook@10.5.7(@types/react@19.2.18)(prettier@3.9.6)(react@19.2.8))
@@ -107,7 +110,7 @@ importers:
         version: 19.2.4(@types/react@19.2.18)
       '@vitejs/plugin-react':
         specifier: ^6.0.5
-        version: 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       '@vitest/browser':
         specifier: ^4.1.10
         version: 4.1.10(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)
@@ -182,71 +185,48 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/code-frame@8.0.0':
-    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/compat-data@7.29.7':
     resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/compat-data@8.0.0':
-    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/core@7.29.7':
     resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@8.0.1':
-    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/generator@7.29.8':
     resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0':
-    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/helper-annotate-as-pure@8.0.0':
-    resolution: {integrity: sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-compilation-targets@7.29.7':
     resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@8.0.0':
-    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/helper-create-class-features-plugin@8.0.1':
-    resolution: {integrity: sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^8.0.0
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-define-polyfill-provider@0.6.8':
+    resolution: {integrity: sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-globals@8.0.0':
-    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/helper-member-expression-to-functions@8.0.0':
-    resolution: {integrity: sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.29.7':
     resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@8.0.0':
-    resolution: {integrity: sha512-NZ7mSS93o4ndX4KrbD7W8Sf3QT8Qe24PrnFyUcuOPDzK6faqDFKjY9RG7he7+I7FdiQ4llpnosFqzrXa+Vy3Ew==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-module-transforms@7.29.7':
     resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
@@ -254,85 +234,62 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-optimise-call-expression@8.0.0':
-    resolution: {integrity: sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
 
-  '@babel/helper-plugin-utils@8.0.1':
-    resolution: {integrity: sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^8.0.0
+      '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@8.0.1':
-    resolution: {integrity: sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-    peerDependencies:
-      '@babel/core': ^8.0.0
-
-  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
-    resolution: {integrity: sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0':
-    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@8.0.4':
-    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
     resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@8.0.0':
-    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helpers@7.29.7':
     resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helpers@8.0.0':
-    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/parser@7.29.8':
     resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@8.0.4':
-    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-    hasBin: true
-
-  '@babel/plugin-proposal-decorators@8.0.2':
-    resolution: {integrity: sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/plugin-proposal-decorators@7.29.7':
+    resolution: {integrity: sha512-EtU0Hi3GvrTqD56xKmZvV/uCXK2ZbwVNPNLAquVItcAZpUhkXwWlo3Fmj0c2LxgSf2I8IDULeAepwNP1OefLXg==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^8.0.0
+      '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-syntax-decorators@8.0.1':
-    resolution: {integrity: sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/plugin-syntax-decorators@7.29.7':
+    resolution: {integrity: sha512-9MTTLbF39X6sqM92JPEsoI7++26hjZvzkxKZy64aMhWLH2mPkJ/Q3AV4QLmls3R14FpSpkOwQQfUh962JGQxxg==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^8.0.0
+      '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-runtime@8.0.1':
-    resolution: {integrity: sha512-MPDpKBrxn+thQay3eJmUiSeHswiT7MkINb48hHkX6OzodB149PKq1kred+lpMebrDzHA+G1ekCQnlYSkyEqAOw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
+  '@babel/plugin-transform-runtime@7.29.7':
+    resolution: {integrity: sha512-xmAscdE/AsqRW7vutbPNoUmu/nF5SrLKPs7aoJgEjo35lLKA/Bc0i2rMv/hr1+Y0o1bQCiVtith3u2vdgRL39Q==}
+    engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^8.0.0
+      '@babel/core': ^7.0.0-0
 
   '@babel/runtime-corejs3@7.29.7':
     resolution: {integrity: sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==}
@@ -342,32 +299,17 @@ packages:
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/runtime@8.0.0':
-    resolution: {integrity: sha512-sL6cvO2IfkSu/iU+zs2S/w01B7A8V7suXSIKEN4hPFFdZoiPGxrj5pAG0lCaqLWiEIrjKzdznIWuaLcxPR53qw==}
-
   '@babel/template@7.29.7':
     resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/template@8.0.0':
-    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/traverse@7.29.8':
     resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@8.0.4':
-    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.4':
-    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
@@ -1955,12 +1897,6 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
-  '@types/gensync@1.0.5':
-    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
-
-  '@types/jsesc@2.5.1':
-    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
-
   '@types/mdx@2.0.14':
     resolution: {integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==}
 
@@ -2162,6 +2098,21 @@ packages:
   babel-dead-code-elimination@1.0.12:
     resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
 
+  babel-plugin-polyfill-corejs2@0.4.17:
+    resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-corejs3@0.13.0:
+    resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
+  babel-plugin-polyfill-regenerator@0.6.8:
+    resolution: {integrity: sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==}
+    peerDependencies:
+      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
+
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
 
@@ -2261,6 +2212,10 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  core-js-compat@3.50.0:
+    resolution: {integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==}
+    engines: {node: '>=6.4.0'}
 
   core-js-pure@3.50.0:
     resolution: {integrity: sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA==}
@@ -2528,9 +2483,6 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
-  import-meta-resolve@4.2.0:
-    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
-
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
@@ -2583,9 +2535,6 @@ packages:
 
   js-base64@3.9.2:
     resolution: {integrity: sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==}
-
-  js-tokens@10.0.0:
-    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2766,6 +2715,9 @@ packages:
 
   linkifyjs@4.3.3:
     resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
@@ -3644,14 +3596,7 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/code-frame@8.0.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 8.0.4
-      js-tokens: 10.0.0
-
   '@babel/compat-data@7.29.7': {}
-
-  '@babel/compat-data@8.0.0': {}
 
   '@babel/core@7.29.7':
     dependencies:
@@ -3673,25 +3618,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/core@8.0.1':
-    dependencies:
-      '@babel/code-frame': 8.0.0
-      '@babel/generator': 8.0.0
-      '@babel/helper-compilation-targets': 8.0.0
-      '@babel/helpers': 8.0.0
-      '@babel/parser': 8.0.4
-      '@babel/template': 8.0.0
-      '@babel/traverse': 8.0.4
-      '@babel/types': 8.0.4
-      '@types/gensync': 1.0.5
-      convert-source-map: 2.0.0
-      empathic: 2.0.1
-      gensync: 1.0.0-beta.2
-      import-meta-resolve: 4.2.0
-      json5: 2.2.3
-      obug: 2.1.4
-      semver: 7.8.5
-
   '@babel/generator@7.29.8':
     dependencies:
       '@babel/parser': 7.29.8
@@ -3700,18 +3626,9 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@8.0.0':
+  '@babel/helper-annotate-as-pure@7.29.7':
     dependencies:
-      '@babel/parser': 8.0.4
-      '@babel/types': 8.0.4
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
-      jsesc: 3.1.0
-
-  '@babel/helper-annotate-as-pure@8.0.0':
-    dependencies:
-      '@babel/types': 8.0.4
+      '@babel/types': 7.29.8
 
   '@babel/helper-compilation-targets@7.29.7':
     dependencies:
@@ -3721,33 +3638,38 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-compilation-targets@8.0.0':
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/compat-data': 8.0.0
-      '@babel/helper-validator-option': 8.0.0
-      browserslist: 4.28.7
-      lru-cache: 11.5.2
-      semver: 7.8.5
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.8
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
-  '@babel/helper-create-class-features-plugin@8.0.1(@babel/core@8.0.1)':
+  '@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-annotate-as-pure': 8.0.0
-      '@babel/helper-member-expression-to-functions': 8.0.0
-      '@babel/helper-optimise-call-expression': 8.0.0
-      '@babel/helper-replace-supers': 8.0.1(@babel/core@8.0.1)
-      '@babel/helper-skip-transparent-expression-wrappers': 8.0.0
-      '@babel/traverse': 8.0.4
-      semver: 7.8.5
+      '@babel/core': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      debug: 4.4.3
+      lodash.debounce: 4.0.8
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-globals@8.0.0': {}
-
-  '@babel/helper-member-expression-to-functions@8.0.0':
+  '@babel/helper-member-expression-to-functions@7.29.7':
     dependencies:
-      '@babel/traverse': 8.0.4
-      '@babel/types': 8.0.4
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
@@ -3755,11 +3677,6 @@ snapshots:
       '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/helper-module-imports@8.0.0':
-    dependencies:
-      '@babel/traverse': 8.0.4
-      '@babel/types': 8.0.4
 
   '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -3770,73 +3687,68 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-optimise-call-expression@8.0.0':
+  '@babel/helper-optimise-call-expression@7.29.7':
     dependencies:
-      '@babel/types': 8.0.4
+      '@babel/types': 7.29.8
 
-  '@babel/helper-plugin-utils@8.0.1(@babel/core@8.0.1)':
-    dependencies:
-      '@babel/core': 8.0.1
+  '@babel/helper-plugin-utils@7.29.7': {}
 
-  '@babel/helper-replace-supers@8.0.1(@babel/core@8.0.1)':
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-member-expression-to-functions': 8.0.0
-      '@babel/helper-optimise-call-expression': 8.0.0
-      '@babel/traverse': 8.0.4
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
 
-  '@babel/helper-skip-transparent-expression-wrappers@8.0.0':
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
     dependencies:
-      '@babel/traverse': 8.0.4
-      '@babel/types': 8.0.4
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-identifier@8.0.4': {}
-
   '@babel/helper-validator-option@7.29.7': {}
-
-  '@babel/helper-validator-option@8.0.0': {}
 
   '@babel/helpers@7.29.7':
     dependencies:
       '@babel/template': 7.29.7
       '@babel/types': 7.29.8
 
-  '@babel/helpers@8.0.0':
-    dependencies:
-      '@babel/template': 8.0.0
-      '@babel/types': 8.0.4
-
   '@babel/parser@7.29.8':
     dependencies:
       '@babel/types': 7.29.8
 
-  '@babel/parser@8.0.4':
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/types': 8.0.4
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
 
-  '@babel/plugin-proposal-decorators@8.0.2(@babel/core@8.0.1)':
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-create-class-features-plugin': 8.0.1(@babel/core@8.0.1)
-      '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
-      '@babel/plugin-syntax-decorators': 8.0.1(@babel/core@8.0.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-decorators@8.0.1(@babel/core@8.0.1)':
+  '@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
-
-  '@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1)':
-    dependencies:
-      '@babel/core': 8.0.1
-      '@babel/helper-module-imports': 8.0.0
-      '@babel/helper-plugin-utils': 8.0.1(@babel/core@8.0.1)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/runtime-corejs3@7.29.7':
     dependencies:
@@ -3844,19 +3756,11 @@ snapshots:
 
   '@babel/runtime@7.29.7': {}
 
-  '@babel/runtime@8.0.0': {}
-
   '@babel/template@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/parser': 7.29.8
       '@babel/types': 7.29.8
-
-  '@babel/template@8.0.0':
-    dependencies:
-      '@babel/code-frame': 8.0.0
-      '@babel/parser': 8.0.4
-      '@babel/types': 8.0.4
 
   '@babel/traverse@7.29.8':
     dependencies:
@@ -3870,34 +3774,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/traverse@8.0.4':
-    dependencies:
-      '@babel/code-frame': 8.0.0
-      '@babel/generator': 8.0.0
-      '@babel/helper-globals': 8.0.0
-      '@babel/parser': 8.0.4
-      '@babel/template': 8.0.0
-      '@babel/types': 8.0.4
-      obug: 2.1.4
-
   '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@babel/types@8.0.4':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0
-      '@babel/helper-validator-identifier': 8.0.4
-
   '@blazediff/core@1.9.1': {}
 
   '@cfworker/json-schema@4.1.1': {}
 
-  '@cloudflare/ai-chat@0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)':
+  '@cloudflare/ai-chat@0.10.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3))(ai@7.0.55(zod@4.4.3))(react@19.2.8)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/react': 4.0.58(react@19.2.8)(zod@4.4.3)
-      agents: 0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
+      agents: 0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3)
       ai: 7.0.55(zod@4.4.3)
       nanoid: 5.1.16
       react: 19.2.8
@@ -4595,14 +4484,14 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.2.3':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
-      '@babel/core': 8.0.1
+      '@babel/core': 7.29.7
       picomatch: 4.0.5
       rolldown: 1.2.3
     optionalDependencies:
-      '@babel/plugin-transform-runtime': 8.0.1(@babel/core@8.0.1)
-      '@babel/runtime': 8.0.0
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7)
+      '@babel/runtime': 7.29.7
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -5128,10 +5017,6 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
-  '@types/gensync@1.0.5': {}
-
-  '@types/jsesc@2.5.1': {}
-
   '@types/mdx@2.0.14': {}
 
   '@types/node@26.1.2':
@@ -5152,12 +5037,12 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
-  '@vitejs/plugin-react@6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/plugin-react@6.0.5(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/browser-playwright@4.1.10(playwright@1.62.1)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(vitest@4.1.10)':
@@ -5264,14 +5149,14 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3):
+  agents@0.20.1(@ai-sdk/react@4.0.58(react@19.2.8)(zod@4.4.3))(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(@cloudflare/workers-types@5.20260804.1)(@modelcontextprotocol/client@2.0.0)(@modelcontextprotocol/sdk@1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@modelcontextprotocol/server@2.0.0)(ai@7.0.55(zod@4.4.3))(react@19.2.8)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))(zod@4.4.3):
     dependencies:
-      '@babel/plugin-proposal-decorators': 8.0.2(@babel/core@8.0.1)
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
       '@cfworker/json-schema': 4.1.1
       '@modelcontextprotocol/client': 2.0.0
       '@modelcontextprotocol/sdk': 1.30.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
       '@modelcontextprotocol/server': 2.0.0
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@8.0.1)(@babel/plugin-transform-runtime@8.0.1(@babel/core@8.0.1))(@babel/runtime@8.0.0)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7))(@babel/runtime@7.29.7)(rolldown@1.2.3)(vite@8.2.0(@types/node@26.1.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
       cron-schedule: 6.0.0
       esbuild: 0.28.1
       mimetext: 3.0.28
@@ -5292,6 +5177,7 @@ snapshots:
       - '@babel/runtime'
       - '@cloudflare/workers-types'
       - rolldown
+      - supports-color
 
   ai@7.0.55(zod@4.4.3):
     dependencies:
@@ -5341,6 +5227,30 @@ snapshots:
       '@babel/parser': 7.29.8
       '@babel/traverse': 7.29.8
       '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
+      core-js-compat: 3.50.0
+    transitivePeerDependencies:
+      - supports-color
+
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-define-polyfill-provider': 0.6.8(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -5437,6 +5347,10 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  core-js-compat@3.50.0:
+    dependencies:
+      browserslist: 4.28.7
 
   core-js-pure@3.50.0: {}
 
@@ -5704,8 +5618,6 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  import-meta-resolve@4.2.0: {}
-
   indent-string@4.0.0: {}
 
   inherits@2.0.4: {}
@@ -5739,8 +5651,6 @@ snapshots:
   jose@6.2.8: {}
 
   js-base64@3.9.2: {}
-
-  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -5857,6 +5767,8 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.33.0
 
   linkifyjs@4.3.3: {}
+
+  lodash.debounce@4.0.8: {}
 
   loupe@3.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,10 @@ allowBuilds:
   core-js-pure: false
   esbuild: true
   workerd: true
+
+# The React Compiler's Babel plugin runs on Babel 7 — it depends on
+# @babel/types@^7 and, under Babel 8, skips every component with a default in
+# its props (facebook/react#36868). `agents` takes the 7.x decorators plugin for
+# `@callable`, which emits an identical worker. Undo once react#36956 ships.
+overrides:
+  "@babel/plugin-proposal-decorators": ^7.29.7

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -19,14 +19,14 @@ export function usePanels(): PanelState {
 	const narrow = useNarrow(narrowQuery)
 	const [open, setOpen] = useState<PanelId[]>(['chat', 'plan'])
 
-	// The first is the one furthest left, and the one the writer was reading when
-	// the window shrank under them.
-	useEffect(() => {
-		if (narrow) setOpen((held) => (held.length > 1 ? [held[0]] : held))
-	}, [narrow])
+	// Narrowed down to one here rather than in an effect that trims `open`. The
+	// one it keeps is the same one — the furthest left, which is what the writer
+	// was reading when the window shrank under them — but `open` still holds the
+	// rest, so widening again gives them back rather than leaving the one.
+	const shown = narrow && open.length > 1 ? [open[0]] : open
 
 	return {
-		open,
+		open: shown,
 		narrow,
 		toggle: (panel) => setOpen((held) => nextOpenPanels(held, panel, narrow)),
 	}

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -19,10 +19,8 @@ export function usePanels(): PanelState {
 	const narrow = useNarrow(narrowQuery)
 	const [open, setOpen] = useState<PanelId[]>(['chat', 'plan'])
 
-	// Narrowed down to one here rather than in an effect that trims `open`. The
-	// one it keeps is the same one — the furthest left, which is what the writer
-	// was reading when the window shrank under them — but `open` still holds the
-	// rest, so widening again gives them back rather than leaving the one.
+	// A narrow window shows one Panel, the furthest left. `open` keeps the rest,
+	// so widening gives them back.
 	const shown = narrow && open.length > 1 ? [open[0]] : open
 
 	return {

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -1,6 +1,13 @@
 import { getToolName, isTextUIPart, isToolUIPart, type UIMessage } from 'ai'
 import { ChevronDown } from 'lucide-react'
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import {
+	type ReactNode,
+	type RefObject,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react'
 
 import { proposePlanChangeTool, recordOffersTool, webSearchTool } from '../../shared/chat'
 import type { Offer } from '../../shared/offer'
@@ -77,7 +84,7 @@ export function ChatPanel({
 	className,
 }: ChatPanelProps) {
 	const rows = new Map(offers.map((offer) => [offer.id, offer]))
-	const transcript = useFootOfTranscript()
+	const [scroller, transcript] = useFootOfTranscript()
 
 	return (
 		<Panel className={className} divider={divider} grow={grow} padded={false}>
@@ -89,7 +96,7 @@ export function ChatPanel({
 					data-scroller=""
 					className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto p-3.5"
 					onScroll={transcript.onScroll}
-					ref={transcript.ref}
+					ref={scroller}
 				>
 					{messages.map((message) => (
 						<Turn
@@ -161,10 +168,14 @@ const AT_THE_FOOT = 24
  * before the observer can re-pin, so distance from the foot cannot tell the
  * writer's paste apart from the writer scrolling away.
  *
- * Returns the ref for the scrolling element, the `onScroll` that tracks it,
- * whether it is at the foot, and a way back down.
+ * Returns the ref for the scrolling element, then — separately, so that reading
+ * one during render does not count as touching the ref — the `onScroll` that
+ * tracks it, whether it is at the foot, and a way back down.
  */
-function useFootOfTranscript() {
+function useFootOfTranscript(): [
+	RefObject<HTMLDivElement | null>,
+	{ atFoot: boolean; onScroll: () => void; toFoot: () => void },
+] {
 	const panel = useRef<HTMLDivElement>(null)
 	const pinned = useRef(true)
 	const wasAt = useRef(0)
@@ -204,28 +215,30 @@ function useFootOfTranscript() {
 		// `foot` reads refs alone, so it cannot go stale.
 	}, [])
 
-	return {
-		ref: panel,
-		atFoot,
-		onScroll: () => {
-			const scroller = panel.current
-			if (scroller === null) return
+	return [
+		panel,
+		{
+			atFoot,
+			onScroll: () => {
+				const scroller = panel.current
+				if (scroller === null) return
 
-			const off = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
-			if (off <= AT_THE_FOOT) settle(true)
-			else if (scroller.scrollTop < wasAt.current) settle(false)
+				const off = scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight
+				if (off <= AT_THE_FOOT) settle(true)
+				else if (scroller.scrollTop < wasAt.current) settle(false)
 
-			wasAt.current = scroller.scrollTop
+				wasAt.current = scroller.scrollTop
+			},
+			toFoot: () => {
+				const scroller = panel.current
+				if (scroller === null) return
+
+				settle(true)
+				wasAt.current = scroller.scrollHeight
+				scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
+			},
 		},
-		toFoot: () => {
-			const scroller = panel.current
-			if (scroller === null) return
-
-			settle(true)
-			wasAt.current = scroller.scrollHeight
-			scroller.scrollTo({ top: scroller.scrollHeight, behavior: 'smooth' })
-		},
-	}
+	]
 }
 
 /** Why the composer will not send, and null when it will. Nothing expires an

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -168,8 +168,7 @@ const AT_THE_FOOT = 24
  * before the observer can re-pin, so distance from the foot cannot tell the
  * writer's paste apart from the writer scrolling away.
  *
- * Returns the ref for the scrolling element, then — separately, so that reading
- * one during render does not count as touching the ref — the `onScroll` that
+ * Returns the ref for the scrolling element, and separately the `onScroll` that
  * tracks it, whether it is at the foot, and a way back down.
  */
 function useFootOfTranscript(): [

--- a/src/client/draft/useDraft.ts
+++ b/src/client/draft/useDraft.ts
@@ -33,16 +33,13 @@ export function useDraft(store: DraftStore): DraftConnection {
 
 	const editorRef = useRef<Editor | null>(null)
 
-	// An Effect Event, because the writer reads the editor when it saves and the
-	// editor is only there from `attachEditor` onwards. This keeps one identity
-	// for the writer to hold and still reads the ref outside render.
+	// An Effect Event, so the writer can read the editor on save without the ref
+	// being touched during render.
 	const read = useEffectEvent((previous: readonly BlockRow[]) =>
 		editorRef.current === null ? previous : toRows(editorRef.current.state.doc, previous),
 	)
 
-	// Lazy `useState` rather than a ref filled in on first render: the writer has
-	// to be one per mount, and this is the form that says so without reading a
-	// ref while rendering.
+	// One per mount: the cleanup below disposes on `writer` changing.
 	const [writer] = useState(() =>
 		createDraftWriter({
 			read,

--- a/src/client/draft/useDraft.ts
+++ b/src/client/draft/useDraft.ts
@@ -1,5 +1,5 @@
 import type { Editor } from '@tiptap/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
 
 import type { BlockRow } from '../../shared/draft'
 import type { DraftStore } from '../lib/article'
@@ -33,17 +33,24 @@ export function useDraft(store: DraftStore): DraftConnection {
 
 	const editorRef = useRef<Editor | null>(null)
 
-	const writerRef = useRef<ReturnType<typeof createDraftWriter> | null>(null)
-	writerRef.current ??= createDraftWriter({
-		read: (previous) =>
-			editorRef.current === null
-				? previous
-				: toRows(editorRef.current.state.doc, previous),
-		save: (change) => store.saveBlocks(change),
-		onStatus: setStatus,
-		describeFailure: (error) => failureText('The Draft did not save.', error) ?? '',
-	})
-	const writer = writerRef.current
+	// An Effect Event, because the writer reads the editor when it saves and the
+	// editor is only there from `attachEditor` onwards. This keeps one identity
+	// for the writer to hold and still reads the ref outside render.
+	const read = useEffectEvent((previous: readonly BlockRow[]) =>
+		editorRef.current === null ? previous : toRows(editorRef.current.state.doc, previous),
+	)
+
+	// Lazy `useState` rather than a ref filled in on first render: the writer has
+	// to be one per mount, and this is the form that says so without reading a
+	// ref while rendering.
+	const [writer] = useState(() =>
+		createDraftWriter({
+			read,
+			save: (change) => store.saveBlocks(change),
+			onStatus: setStatus,
+			describeFailure: (error) => failureText('The Draft did not save.', error) ?? '',
+		}),
+	)
 
 	useEffect(() => {
 		let live = true

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -1,5 +1,5 @@
 import { useAgent } from 'agents/react'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useEffectEvent, useRef, useState } from 'react'
 
 import type { BlockRow, DraftChange, DraftSaved } from '../../shared/draft'
 import { isFrame } from '../../shared/frame'
@@ -42,10 +42,13 @@ export function wakeArticleAgent(articleId: string): void {
 }
 
 export function useArticleAgent(articleId: string): ArticleConnection {
-	// `useAgent` hands back a new client on each reconnect, so both halves read
-	// this rather than closing over one generation of it.
+	// The Plan writer is built once, above the client it writes through, so it
+	// sends via this rather than closing over one generation of the client. An
+	// effect fills it, which a store could not wait for — but nothing writes a
+	// Plan until the writer has typed, long after every effect has run.
 	const socket = useRef<ArticleSocket | null>(null)
-	const channel = usePlanChannel(() => socket.current)
+	const send = useEffectEvent((next: Plan) => socket.current?.setState(next))
+	const channel = usePlanChannel(send)
 
 	// The Round a `review_finished` frame last named. State rather than a
 	// listener registry, so nothing holds a mutable set across renders.
@@ -68,48 +71,47 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 		},
 	})
 
-	// In render, not an effect: React runs a child's effects first, so the Panels
-	// below would make their first RPC against a null socket.
-	socket.current = agent
+	useEffect(() => {
+		socket.current = agent
+	}, [agent])
 
-	// `[]` keeps the store's identity: `useOfferLedger` reads its rows once per
-	// store it is given, and `useDraft` loads once per store.
-	const offers = useMemo<OfferStore>(
-		() => ({
-			listOffers: () => call<Offer[]>(socket, 'listOffers'),
-			setOfferDisposition: (id: string, ruling: Ruling) =>
-				call<Offer>(socket, 'setOfferDisposition', [id, ruling]),
-			restoreOffer: (id: string) => call<Offer>(socket, 'restoreOffer', [id]),
-		}),
-		[],
+	/** One `@callable` RPC on whichever client is current. */
+	const call = useEffectEvent(
+		<T>(method: string, args?: unknown[], timeout?: number): Promise<T> =>
+			agent.call<T>(method, args, timeout === undefined ? undefined : { timeout }),
 	)
 
-	const draft = useMemo<DraftStore>(
-		() => ({
-			listBlocks: () => call<BlockRow[]>(socket, 'listBlocks'),
-			// Shorter than the SDK's 30-second default: a save that has not
-			// landed leaves "Saving…" on screen, and half a minute of that says
-			// something is fine when it is not.
-			saveBlocks: (change: DraftChange) =>
-				call<DraftSaved>(socket, 'saveBlocks', [change], SAVE_TIMEOUT),
-		}),
-		[],
-	)
+	// Lazy `useState` and not `useMemo`: the identity is the contract rather than
+	// a saving. `useOfferLedger` reads its rows once per store, `useDraft` loads
+	// once per store, and `useNotes` reads its rows once per store — so a store
+	// rebuilt mid-session would make all three read again. React reserves the
+	// right to forget a `useMemo`; it promises to keep this.
+	const [offers] = useState<OfferStore>(() => ({
+		listOffers: () => call<Offer[]>('listOffers'),
+		setOfferDisposition: (id: string, ruling: Ruling) =>
+			call<Offer>('setOfferDisposition', [id, ruling]),
+		restoreOffer: (id: string) => call<Offer>('restoreOffer', [id]),
+	}))
 
-	const notes = useMemo<NoteStore>(
-		() => ({
-			listRounds: () => call<Round[]>(socket, 'listRounds'),
-			listNotes: () => call<Note[]>(socket, 'listNotes'),
-			// A short call even for a thorough pass — `NoteStore.startReview`.
-			startReview: (request: ReviewRequest) =>
-				call<Round>(socket, 'startReview', [request]),
-			setNoteDisposition: (id: string, ruling: NoteRuling) =>
-				call<Note>(socket, 'setNoteDisposition', [id, ruling]),
-			resolveNote: (id: string) => call<Note>(socket, 'resolveNote', [id]),
-			restoreNote: (id: string) => call<Note>(socket, 'restoreNote', [id]),
-		}),
-		[],
-	)
+	const [draft] = useState<DraftStore>(() => ({
+		listBlocks: () => call<BlockRow[]>('listBlocks'),
+		// Shorter than the SDK's 30-second default: a save that has not
+		// landed leaves "Saving…" on screen, and half a minute of that says
+		// something is fine when it is not.
+		saveBlocks: (change: DraftChange) =>
+			call<DraftSaved>('saveBlocks', [change], SAVE_TIMEOUT),
+	}))
+
+	const [notes] = useState<NoteStore>(() => ({
+		listRounds: () => call<Round[]>('listRounds'),
+		listNotes: () => call<Note[]>('listNotes'),
+		// A short call even for a thorough pass — `NoteStore.startReview`.
+		startReview: (request: ReviewRequest) => call<Round>('startReview', [request]),
+		setNoteDisposition: (id: string, ruling: NoteRuling) =>
+			call<Note>('setNoteDisposition', [id, ruling]),
+		resolveNote: (id: string) => call<Note>('resolveNote', [id]),
+		restoreNote: (id: string) => call<Note>('restoreNote', [id]),
+	}))
 
 	return {
 		article: { offers, draft, notes, reviewFinished, plan: channel.connection },
@@ -119,22 +121,3 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 
 /** How long a save may be in flight before it is called failed. */
 const SAVE_TIMEOUT = 10_000
-
-/** An RPC on whichever socket is current. The client queues one made before the
- * socket opens, so only a caller ahead of the render above is refused. */
-function call<T>(
-	socket: { current: ArticleSocket | null },
-	method: string,
-	args?: unknown[],
-	timeout?: number,
-): Promise<T> {
-	if (socket.current === null) {
-		return Promise.reject(new Error('The Article Agent is not connected yet.'))
-	}
-
-	return socket.current.call<T>(
-		method,
-		args,
-		timeout === undefined ? undefined : { timeout },
-	)
-}

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -42,10 +42,9 @@ export function wakeArticleAgent(articleId: string): void {
 }
 
 export function useArticleAgent(articleId: string): ArticleConnection {
-	// The Plan writer is built once, above the client it writes through, so it
-	// sends via this rather than closing over one generation of the client. An
-	// effect fills it, which a store could not wait for — but nothing writes a
-	// Plan until the writer has typed, long after every effect has run.
+	// The Plan writer is built once, so it reaches the client through this rather
+	// than closing over one. Filled in an effect, which is late enough: nothing
+	// sends a Plan until the writer has typed.
 	const socket = useRef<ArticleSocket | null>(null)
 	const send = useEffectEvent((next: Plan) => socket.current?.setState(next))
 	const channel = usePlanChannel(send)
@@ -81,11 +80,9 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 			agent.call<T>(method, args, timeout === undefined ? undefined : { timeout }),
 	)
 
-	// Lazy `useState` and not `useMemo`: the identity is the contract rather than
-	// a saving. `useOfferLedger` reads its rows once per store, `useDraft` loads
-	// once per store, and `useNotes` reads its rows once per store — so a store
-	// rebuilt mid-session would make all three read again. React reserves the
-	// right to forget a `useMemo`; it promises to keep this.
+	// Lazy `useState` and not `useMemo`, because the identity is the contract:
+	// `useOfferLedger`, `useDraft` and `useNotes` each load once per store, and
+	// React may recompute a `useMemo`.
 	const [offers] = useState<OfferStore>(() => ({
 		listOffers: () => call<Offer[]>('listOffers'),
 		setOfferDisposition: (id: string, ruling: Ruling) =>

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import type { Plan, Refusal } from '../../shared/plan'
 import { isPlanRefused } from '../../shared/plan'
@@ -23,8 +23,6 @@ export type PlanConnection = {
 	rejected: string | null
 }
 
-export type PlanSocket = { setState: (plan: Plan) => void }
-
 export type PlanChannel = {
 	connection: PlanConnection
 	/** The two `useAgent` handlers the Plan needs. */
@@ -34,20 +32,20 @@ export type PlanChannel = {
 	onFrame: (frame: unknown) => void
 }
 
-/** `socket` is a getter, because `useAgent` has none to give on the first render
- * and swaps it on reconnect. */
-export function usePlanChannel(socket: () => PlanSocket | null): PlanChannel {
+/** `send` hands a Plan to the Article Agent. `useArticleAgent` supplies one that
+ * stays the same function across a reconnect, since the writer below is built
+ * once and outlives any one client. */
+export function usePlanChannel(send: (plan: Plan) => void): PlanChannel {
 	const [plan, setPlan] = useState<Plan | null>(null)
 	const [refusal, setRefusal] = useState<Refusal | null>(null)
 	const [rejected, setRejected] = useState<string | null>(null)
 
-	const held = useRef<ReturnType<typeof createPlanWriter> | null>(null)
-	held.current ??= createPlanWriter({
-		send: (next) => socket()?.setState(next),
-		onPlan: setPlan,
-		onRefusal: setRefusal,
-	})
-	const writer = held.current
+	// Lazy `useState` rather than a ref filled in on first render: the writer has
+	// to be one per mount, and this is the form that says so without reading a
+	// ref while rendering.
+	const [writer] = useState(() =>
+		createPlanWriter({ send, onPlan: setPlan, onRefusal: setRefusal }),
+	)
 
 	// Flushing on the way out is what keeps the last keystroke of a burst.
 	useEffect(() => () => writer.dispose(), [writer])

--- a/src/client/plan/usePlan.ts
+++ b/src/client/plan/usePlan.ts
@@ -32,17 +32,14 @@ export type PlanChannel = {
 	onFrame: (frame: unknown) => void
 }
 
-/** `send` hands a Plan to the Article Agent. `useArticleAgent` supplies one that
- * stays the same function across a reconnect, since the writer below is built
- * once and outlives any one client. */
+/** `send` reaches whichever client is current. `useArticleAgent` supplies one
+ * that keeps its identity, since the writer below is built once. */
 export function usePlanChannel(send: (plan: Plan) => void): PlanChannel {
 	const [plan, setPlan] = useState<Plan | null>(null)
 	const [refusal, setRefusal] = useState<Refusal | null>(null)
 	const [rejected, setRejected] = useState<string | null>(null)
 
-	// Lazy `useState` rather than a ref filled in on first render: the writer has
-	// to be one per mount, and this is the form that says so without reading a
-	// ref while rendering.
+	// One per mount: the cleanup below disposes on `writer` changing.
 	const [writer] = useState(() =>
 		createPlanWriter({ send, onPlan: setPlan, onRefusal: setRefusal }),
 	)


### PR DESCRIPTION
Closes #71.

The compiler skips any function it cannot prove follows the Rules of React, and it says nothing when it does. Two separate things were causing skips. Both are fixed, and the compiler now reports **123 functions compiled, 0 bail-outs** across `src/client` — up from 84 on `main`.

## 1. The Rules of React violations — the twelve `react/react-compiler` reports

`.oxlintrc.json` moves from `warn` to `error`.

- **`usePlan.ts` and `useDraft.ts`** held their writer in a ref filled in on the first render (`held.current ??= …`). Lazy `useState` holds one value for the component's life, which is what both wanted. `useDraft`'s `read` reaches the editor through an Effect Event, since the writer holds it and the editor only arrives with `attachEditor`.

- **`useArticleAgent.ts`** wrote the socket into a ref during render, because a Panel's first RPC would otherwise go out against a null socket. The stores now call through an Effect Event bound after the client, so the render-time write goes. The ref stays for the Plan writer alone, filled in an effect — the Plan channel and the socket are genuinely circular, and nothing writes a Plan until the writer has typed.

  A call made before the socket opens is now queued by the client rather than rejected; the "not connected yet" refusal went with the ref.

- **The three stores** move from `useMemo(…, [])` to lazy `useState`. `useOfferLedger`, `useDraft` and `useNotes` each key their load on the store's identity, and `useMemo` is a performance hint React reserves the right to forget. `MockArticle` holds its stores the same way, for the same reason.

- **`ChatPanel.tsx`** — `useFootOfTranscript` returned the scroller ref inside the object the render reads, which counted as touching a ref. It hands the ref back separately now.

- **`usePanels.ts`** set state from an effect when the window went narrow. It derives the one open Panel during render instead. **This changes behaviour:** widening again gives the other Panels back, where before the effect had trimmed them out of `open` for good. It composes with the `localStorage` persistence from #89 — `open` is the wide layout and stays that way through a resize.

## 2. The build ran the compiler on a Babel it does not support

`babel-plugin-react-compiler@1.0.0` depends on `@babel/types@^7` and declares no `@babel/core` peer. On Babel 8 it calls `path.isLVal()` on a destructured property value, and Babel 8 dropped `AssignmentPattern` from the `LVal` alias — so **every component with a default in its props errored out and was skipped, silently**. That was 34 of them: `ChatPanel`, `Panel`, `Button`, `DraftPanel`, most of `components/`.

Upstream: facebook/react#36868, open. Fix in facebook/react#36956, not shipped.

The build now runs Babel 7. `agents` runs `@babel/plugin-proposal-decorators` for `@callable` and its 8.x line wants `@babel/core@^8`, so an override in `pnpm-workspace.yaml` takes the 7.x line instead — both accept `version: "2023-11"`.

**The built worker is identical either way.** No differing lines once the pnpm store paths in its comments are normalised, and the 105 worker tests, which make real `@callable` RPC calls, pass. `pnpm peers check` reports no issues, as it did before — it could not have caught this, because the compiler plugin names no core version to disagree with.

## Verification

| check | result |
| --- | --- |
| compiler probe | 123 compiled, 0 bailed out |
| built worker vs Babel 8 | 0 differing lines |
| `pnpm lint` | clean, rule at `error` |
| `pnpm format:check` | clean |
| `pnpm typecheck` | clean |
| shared + client + worker tests | 449 passed |
| story tests | 50 passed, 2 runs |
| `pnpm peers check` | no issues |

`main` is merged in. The only conflict was `pnpm-lock.yaml`, regenerated with `pnpm install`.

## Worth knowing before merge

Neither guard in CI can see the toolchain half of this. `pnpm lint` exited 0 the whole time 34 components were being skipped — the `react/react-compiler` rule covers Rules-of-React bail-outs, not compiler-versus-Babel ones. So if `@babel/core` drifts back to 8 in a future upgrade, nothing will say so. A probe in CI would close that gap; it is a separate change from this one.

---
_Generated by [Claude Code](https://claude.ai/code/session_014mcRxPvmXaEiANvRjrdx9h)_