### PR TITLE
Sync Offers through a party-db collection (#94)

### DIFF
--- a/.storybook/mock/MockArticle.tsx
+++ b/.storybook/mock/MockArticle.tsx
@@ -2,13 +2,13 @@ import { createCollection, localOnlyCollectionOptions } from '@tanstack/db'
 import { type ReactNode, useState } from 'react'
 
 import {
+	type Article,
 	ArticleProvider,
 	type DraftStore,
 	type NoteStore,
 	type OfferStore,
 	useArticle,
 } from '../../src/client/lib/article'
-import type { ArticleSync } from '../../src/client/lib/sync'
 import { createPlanWriter } from '../../src/client/plan/writer'
 import type { BlockRow, DraftChange } from '../../src/shared/draft'
 import {
@@ -21,6 +21,7 @@ import {
 	restoredTo,
 } from '../../src/shared/note'
 import {
+	type Disposition,
 	missingOffer,
 	notDeclined,
 	type Offer,
@@ -30,10 +31,13 @@ import { emptyPlan, type Plan, type Refusal } from '../../src/shared/plan'
 import type { ReviewRequest, Round } from '../../src/shared/review'
 import {
 	fromNote,
+	fromOffer,
 	fromRound,
 	type NoteRow,
+	type OfferRow,
 	type RoundRow,
 	toNote,
+	toOffer,
 	toRound,
 } from '../../src/shared/sync'
 import { offers as seeded, plan as seededPlan } from './content'
@@ -59,11 +63,10 @@ export function MockArticle({ children }: { children: ReactNode }) {
 		return held
 	})
 
-	// One store per story, for the reason `useArticleAgent` gives: the readers
+	// One seam per story, for the reason `useArticleAgent` gives: the readers
 	// each load once per store identity, and the collections hold the rows.
-	const [offers] = useState(() => memoryOfferStore(seeded))
 	const [draft] = useState(() => memoryDraftStore())
-	const [{ notes, sync }] = useState(() => memoryNotes())
+	const [seam] = useState(() => memoryArticle({ offers: seeded }))
 
 	const edit = (next: Parameters<typeof writer.edit>[0]) => {
 		setRefusal(null)
@@ -73,13 +76,7 @@ export function MockArticle({ children }: { children: ReactNode }) {
 
 	return (
 		<ArticleProvider
-			value={{
-				offers,
-				draft,
-				notes,
-				sync,
-				plan: { plan, edit, refusal, rejected: null },
-			}}
+			value={{ ...seam, draft, plan: { plan, edit, refusal, rejected: null } }}
 		>
 			{children}
 		</ArticleProvider>
@@ -144,8 +141,8 @@ function memoryCollection<Row extends { id: string }>(seed: Row[]) {
 }
 
 /**
- * The Notes and Rounds held in memory: real collections behind the real live
- * queries, plus a store running the real ruling rules — the same two halves
+ * One Article seam held in memory: real collections behind the real live
+ * queries, plus the stores running the real ruling rules — the same two halves
  * `useArticleAgent` hands the Panels.
  *
  * `answer` is what a Review comes back with, after a beat — enough for a story
@@ -153,29 +150,35 @@ function memoryCollection<Row extends { id: string }>(seed: Row[]) {
  * Leaving it out leaves every Review running, which is the state a story shows
  * when it is about the waiting.
  */
-export function memoryNotes(
+export function memoryArticle(
 	options: {
+		offers?: readonly Offer[]
 		rounds?: readonly Round[]
 		notes?: readonly Note[]
 		answer?: { passages: Round['passages']; notes: readonly Note[] }
 		/** How long a Review takes to come back. */
 		takes?: number
 	} = {},
-): { notes: NoteStore; sync: ArticleSync } {
+): Pick<Article, 'notes' | 'offers' | 'sync'> {
 	let noteSeq = 0
 	const note = memoryCollection<NoteRow>(
 		(options.notes ?? []).map((one) => fromNote(one, ++noteSeq)),
 	)
 	const round = memoryCollection<RoundRow>((options.rounds ?? []).map(fromRound))
 
-	const find = (id: string): NoteRow => {
+	let offerSeq = 0
+	const offer = memoryCollection<OfferRow>(
+		(options.offers ?? []).map((one) => fromOffer(one, ++offerSeq)),
+	)
+
+	const findNote = (id: string): NoteRow => {
 		const row = note.get(id)
 		if (row === undefined) throw missingNote(id)
 
 		return row
 	}
 
-	const move = (row: NoteRow, disposition: NoteDisposition) => {
+	const moveNote = (row: NoteRow, disposition: NoteDisposition) => {
 		const decidedAt = disposition === 'proposed' ? null : Date.now()
 		note.update(row.id, (draft) => {
 			draft.disposition = disposition
@@ -185,7 +188,7 @@ export function memoryNotes(
 		return Promise.resolve(toNote({ ...row, disposition, decided_at: decidedAt }))
 	}
 
-	const store: NoteStore = {
+	const notes: NoteStore = {
 		startReview: (request: ReviewRequest) => {
 			// Minted, not counted off the length: a story seeds Rounds whose ids and
 			// ordinals start past 1.
@@ -225,67 +228,65 @@ export function memoryNotes(
 		},
 
 		setNoteDisposition: (id: string, ruling) => {
-			const row = find(id)
+			const row = findNote(id)
 			if (row.disposition !== 'proposed') {
 				return Promise.reject(alreadyRuled(toNote(row)))
 			}
 
-			return move(row, ruling)
+			return moveNote(row, ruling)
 		},
 
 		resolveNote: (id: string) => {
-			const row = find(id)
+			const row = findNote(id)
 			if (row.disposition !== 'accepted') {
 				return Promise.reject(notAccepted(toNote(row)))
 			}
 
-			return move(row, 'resolved')
+			return moveNote(row, 'resolved')
 		},
 
 		restoreNote: (id: string) => {
-			const row = find(id)
+			const row = findNote(id)
 			const back = restoredTo(row.disposition)
 			if (back === null) return Promise.reject(notRestorable(toNote(row)))
 
-			return move(row, back)
+			return moveNote(row, back)
 		},
 	}
 
-	return { notes: store, sync: { note, round } }
-}
+	const findOffer = (id: string): OfferRow => {
+		const row = offer.get(id)
+		if (row === undefined) throw missingOffer(id)
 
-export function memoryOfferStore(seed: readonly Offer[]): OfferStore {
-	const rows = seed.map((offer) => ({ ...offer }))
-
-	const find = (id: string): Offer => {
-		const offer = rows.find((held) => held.id === id)
-		if (offer === undefined) throw missingOffer(id)
-
-		return offer
+		return row
 	}
 
-	const rule = (
-		offer: Offer,
-		disposition: Offer['disposition'],
+	const moveOffer = (
+		row: OfferRow,
+		disposition: Disposition,
 		decidedAt: number | null,
 	) => {
-		const ruled = { ...offer, disposition, decidedAt }
-		rows.splice(rows.indexOf(offer), 1, ruled)
+		offer.update(row.id, (draft) => {
+			draft.disposition = disposition
+			draft.decided_at = decidedAt
+		})
 
-		return Promise.resolve(ruled)
+		return Promise.resolve(toOffer({ ...row, disposition, decided_at: decidedAt }))
 	}
 
-	return {
-		listOffers: () => Promise.resolve(rows.map((offer) => ({ ...offer }))),
-
+	const offers: OfferStore = {
 		setOfferDisposition: (id: string, ruling: Ruling) =>
-			rule(find(id), ruling, Date.now()),
+			moveOffer(findOffer(id), ruling, Date.now()),
 
 		restoreOffer: (id: string) => {
-			const offer = find(id)
-			if (offer.disposition !== 'declined') return Promise.reject(notDeclined(offer))
+			const row = findOffer(id)
+			if (row.disposition !== 'declined') {
+				return Promise.reject(notDeclined(toOffer(row)))
+			}
 
-			return rule(offer, 'undecided', null)
+			return moveOffer(row, 'undecided', null)
 		},
 	}
+
+	return { notes, offers, sync: { note, round, offer } }
 }

--- a/.storybook/mock/MockArticle.tsx
+++ b/.storybook/mock/MockArticle.tsx
@@ -63,8 +63,8 @@ export function MockArticle({ children }: { children: ReactNode }) {
 		return held
 	})
 
-	// One seam per story, for the reason `useArticleAgent` gives: the readers
-	// each load once per store identity, and the collections hold the rows.
+	// One draft store and one seam per story: `useDraft` and `useNotes` load once
+	// per `draft` store identity, and the seam's collections hold the rows.
 	const [draft] = useState(() => memoryDraftStore())
 	const [seam] = useState(() => memoryArticle({ offers: seeded }))
 
@@ -166,9 +166,8 @@ export function memoryArticle(
 	)
 	const round = memoryCollection<RoundRow>((options.rounds ?? []).map(fromRound))
 
-	let offerSeq = 0
 	const offer = memoryCollection<OfferRow>(
-		(options.offers ?? []).map((one) => fromOffer(one, ++offerSeq)),
+		(options.offers ?? []).map((one, index) => ({ ...fromOffer(one), seq: index + 1 })),
 	)
 
 	const findNote = (id: string): NoteRow => {
@@ -261,11 +260,8 @@ export function memoryArticle(
 		return row
 	}
 
-	const moveOffer = (
-		row: OfferRow,
-		disposition: Disposition,
-		decidedAt: number | null,
-	) => {
+	const moveOffer = (row: OfferRow, disposition: Disposition) => {
+		const decidedAt = disposition === 'undecided' ? null : Date.now()
 		offer.update(row.id, (draft) => {
 			draft.disposition = disposition
 			draft.decided_at = decidedAt
@@ -275,8 +271,7 @@ export function memoryArticle(
 	}
 
 	const offers: OfferStore = {
-		setOfferDisposition: (id: string, ruling: Ruling) =>
-			moveOffer(findOffer(id), ruling, Date.now()),
+		setOfferDisposition: (id: string, ruling: Ruling) => moveOffer(findOffer(id), ruling),
 
 		restoreOffer: (id: string) => {
 			const row = findOffer(id)
@@ -284,7 +279,7 @@ export function memoryArticle(
 				return Promise.reject(notDeclined(toOffer(row)))
 			}
 
-			return moveOffer(row, 'undecided', null)
+			return moveOffer(row, 'undecided')
 		},
 	}
 

--- a/.storybook/panels/Draft.stories.tsx
+++ b/.storybook/panels/Draft.stories.tsx
@@ -7,7 +7,7 @@ import { ArticleDraftPanel } from '../../src/client/draft/ArticleDraftPanel'
 import { ArticleProvider, type DraftStore } from '../../src/client/lib/article'
 import type { BlockRow } from '../../src/shared/draft'
 import { ARTICLE_TITLE } from '../mock/content'
-import { memoryDraftStore, memoryOfferStore } from '../mock/MockArticle'
+import { memoryArticle, memoryDraftStore } from '../mock/MockArticle'
 
 const meta = {
 	title: 'Panels/Draft',
@@ -32,13 +32,17 @@ const SEEDED: BlockRow[] = [
 	para('b1', 1, 'The council voted on Tuesday to extend the scheme.'),
 ]
 
+/** Built once: this screen reads no Offers, Notes or Rounds, and the collections
+ * behind them should not be rebuilt on every keystroke. */
+const others = memoryArticle()
+
 /** Only the Draft's half of the Article seam; nothing here reads the Plan. */
 function DraftScreen({ store }: { store: DraftStore }) {
 	return (
 		<ArticleProvider
 			value={{
+				...others,
 				draft: store,
-				offers: memoryOfferStore([]),
 				plan: { plan: null, edit: () => null, refusal: null, rejected: null },
 			}}
 		>

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -280,6 +280,14 @@ export const F_LedgerDrawer: Story = {
 		// wrapper's edge rather than at the field.
 		const foot = () => transcript.getBoundingClientRect().bottom
 
+		// The rows arrive through the synced `offer` collection (§12), so the
+		// drawer draws them with nothing having asked for them.
+		await waitFor(() =>
+			expect(
+				within(drawer as HTMLElement).getAllByText(/Permit throughput/).length,
+			).toBeGreaterThan(0),
+		)
+
 		// The drawer covers the transcript and leaves the composer alone, which is
 		// what keeps the toggle in place for the second click.
 		await expect(toggle.getAttribute('aria-expanded')).toBe('true')

--- a/.storybook/screens/article/PlanAnArticle.stories.tsx
+++ b/.storybook/screens/article/PlanAnArticle.stories.tsx
@@ -280,8 +280,8 @@ export const F_LedgerDrawer: Story = {
 		// wrapper's edge rather than at the field.
 		const foot = () => transcript.getBoundingClientRect().bottom
 
-		// The rows arrive through the synced `offer` collection (§12), so the
-		// drawer draws them with nothing having asked for them.
+		// The rows land through the synced `offer` collection rather than on first
+		// paint, so the geometry below would measure an empty drawer without this.
 		await waitFor(() =>
 			expect(
 				within(drawer as HTMLElement).getAllByText(/Permit throughput/).length,

--- a/.storybook/screens/review/FullReviewScreen.tsx
+++ b/.storybook/screens/review/FullReviewScreen.tsx
@@ -10,7 +10,7 @@ import type { Note } from '../../../src/shared/note'
 import { restoredTo } from '../../../src/shared/note'
 import type { Round } from '../../../src/shared/review'
 import { ARTICLE_TITLE, plan } from '../../mock/content'
-import { memoryDraftStore, memoryNotes, memoryOfferStore } from '../../mock/MockArticle'
+import { memoryArticle, memoryDraftStore } from '../../mock/MockArticle'
 import { reviewNotes, reviewRound, reviewRounds } from '../../mock/review'
 
 /**
@@ -75,8 +75,7 @@ export function MockNotes({
 }: MockNotesProps) {
 	const [seam] = useState(() => ({
 		draft: memoryDraftStore({ seed: draft }),
-		offers: memoryOfferStore([]),
-		...memoryNotes({ rounds, notes, answer }),
+		...memoryArticle({ rounds, notes, answer }),
 	}))
 
 	return (

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -44,6 +44,11 @@ the collections would live in the per-Article object rather than a new one. That
 120 lines of forked party-db glue and makes the client discriminate frames on the
 multiplexed socket. Below the size ceiling the blob is less work; above it, it is not.
 
+**Amended:** #92 and #94 composed party-db into the Article Agent, and Notes, Rounds and
+Offers are collections now — so "read when the writer opens a Panel" describes none of
+them. The decision this ADR records is unchanged: the Plan stays a blob in Article Agent
+state, and architecture.md §3 carries the rule as it now stands.
+
 **The migration is bounded but not free.** The decisions below buy it: stable IDs
 everywhere, parents by containment, References already row-shaped and carrying Provenance.
 What they do not buy is the read sites — every `plan.outline.map(…)` becomes a query.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -648,12 +648,12 @@ issue #11. `startReview` writes a Round row, answers with it, and carries on und
   across an `await` (#9), which a field could not — in-memory state does not survive
   hibernation, and a check-then-write races itself.
 
-**Notes, Rounds and Offers are party-db collections, hosted by the Article Agent itself.**
-This
-is #84's hosting question, answered: the Agent cannot subclass `PartyDbServer` — it
-already extends `AIChatAgent` — so it holds a `PartyDbCore` built over its own SQLite
-(party-db#43), and §3 rule 2 stands as written. No room Durable Object sits beside it.
-The composition is four seams, all keyed on party-db's own `?proto=party-db` marker:
+**Notes, Rounds and Offers are party-db collections, hosted by the Article Agent
+itself.** This is #84's hosting question, answered: the Agent cannot subclass
+`PartyDbServer` — it already extends `AIChatAgent` — so it holds a `PartyDbCore` built
+over its own SQLite (party-db#43), and §3 rule 2 stands as written. No room Durable
+Object sits beside it. The composition is four seams, all keyed on party-db's own
+`?proto=party-db` marker:
 
 - **A second socket, not a shared one.** `partyTransport` connects to the same Durable
   Object over partyserver's `/parties/article-agent/:name` route, beside the `useAgent`
@@ -674,12 +674,13 @@ The composition is four seams, all keyed on party-db's own `?proto=party-db` mar
 write reaches a fresh snapshot and never an already-connected client, because only the
 oplog feeds the stream. Reads stay plain SQL, the fingerprint dedupe in `recordOffers`
 among them: the oplog carries writes. The Guide writes a Round's Notes and its settle in
-one commit, so a subscriber that hears the Round settle already holds its Notes; a
-research turn commits one Offer at a time, so the writer watches the rows arrive.
-Rulings stay `@callable` RPC for their guards on all three types, implemented over
-`commit()` so the ruled row syncs. Nothing announces a Review settling or a turn
-recording any more — the rows landing is the announcement, which is what deleted the
-`review_finished` frame, the Notes Panel's poll, its reload counter, and the Ledger's.
+one commit, and a research turn commits its Offers in one too — a subscriber that hears
+the Round settle already holds its Notes, and a turn that found seventeen things costs
+one batch rather than seventeen. Rulings stay `@callable` RPC for their guards on all
+three types, implemented over `commit()` so the ruled row syncs. Nothing announces a
+Review settling or a turn recording any more — the rows landing is the announcement,
+which is what deleted the `review_finished` frame, the Notes Panel's poll, its reload
+counter, and the Ledger's.
 
 **The wire rows are the table rows.** `src/shared/sync.ts` declares the three collections'
 schemas as the columns stand — snake_case, JSON columns as the text they store — and owns

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,9 +43,9 @@ Browser — React + Vite + TanStack Router
   ├─ Plan Panel    ├── useAgent WebSocket ───► Article Agent (one per Article)
   ├─ Draft Panel   ├── party-db WebSocket ──►   ├─ Agents SDK store: the Chat transcript
   └─ Notes Panel  ─┘    (same Agent, §12)       ├─ Agent state (one JSON blob): the Plan
-                                                ├─ SQLite rows: Blocks, Offers
+                                                ├─ SQLite rows: Blocks
                                                 ├─ party-db collections over its SQLite:
-                                                │    Notes, Rounds (synced, §12)
+                                                │    Notes, Rounds, Offers (synced, §12)
                    ── party-db WebSocket ──►  The House (one party-db room, → D1)   [1b]
                    ── HTTP (Hono) ─────────►  The article index (→ D1)
                                               Archived reads, export
@@ -105,11 +105,11 @@ Recorded in [ADR 0001](./adr/0001-phase-1-storage-shape.md).
 **The blob is a reactive store; a table is on-demand until it is published as a
 party-db collection.** A bare row in a Durable Object's SQLite has no sync — `@callable`
 RPC is request and response, so nothing tells a client it changed. That still suits
-Blocks and Offers, which are read when a Panel opens. Notes and Rounds are published as
+Blocks, which the client both writes and reads. Notes, Rounds and Offers are published as
 party-db collections instead (§12): reads are synced live queries, the Guide's writes go
 through `commit()`, and rule 2's write path still holds for what the writer sends up —
-rulings stay RPC. Which tables join the collections next is decided per table, Offers
-first (#92's second pass).
+rulings stay RPC. Which table joins them next is decided per table; the Draft is the one
+left, and §10 says why it can wait.
 
 ## 4. The Plan
 
@@ -178,7 +178,8 @@ relief valve is moving References into SQLite rows, which is the phase 2 move an
 
 ## 5. Chat and the Offers Ledger
 
-The Chat turns up Offers — Links and Quotes — as SQLite rows in the Article Agent. The
+The Chat turns up Offers — Links and Quotes — as rows in the Article Agent's `offer`
+collection, synced to every connected client (§12). The
 **Ledger** is a View over all the Offers surfaced in this Chat. Offers can be
 **Undecided**, **Accepted**, or **Declined** (restorable). In this way, the Ledger is used
 as a direct sibling to, or alternative to, showing the chat transcript. We toggle it on or
@@ -220,6 +221,12 @@ copy for an Offer already Accepted. Nothing recovers it, and nothing surfaces it
 refusal, and `useOfferLedger` reads it: sending the ruling anyway would land the app in
 exactly that stranded state. The writer gets the applier's sentence instead, built at the
 edge from `refusal.reason` like every other one (§6).
+
+**Nothing announces a research turn's rows.** They land through the sync as the Guide
+commits them, on the Ledger of every connected client — which is what deleted
+`listOffers` as a `@callable`, the Ledger's load-once contract, and the reload the Chat
+threaded through when it read fresh ids out of the transcript. The Chat still reads that
+tool output, for the Offer cards it draws in the transcript.
 
 **The writer pastes their own References straight into the Plan**, and those carry
 `provenance: { type: 'writer' }` rather than an Offer id. They never enter the Ledger: an
@@ -435,7 +442,7 @@ party-db's lobby and write path at 1b, archived reads, and export.
 
 **TanStack Query** serves the article index and the archived and export reads. Live data is
 already reactive through Article Agent state and party-db's TanStack DB collections — the
-Notes Panel's today (§12), the House's at 1b.
+Notes Panel's and the Offer ledger's today (§12), the House's at 1b.
 
 **The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
 narrow screen, and which are all more or less their own little interfaces, with very specific
@@ -550,10 +557,10 @@ Guide, the Notes Panel, and everything that reads the prose are not.
   and **a save carries a delta** rather than the whole Draft. The delta is what bounds a
   stale tab: a client can only name a Block it has already seen, so a paragraph written
   somewhere else is not one it can delete.
-- **Sync arrived early, and only for the Notes Panel.** party-db (`mhsnook/party-db`,
-  checked out at `~/code/party-db`) runs inside the Article Agent for Notes and Rounds
-  (§12); the House at 1b gets its own room. The Draft is not synced and can move onto a
-  collection later without changing shape. Until then two tabs on one Draft is
+- **Sync arrived early, and the Draft is what is left out.** party-db (`mhsnook/party-db`,
+  checked out at `~/code/party-db`) runs inside the Article Agent for Notes, Rounds and
+  Offers (§12); the House at 1b gets its own room. The Draft is not synced and can move
+  onto a collection later without changing shape. Until then two tabs on one Draft is
   last-write-wins per Block, which is what §1's "only one editor at a time" costs.
   Findings #7 and #18 stand and are not load-bearing yet.
 - **Notes is the fourth Panel**, and it is built — §12. What is still phase 2's is the
@@ -641,7 +648,8 @@ issue #11. `startReview` writes a Round row, answers with it, and carries on und
   across an `await` (#9), which a field could not — in-memory state does not survive
   hibernation, and a check-then-write races itself.
 
-**Notes and Rounds are party-db collections, hosted by the Article Agent itself.** This
+**Notes, Rounds and Offers are party-db collections, hosted by the Article Agent itself.**
+This
 is #84's hosting question, answered: the Agent cannot subclass `PartyDbServer` — it
 already extends `AIChatAgent` — so it holds a `PartyDbCore` built over its own SQLite
 (party-db#43), and §3 rule 2 stands as written. No room Durable Object sits beside it.
@@ -664,13 +672,16 @@ The composition is four seams, all keyed on party-db's own `?proto=party-db` mar
 
 **Every server write to a synced table goes through `commit()`, never raw SQL.** A raw
 write reaches a fresh snapshot and never an already-connected client, because only the
-oplog feeds the stream. The Guide writes a Round's Notes and its settle in one commit, so
-a subscriber that hears the Round settle already holds its Notes; rulings stay `@callable`
-RPC for their guards, implemented over `commit()` so the ruled row syncs. Nothing
-announces a Review settling any more — the rows landing is the announcement, which is
-what deleted the `review_finished` frame, the Notes Panel's poll, and its reload counter.
+oplog feeds the stream. Reads stay plain SQL, the fingerprint dedupe in `recordOffers`
+among them: the oplog carries writes. The Guide writes a Round's Notes and its settle in
+one commit, so a subscriber that hears the Round settle already holds its Notes; a
+research turn commits one Offer at a time, so the writer watches the rows arrive.
+Rulings stay `@callable` RPC for their guards on all three types, implemented over
+`commit()` so the ruled row syncs. Nothing announces a Review settling or a turn
+recording any more — the rows landing is the announcement, which is what deleted the
+`review_finished` frame, the Notes Panel's poll, its reload counter, and the Ledger's.
 
-**The wire rows are the table rows.** `src/shared/sync.ts` declares the two collections'
+**The wire rows are the table rows.** `src/shared/sync.ts` declares the three collections'
 schemas as the columns stand — snake_case, JSON columns as the text they store — and owns
 the one mapping to the shapes the app reads. JSON-typed fields would arrive unparsed
 anyway: party-db's column codec reads Zod v3 internals and this repo is on Zod v4

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -341,6 +341,7 @@ function Turn({
 					const found = recorded
 						.map(({ id }) => rows.get(id))
 						.filter((offer): offer is Offer => offer !== undefined)
+					const arriving = recorded.length - found.length
 
 					return (
 						<div key={key} className="flex flex-col gap-2">
@@ -352,10 +353,10 @@ function Turn({
 									onDecline={() => onDeclineOffer(offer)}
 								/>
 							))}
-							{found.length < recorded.length ? (
+							{arriving > 0 ? (
 								<ChatNote>
-									{recorded.length} found, and {recorded.length - found.length} are still
-									arriving.
+									{recorded.length} found, and {arriving} {arriving === 1 ? 'is' : 'are'}{' '}
+									still arriving.
 								</ChatNote>
 							) : null}
 						</div>

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -354,8 +354,8 @@ function Turn({
 							))}
 							{found.length < recorded.length ? (
 								<ChatNote>
-									{recorded.length} found, and the Offer ledger has not read them all back
-									yet.
+									{recorded.length} found, and {recorded.length - found.length} are still
+									arriving.
 								</ChatNote>
 							) : null}
 						</div>

--- a/src/client/chat/offers.ts
+++ b/src/client/chat/offers.ts
@@ -1,10 +1,4 @@
-import {
-	type DynamicToolUIPart,
-	getToolName,
-	isToolUIPart,
-	type ToolUIPart,
-	type UIMessage,
-} from 'ai'
+import { type DynamicToolUIPart, getToolName, type ToolUIPart } from 'ai'
 
 import {
 	type RecordedOffers,
@@ -27,21 +21,4 @@ export function readRecordedOffers(
 	const parsed = recordedOffersOutput.safeParse(part.output)
 
 	return parsed.success ? parsed.data : null
-}
-
-/** A fresh array of every Offer id the transcript names, in order, deduped. */
-export function recordedOfferIds(messages: readonly UIMessage[]): string[] {
-	const ids: string[] = []
-
-	for (const message of messages) {
-		for (const part of message.parts) {
-			if (!isToolUIPart(part)) continue
-
-			for (const recorded of readRecordedOffers(part) ?? []) {
-				if (!ids.includes(recorded.id)) ids.push(recorded.id)
-			}
-		}
-	}
-
-	return ids
 }

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -7,7 +7,6 @@ import type { Plan } from '../../shared/plan'
 import { useArticle } from '../lib/article'
 import type { ArticleSocket } from '../lib/useArticleAgent'
 import { useOfferLedger, type OfferLedgerHandle } from '../lib/useOfferLedger'
-import { recordedOfferIds } from './offers'
 import {
 	afterRuling,
 	type ProposalCall,
@@ -63,18 +62,6 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 	})
 
 	const { messages, addToolOutput } = chat
-
-	// Nothing on the socket announces a new Offer row (§3), so an id the Chat
-	// names that the Ledger has not got is the signal to read again. Comparing
-	// rather than counting turns is also what makes it safe: a row that never
-	// arrives leaves `missing` true, so the dependency holds and the read stops.
-	const recorded = useMemo(() => recordedOfferIds(messages), [messages])
-	const loaded = new Set(ledger.ledger.offers.map((offer) => offer.id))
-	const missing = recorded.some((id) => !loaded.has(id))
-	const { reload } = ledger
-	useEffect(() => {
-		if (missing) reload()
-	}, [missing, reload])
 
 	const rule = (call: ProposalCall, accepted: boolean) => {
 		const ruling = ruleProposal({

--- a/src/client/lib/article.ts
+++ b/src/client/lib/article.ts
@@ -13,9 +13,9 @@ import type { ArticleSync } from './sync'
  * builds it; the Panels read it.
  */
 
-/** The Article Agent's writer-facing `@callable` methods. */
+/** The Ledger's RPC writes; reads come through the `offer` collection on
+ * `sync`. */
 export type OfferStore = {
-	listOffers(): Promise<Offer[]>
 	setOfferDisposition(id: string, ruling: Ruling): Promise<Offer>
 	restoreOffer(id: string): Promise<Offer>
 }

--- a/src/client/lib/sync.ts
+++ b/src/client/lib/sync.ts
@@ -1,16 +1,22 @@
 import type { Collection } from '@tanstack/db'
 import { createPartyDb, partyTransport } from 'party-db/client'
 
-import { type NoteRow, type RoundRow, syncCollections } from '../../shared/sync'
+import {
+	type NoteRow,
+	type OfferRow,
+	type RoundRow,
+	syncCollections,
+} from '../../shared/sync'
 
 /**
  * One party-db connection per Article — the second socket of architecture.md
- * §12, carrying the `note` and `round` collections.
+ * §12, carrying the `note`, `round` and `offer` collections.
  */
 
 export type ArticleSync = {
 	note: Collection<NoteRow>
 	round: Collection<RoundRow>
+	offer: Collection<OfferRow>
 }
 
 /** Held for the session: party-db has no transport close yet (party-db#46),
@@ -32,13 +38,15 @@ export function articleSync(articleId: string): ArticleSync {
 	const sync: ArticleSync = {
 		note: db.note as Collection<NoteRow>,
 		round: db.round as Collection<RoundRow>,
+		offer: db.offer as Collection<OfferRow>,
 	}
 
-	// Pin both collections: TanStack DB garbage-collects a collection once its
+	// Pin every collection: TanStack DB garbage-collects a collection once its
 	// last subscriber leaves, and a party-db collection that restarts gets no
 	// second snapshot (party-db#47; the other §11 carry).
 	sync.note.subscribeChanges(() => {})
 	sync.round.subscribeChanges(() => {})
+	sync.offer.subscribeChanges(() => {})
 
 	held.set(articleId, sync)
 

--- a/src/client/lib/sync.ts
+++ b/src/client/lib/sync.ts
@@ -43,10 +43,9 @@ export function articleSync(articleId: string): ArticleSync {
 
 	// Pin every collection: TanStack DB garbage-collects a collection once its
 	// last subscriber leaves, and a party-db collection that restarts gets no
-	// second snapshot (party-db#47; the other §11 carry).
-	sync.note.subscribeChanges(() => {})
-	sync.round.subscribeChanges(() => {})
-	sync.offer.subscribeChanges(() => {})
+	// second snapshot (party-db#47; the other §11 carry). Iterated rather than
+	// listed, so a collection cannot join `ArticleSync` unpinned.
+	for (const collection of Object.values(sync)) collection.subscribeChanges(() => {})
 
 	held.set(articleId, sync)
 

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -64,7 +64,9 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 	)
 
 	// Lazy `useState` and not `useMemo`, because the identity is the contract:
-	// `useDraft` loads once per store, and React may recompute a `useMemo`.
+	// `useDraft` and `useNotes` each load the Blocks once per `draft` store, and
+	// React may recompute a `useMemo`. The other two stores are built the same
+	// way, so no reader has to check which one it may key on.
 	const [offers] = useState<OfferStore>(() => ({
 		setOfferDisposition: (id: string, ruling: Ruling) =>
 			call<Offer>('setOfferDisposition', [id, ruling]),

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -64,10 +64,8 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 	)
 
 	// Lazy `useState` and not `useMemo`, because the identity is the contract:
-	// `useOfferLedger`, `useDraft` and `useNotes` each load once per store, and
-	// React may recompute a `useMemo`.
+	// `useDraft` loads once per store, and React may recompute a `useMemo`.
 	const [offers] = useState<OfferStore>(() => ({
-		listOffers: () => call<Offer[]>('listOffers'),
 		setOfferDisposition: (id: string, ruling: Ruling) =>
 			call<Offer>('setOfferDisposition', [id, ruling]),
 		restoreOffer: (id: string) => call<Offer>('restoreOffer', [id]),

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -11,8 +11,7 @@ import { failureText } from './failure'
 
 /**
  * The Offer ledger, live: a live query over the synced `offer` collection,
- * writes over RPC — architecture.md §12. A research turn's rows land as the
- * Guide commits them, so nothing here asks for them.
+ * writes over RPC — architecture.md §12.
  */
 
 export type OfferLedgerHandle = {

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -1,73 +1,53 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useLiveQuery } from '@tanstack/react-db'
+import { useState } from 'react'
 
 import { offerLedger, type OfferLedger } from '../../shared/ledger'
 import type { Offer } from '../../shared/offer'
+import { toOffer } from '../../shared/sync'
 import { acceptOffer } from '../plan/edits'
 import { refusalText } from '../plan/refusalText'
 import { useArticle } from './article'
 import { failureText } from './failure'
 
 /**
- * The Offer ledger, live. Rows come down once per store, since nothing announces
- * a row changing — §3. A research turn writes rows behind the client's back, so
- * the Chat calls `reload` when a turn records some.
+ * The Offer ledger, live: a live query over the synced `offer` collection,
+ * writes over RPC — architecture.md §12. A research turn's rows land as the
+ * Guide commits them, so nothing here asks for them.
  */
 
 export type OfferLedgerHandle = {
 	ledger: OfferLedger
-	/** Until the first `listOffers` answers. */
+	/** Until the collection's first snapshot arrives. */
 	loading: boolean
 	failure: string | null
 	accept: (offer: Offer) => void
 	decline: (offer: Offer) => void
 	restore: (offer: Offer) => void
-	/** For after a turn records rows this client did not ask for. */
-	reload: () => void
 }
 
 export function useOfferLedger(): OfferLedgerHandle {
-	const { offers: store, plan: connection } = useArticle()
+	const { offers: store, sync, plan: connection } = useArticle()
 	const { edit, plan } = connection
-	const [rows, setRows] = useState<Offer[] | null>(null)
 	const [failure, setFailure] = useState<string | null>(null)
-	const [reads, setReads] = useState(0)
 
-	const reload = useCallback(() => setReads((count) => count + 1), [])
+	// Ordered by `seq` in the query, the way the server orders the table.
+	const rows = useLiveQuery(
+		(q) => q.from({ offer: sync.offer }).orderBy(({ offer }) => offer.seq),
+		[sync.offer],
+	)
 
-	useEffect(() => {
-		let live = true
+	const offers = rows.data.map(toOffer)
 
-		store.listOffers().then(
-			(listed) => {
-				if (live) setRows(listed)
-			},
-			(error: unknown) => {
-				if (live) setFailure(failureText('The Offers did not load.', error))
-			},
-		)
-
-		return () => {
-			live = false
-		}
-	}, [store, reads])
-
-	/** In place: a ruling does not change the recorded order. */
-	function replace(ruled: Offer) {
-		setRows((held) =>
-			(held ?? []).map((offer) => (offer.id === ruled.id ? ruled : offer)),
-		)
-	}
-
-	function run(what: string, write: () => Promise<Offer>, then: (ruled: Offer) => void) {
+	/** The ruled row returns through the sync; only a failure needs handling. */
+	function run(what: string, write: () => Promise<Offer>) {
 		setFailure(null)
-		write().then(then, (error: unknown) => setFailure(failureText(what, error)))
+		write().catch((error: unknown) => setFailure(failureText(what, error)))
 	}
 
 	return {
-		ledger: offerLedger(rows ?? []),
-		loading: rows === null,
+		ledger: offerLedger(offers),
+		loading: !rows.isReady,
 		failure,
-		reload,
 
 		// Two writes against two stores, decoupled — §5, which says why this
 		// order and not the other. The Plan goes first because the copy is built
@@ -84,23 +64,19 @@ export function useOfferLedger(): OfferLedgerHandle {
 				return
 			}
 
-			run(
-				'This Offer was not Accepted.',
-				() => store.setOfferDisposition(offer.id, 'accepted'),
-				replace,
+			run('This Offer was not Accepted.', () =>
+				store.setOfferDisposition(offer.id, 'accepted'),
 			)
 		},
 
 		decline(offer) {
-			run(
-				'This Offer was not Declined.',
-				() => store.setOfferDisposition(offer.id, 'declined'),
-				replace,
+			run('This Offer was not Declined.', () =>
+				store.setOfferDisposition(offer.id, 'declined'),
 			)
 		},
 
 		restore(offer) {
-			run('This Offer was not restored.', () => store.restoreOffer(offer.id), replace)
+			run('This Offer was not restored.', () => store.restoreOffer(offer.id))
 		},
 	}
 }

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -49,9 +49,7 @@ import {
 	planSchema,
 	type ReferenceContent,
 	referenceContentSchema,
-	type ReferenceType,
 	sectionIds,
-	type Source,
 } from '../shared/plan'
 import {
 	type ReviewOutput,
@@ -63,10 +61,13 @@ import {
 	type RoundState,
 } from '../shared/review'
 import {
+	fromOffer,
 	type NoteRow,
+	type OfferRow,
 	type RoundRow,
 	syncCollections,
 	toNote,
+	toOffer,
 	toRound,
 } from '../shared/sync'
 import { chatTurn } from './llm/chat-turn'
@@ -75,35 +76,9 @@ import { reviewTurn } from './llm/review'
 import type { ReviewPack } from './llm/review-pack'
 import { webSearch, type WebSearch } from './llm/search'
 
-/** One Offer row as SQLite returns it. `this.sql` asserts the row type rather
+/** One Block row as SQLite returns it. `this.sql` asserts the row type rather
  * than checking it, and this class is the table's only writer, so the columns
- * are stated as what `createOffer` parsed before writing them. */
-type OfferRow = {
-	seq: number
-	id: string
-	type: ReferenceType
-	disposition: Disposition
-	text: string | null
-	source: string | null
-	note: string | null
-	created_at: number
-	decided_at: number | null
-}
-
-function toOffer(row: OfferRow): Offer {
-	return {
-		id: row.id,
-		type: row.type,
-		disposition: row.disposition,
-		text: row.text ?? undefined,
-		source: row.source === null ? undefined : (JSON.parse(row.source) as Source),
-		note: row.note ?? undefined,
-		createdAt: row.created_at,
-		decidedAt: row.decided_at,
-	}
-}
-
-/** One Block row as SQLite returns it, read the same way `OfferRow` is. */
+ * are stated as what `saveBlocks` parsed before writing them. */
 type BlockDbRow = {
 	id: string
 	ord: number
@@ -391,8 +366,10 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 *
 	 * `seq` orders it, not `created_at`: a Worker's clock does not advance
 	 * across local writes, so a research turn that records four Offers stamps
-	 * them with one or two milliseconds between them. */
-	@callable()
+	 * them with one or two milliseconds between them.
+	 *
+	 * Not `@callable` — a client reads its synced collection (§12); this reader
+	 * serves the dedupe below, this class, and its tests. */
 	listOffers(): Offer[] {
 		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY seq`.map(toOffer)
 	}
@@ -404,81 +381,93 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * Not `@callable`, and neither is `createOffer`: the research tool is the
 	 * only caller and it runs inside this Agent (§3, rule 4).
 	 */
-	recordOffers(batch: unknown): RecordedOffer[] {
+	async recordOffers(batch: unknown): Promise<RecordedOffer[]> {
 		const found = offerBatchSchema.parse(batch)
 
 		// Added to as the batch is written, so a turn dedupes against itself.
+		// Reading stays plain SQL: the oplog carries writes, not reads.
 		const held = new Map(
 			this.listOffers().map((offer) => [offerFingerprint(offer), offer]),
 		)
 
-		return found.map((material) => {
+		// One commit per Offer, so a subscriber watching a research turn sees
+		// each row land as it is written rather than the batch at the end.
+		const recorded: RecordedOffer[] = []
+		for (const material of found) {
 			const fingerprint = offerFingerprint(material)
 			const already = held.get(fingerprint)
-			if (already !== undefined) return { offer: already, duplicate: true }
+			if (already !== undefined) {
+				recorded.push({ offer: already, duplicate: true })
+				continue
+			}
 
-			const offer = this.createOffer(material)
+			const offer = await this.createOffer(material)
 			held.set(fingerprint, offer)
+			recorded.push({ offer, duplicate: false })
+		}
 
-			return { offer, duplicate: false }
-		})
+		return recorded
 	}
 
-	/** Starts Undecided. */
-	createOffer(content: ReferenceContent): Offer {
-		const offer: Offer = {
+	/** Starts Undecided. The resolved row carries the `seq` the table assigned,
+	 * which is the order the Ledger reads — so the Offer comes from the commit's
+	 * answer, not from `value`. */
+	async createOffer(content: ReferenceContent): Promise<Offer> {
+		const value = fromOffer({
 			...referenceContentSchema.parse(content),
 			id: crypto.randomUUID(),
 			disposition: 'undecided',
 			createdAt: Date.now(),
 			decidedAt: null,
-		}
+		})
 
-		this.sql`
-			INSERT INTO offer (id, type, disposition, text, source, note, created_at, decided_at)
-			VALUES (
-				${offer.id},
-				${offer.type},
-				${offer.disposition},
-				${offer.text ?? null},
-				${offer.source === undefined ? null : JSON.stringify(offer.source)},
-				${offer.note ?? null},
-				${offer.createdAt},
-				${offer.decidedAt}
-			)
-		`
+		const [batch] = await this.db.commit([
+			{ channel: 'offer', ops: [{ type: 'insert', value }] },
+		])
 
-		return offer
+		return toOffer(batch.ops[0].value as OfferRow)
 	}
 
 	/** Mark an Offer as having been Accepted or Declined by the client. */
 	@callable()
-	setOfferDisposition(id: string, disposition: Ruling): Offer {
+	async setOfferDisposition(id: string, disposition: Ruling): Promise<Offer> {
 		const ruling = rulingSchema.parse(disposition)
 
-		const rows = this.sql<OfferRow>`
-			UPDATE offer SET disposition = ${ruling}, decided_at = ${Date.now()}
-			WHERE id = ${id} RETURNING *
-		`
-		if (rows.length === 0) throw missingOffer(id)
+		// Read first, so an id no Offer carries throws rather than committing an
+		// update that moves nothing: a commit's answer carries no row count,
+		// where the `UPDATE ... RETURNING` this replaced did.
+		this.readOffer(id)
 
-		return toOffer(rows[0])
+		return this.moveOffer(id, ruling, Date.now())
 	}
 
 	/** Restore a Declined Offer back to Undecided. */
 	@callable()
-	restoreOffer(id: string): Offer {
+	async restoreOffer(id: string): Promise<Offer> {
 		// Read first: an Offer that is Accepted and one that does not exist have
-		// to be told apart, and one conditional UPDATE cannot do that.
+		// to be told apart, and one conditional update cannot do that.
 		const offer = this.readOffer(id)
 		if (offer.disposition !== 'declined') throw notDeclined(offer)
 
-		const rows = this.sql<OfferRow>`
-			UPDATE offer SET disposition = 'undecided', decided_at = NULL
-			WHERE id = ${id} RETURNING *
-		`
+		return this.moveOffer(id, 'undecided', null)
+	}
 
-		return toOffer(rows[0])
+	/** `decided_at` is the moment the writer ruled, so restoring to Undecided
+	 * clears it. The update value names only the columns it moves; the commit's
+	 * answer is the whole row. */
+	private async moveOffer(
+		id: string,
+		disposition: Disposition,
+		decidedAt: number | null,
+	): Promise<Offer> {
+		const [batch] = await this.db.commit([
+			{
+				channel: 'offer',
+				ops: [{ type: 'update', value: { id, disposition, decided_at: decidedAt } }],
+			},
+		])
+
+		return toOffer(batch.ops[0].value as OfferRow)
 	}
 
 	private readOffer(id: string): Offer {

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -111,6 +111,9 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * request, or RPC reaches this class — so the `!` holds. */
 	db!: PartyDbCore
 
+	/** Orders `recordOffers` against itself — see the dedupe there. */
+	private recording: Promise<unknown> = Promise.resolve()
+
 	/** Runs on every wake, so every statement here has to be idempotent. A new
 	 * table can join this one. A new column cannot go in bare — SQLite has no
 	 * ADD COLUMN IF NOT EXISTS, so the second wake throws on a duplicate and
@@ -384,6 +387,30 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	async recordOffers(batch: unknown): Promise<RecordedOffer[]> {
 		const found = offerBatchSchema.parse(batch)
 
+		// Queued against every other call, the way party-db serialises its own
+		// writes. The dedupe below reads the table and then commits, and
+		// `commit` always yields — so two turns offering one source would each
+		// read before the other's rows landed and write it twice. Parsing stays
+		// outside the queue: a batch that does not parse writes nothing.
+		const run = this.recording.then(
+			() => this.writeOffers(found),
+			() => this.writeOffers(found),
+		)
+		this.recording = run.catch(() => {})
+
+		return run
+	}
+
+	/**
+	 * One turn's rows, written under `recordOffers`'s queue.
+	 *
+	 * The queue orders calls inside one isolate, which is the only place two can
+	 * overlap: a call in flight holds the Agent awake, so nothing interleaves
+	 * across a hibernation. A guard that did not depend on that would be a
+	 * stored fingerprint column with a UNIQUE index, the way `round_one_running`
+	 * backs `startReview`.
+	 */
+	private async writeOffers(found: ReferenceContent[]): Promise<RecordedOffer[]> {
 		// Added to as the batch is built, so a turn dedupes against itself. A
 		// read, so no commit: §12's commit-only rule covers writes.
 		const held = new Map(

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -378,54 +378,40 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * One research turn. An entry this Article already carries comes back as it
 	 * stands, keeping the disposition the writer gave it — §5.
 	 *
-	 * Not `@callable`, and neither is `createOffer`: the research tool is the
-	 * only caller and it runs inside this Agent (§3, rule 4).
+	 * Not `@callable`: the research tool is the only caller and it runs inside
+	 * this Agent (§3, rule 4).
 	 */
 	async recordOffers(batch: unknown): Promise<RecordedOffer[]> {
 		const found = offerBatchSchema.parse(batch)
 
-		// Added to as the batch is written, so a turn dedupes against itself.
-		// Reading stays plain SQL: the oplog carries writes, not reads.
+		// Added to as the batch is built, so a turn dedupes against itself. A
+		// read, so no commit: §12's commit-only rule covers writes.
 		const held = new Map(
 			this.listOffers().map((offer) => [offerFingerprint(offer), offer]),
 		)
 
-		// One commit per Offer, so a subscriber watching a research turn sees
-		// each row land as it is written rather than the batch at the end.
-		const recorded: RecordedOffer[] = []
-		for (const material of found) {
+		const ops: { type: 'insert'; value: OfferRow }[] = []
+		const recorded = found.map((material): RecordedOffer => {
 			const fingerprint = offerFingerprint(material)
 			const already = held.get(fingerprint)
-			if (already !== undefined) {
-				recorded.push({ offer: already, duplicate: true })
-				continue
-			}
+			if (already !== undefined) return { offer: already, duplicate: true }
 
-			const offer = await this.createOffer(material)
+			const value = offerRow(material)
+			const offer = toOffer(value)
 			held.set(fingerprint, offer)
-			recorded.push({ offer, duplicate: false })
-		}
+			ops.push({ type: 'insert', value })
 
-		return recorded
-	}
-
-	/** Starts Undecided. The resolved row carries the `seq` the table assigned,
-	 * which is the order the Ledger reads — so the Offer comes from the commit's
-	 * answer, not from `value`. */
-	async createOffer(content: ReferenceContent): Promise<Offer> {
-		const value = fromOffer({
-			...referenceContentSchema.parse(content),
-			id: crypto.randomUUID(),
-			disposition: 'undecided',
-			createdAt: Date.now(),
-			decidedAt: null,
+			return { offer, duplicate: false }
 		})
 
-		const [batch] = await this.db.commit([
-			{ channel: 'offer', ops: [{ type: 'insert', value }] },
-		])
+		// One commit for the turn, the way `writeReview` writes a Round's Notes:
+		// seventeen findings cost one batch, one oplog entry and one frame per
+		// subscriber rather than seventeen of each. A batch with no ops would
+		// still reach every subscriber, so a turn that found nothing new
+		// commits nothing.
+		if (ops.length > 0) await this.db.commit([{ channel: 'offer', ops }])
 
-		return toOffer(batch.ops[0].value as OfferRow)
+		return recorded
 	}
 
 	/** Mark an Offer as having been Accepted or Declined by the client. */
@@ -433,12 +419,11 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	async setOfferDisposition(id: string, disposition: Ruling): Promise<Offer> {
 		const ruling = rulingSchema.parse(disposition)
 
-		// Read first, so an id no Offer carries throws rather than committing an
-		// update that moves nothing: a commit's answer carries no row count,
-		// where the `UPDATE ... RETURNING` this replaced did.
+		// Read first: an update that matches no row comes back as the value it
+		// was sent, so `moveOffer` cannot tell a miss from a hit.
 		this.readOffer(id)
 
-		return this.moveOffer(id, ruling, Date.now())
+		return this.moveOffer(id, ruling)
 	}
 
 	/** Restore a Declined Offer back to Undecided. */
@@ -449,17 +434,14 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 		const offer = this.readOffer(id)
 		if (offer.disposition !== 'declined') throw notDeclined(offer)
 
-		return this.moveOffer(id, 'undecided', null)
+		return this.moveOffer(id, 'undecided')
 	}
 
 	/** `decided_at` is the moment the writer ruled, so restoring to Undecided
 	 * clears it. The update value names only the columns it moves; the commit's
 	 * answer is the whole row. */
-	private async moveOffer(
-		id: string,
-		disposition: Disposition,
-		decidedAt: number | null,
-	): Promise<Offer> {
+	private async moveOffer(id: string, disposition: Disposition): Promise<Offer> {
+		const decidedAt = disposition === 'undecided' ? null : Date.now()
 		const [batch] = await this.db.commit([
 			{
 				channel: 'offer',
@@ -776,6 +758,19 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 
 		return toNote(rows[0])
 	}
+}
+
+/** One Offer as a row, ready to commit. Starts Undecided. The table fills in
+ * `seq` and `Offer` does not carry it, so a caller reads the same Offer off
+ * this row as off the commit's answer. */
+function offerRow(content: ReferenceContent): OfferRow {
+	return fromOffer({
+		...referenceContentSchema.parse(content),
+		id: crypto.randomUUID(),
+		disposition: 'undecided',
+		createdAt: Date.now(),
+		decidedAt: null,
+	})
 }
 
 /** One Note as a row, ready to commit. Starts proposed; the anchor is settled

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -90,7 +90,9 @@ const recordOffers = tool({
 		if (agent === undefined)
 			throw new Error('The Offer tool ran outside an Article Agent.')
 
-		return agent.recordOffers(offers).map(({ offer, duplicate }) => ({
+		const recorded = await agent.recordOffers(offers)
+
+		return recorded.map(({ offer, duplicate }) => ({
 			id: offer.id,
 			name: offer.source?.title ?? offer.text,
 			disposition: offer.disposition,

--- a/src/shared/sync.ts
+++ b/src/shared/sync.ts
@@ -49,9 +49,9 @@ export const roundRowSchema = z.object({
 })
 export type RoundRow = z.infer<typeof roundRowSchema>
 
-/** One `offer` row as it travels. An absent field is null on the wire and
- * `undefined` on an `Offer` — §4's one spelling per state, either side of a
- * column that has only the one way to say "nothing here". */
+/** One `offer` row as it travels. A column says "nothing here" with null and
+ * the `Offer` field says it by being absent; `toOffer` and `fromOffer` map
+ * between the two. */
 export const offerRowSchema = z.object({
 	seq: z.number().optional(),
 	id: z.string(),
@@ -118,12 +118,11 @@ export function fromRound(round: Round): RoundRow {
 	}
 }
 
-/** The inverse of `toOffer`, for code that builds rows — the Article Agent's
- * insert, which leaves `seq` to the table, and the Storybook mocks, which
- * stand in for it. */
-export function fromOffer(offer: Offer, seq?: number): OfferRow {
+/** The inverse of `toOffer`, for code that builds rows. `seq` is left to the
+ * table, so a caller that stands in for it — the Storybook mocks — sets it on
+ * the row this returns. */
+export function fromOffer(offer: Offer): OfferRow {
 	return {
-		...(seq === undefined ? {} : { seq }),
 		id: offer.id,
 		type: offer.type,
 		disposition: offer.disposition,

--- a/src/shared/sync.ts
+++ b/src/shared/sync.ts
@@ -2,15 +2,19 @@ import { definePartyCollection } from 'party-db'
 import { z } from 'zod'
 
 import { type Note, type NoteAnchor, noteDispositions } from './note'
+import { dispositions, type Offer } from './offer'
+import { referenceTypeSchema, type Source } from './plan/schema'
 import { reviewDepths, type Round, type RoundPassage, roundStates } from './review'
 
 /**
- * The `note` and `round` party-db collections — docs/architecture.md §12.
+ * The `note`, `round` and `offer` party-db collections — docs/architecture.md
+ * §12.
  *
  * The schemas spell the columns as the tables do: snake_case names, JSON
- * columns (`anchor`, `passages`) as the text they store. `z.string()` for the
- * JSON columns sidesteps party-db's Zod-v3-only column codec (party-db#45);
- * `toNote` and `toRound` parse the text into the shapes the app reads.
+ * columns (`anchor`, `passages`, `source`) as the text they store. `z.string()`
+ * for the JSON columns sidesteps party-db's Zod-v3-only column codec
+ * (party-db#45); `toNote`, `toRound` and `toOffer` parse the text into the
+ * shapes the app reads.
  */
 
 /** One `note` row as it travels. `seq` is assigned by the table, so a write
@@ -45,6 +49,23 @@ export const roundRowSchema = z.object({
 })
 export type RoundRow = z.infer<typeof roundRowSchema>
 
+/** One `offer` row as it travels. An absent field is null on the wire and
+ * `undefined` on an `Offer` — §4's one spelling per state, either side of a
+ * column that has only the one way to say "nothing here". */
+export const offerRowSchema = z.object({
+	seq: z.number().optional(),
+	id: z.string(),
+	type: referenceTypeSchema,
+	disposition: z.enum(dispositions),
+	text: z.string().nullable(),
+	/** JSON text of a `Source`. */
+	source: z.string().nullable(),
+	note: z.string().nullable(),
+	created_at: z.number(),
+	decided_at: z.number().nullable(),
+})
+export type OfferRow = z.infer<typeof offerRowSchema>
+
 /** name === channel === table name, on both sides of the wire. */
 export const noteCollection = definePartyCollection({
 	name: 'note',
@@ -58,7 +79,13 @@ export const roundCollection = definePartyCollection({
 	schema: roundRowSchema,
 })
 
-export const syncCollections = [noteCollection, roundCollection]
+export const offerCollection = definePartyCollection({
+	name: 'offer',
+	key: 'id',
+	schema: offerRowSchema,
+})
+
+export const syncCollections = [noteCollection, roundCollection, offerCollection]
 
 /** The inverse of `toNote`, for code that builds rows — the Storybook mocks. */
 export function fromNote(note: Note, seq: number): NoteRow {
@@ -91,6 +118,23 @@ export function fromRound(round: Round): RoundRow {
 	}
 }
 
+/** The inverse of `toOffer`, for code that builds rows — the Article Agent's
+ * insert, which leaves `seq` to the table, and the Storybook mocks, which
+ * stand in for it. */
+export function fromOffer(offer: Offer, seq?: number): OfferRow {
+	return {
+		...(seq === undefined ? {} : { seq }),
+		id: offer.id,
+		type: offer.type,
+		disposition: offer.disposition,
+		text: offer.text ?? null,
+		source: offer.source === undefined ? null : JSON.stringify(offer.source),
+		note: offer.note ?? null,
+		created_at: offer.createdAt,
+		decided_at: offer.decidedAt,
+	}
+}
+
 export function toNote(row: NoteRow): Note {
 	return {
 		id: row.id,
@@ -116,5 +160,18 @@ export function toRound(row: RoundRow): Round {
 		failure: row.failure,
 		startedAt: row.started_at,
 		finishedAt: row.finished_at,
+	}
+}
+
+export function toOffer(row: OfferRow): Offer {
+	return {
+		id: row.id,
+		type: row.type,
+		disposition: row.disposition,
+		text: row.text ?? undefined,
+		source: row.source === null ? undefined : (JSON.parse(row.source) as Source),
+		note: row.note ?? undefined,
+		createdAt: row.created_at,
+		decidedAt: row.decided_at,
 	}
 }

--- a/test/client/chat-offers.test.ts
+++ b/test/client/chat-offers.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { readRecordedOffers, recordedOfferIds } from '../../src/client/chat/offers'
+import { readRecordedOffers } from '../../src/client/chat/offers'
 import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
-import { toolPart, transcript } from './chat-fixtures'
+import { toolPart } from './chat-fixtures'
 
-/** Reading a research turn's result, which is the Ledger's only signal that its
- * list moved — §3. */
+/** Reading a research turn's result, which is what the transcript's Offer cards
+ * are drawn from. The rows themselves arrive through the sync — §12. */
 
 const part = (state: string, extra: Record<string, unknown> = {}) =>
 	toolPart(recordOffersTool, state, { input: { offers: [] }, ...extra })
@@ -35,28 +35,5 @@ describe('a research turn', () => {
 		})
 
 		expect(readRecordedOffers(proposal as never)).toBeNull()
-	})
-
-	/** Two turns can offer the same source: the second comes back marked a
-	 * duplicate, naming the row the first one wrote. */
-	it('names each id once, in the order the turns recorded them', () => {
-		const ids = recordedOfferIds([
-			...transcript(part('output-available', { output: recorded })),
-			{
-				id: 'm-2',
-				role: 'assistant',
-				parts: [
-					part('output-available', {
-						toolCallId: 'call-3',
-						output: [
-							{ id: 'offer-b', disposition: 'accepted', duplicate: true },
-							{ id: 'offer-c', disposition: 'undecided', duplicate: false },
-						],
-					}),
-				],
-			},
-		])
-
-		expect(ids).toEqual(['offer-a', 'offer-b', 'offer-c'])
 	})
 })

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -1,4 +1,4 @@
-import { env, evictDurableObject, runInDurableObject } from 'cloudflare:test'
+import { evictDurableObject } from 'cloudflare:test'
 import { describe, expect, it } from 'vitest'
 
 import type { RecordedOffer } from '../../src/server/article-agent'
@@ -8,31 +8,27 @@ import type { Plan, ReferenceContent } from '../../src/shared/plan'
 import { emptyPlan, isPlanRefused } from '../../src/shared/plan'
 import { makeNode, makePlan, makeReference } from '../shared/plan-fixtures'
 import { openAgentSocket } from './agent-socket'
+import { agentStub, inAgent } from './scripted'
 
-/** Record an Offer the way the Chat will: inside the Agent, not over RPC.
- * `createOffer` is deliberately not `@callable`, so a test reaches it the same
- * way the research tool does. The Article Agent must already be awake, which
- * every caller here arranges by opening a socket first. */
-function createOffer(name: string, content: ReferenceContent): Promise<Offer> {
-	const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName(name))
-
-	return runInDurableObject(stub, (agent) => agent.createOffer(content))
+/** One research turn, the way the tool will run it: inside the Agent, not over
+ * RPC. The Article Agent must already be awake, which every caller here
+ * arranges by opening a socket first. */
+function recordOffers(name: string, batch: unknown): Promise<RecordedOffer[]> {
+	return inAgent(name, (agent) => agent.recordOffers(batch))
 }
 
-/** One research turn, the way the tool will run it. */
-function recordOffers(name: string, batch: unknown): Promise<RecordedOffer[]> {
-	const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName(name))
+/** One Offer, as a turn that found one thing. */
+async function createOffer(name: string, content: ReferenceContent): Promise<Offer> {
+	const [recorded] = await recordOffers(name, [content])
 
-	return runInDurableObject(stub, (agent) => agent.recordOffers(batch))
+	return recorded.offer
 }
 
 /** Every Offer, read inside the Agent. `listOffers` is not `@callable`: a
  * client reads its synced `offer` collection (§12), which `sync.test.ts`
  * covers. */
 function listOffers(name: string): Promise<Offer[]> {
-	const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName(name))
-
-	return runInDurableObject(stub, (agent) => agent.listOffers())
+	return inAgent(name, (agent) => agent.listOffers())
 }
 
 /** A Plan that parses: one Section, and one Reference placed at it. */
@@ -121,19 +117,17 @@ describe('the Plan in Article Agent state', () => {
 
 describe('Offers in the Article Agent', () => {
 	// `@callable` is the whole allowlist of what a browser may invoke on this
-	// Durable Object, so the set is worth naming — `createOffer` is absent
+	// Durable Object, so the set is worth naming — `recordOffers` is absent
 	// because only the Chat records an Offer. It also proves the decorator
 	// survived the build: oxc does not lower one, and `agents/vite` does.
 	it('marks every writer-facing method callable, and nothing else', async () => {
-		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('callable-set'))
-
-		const methods = await runInDurableObject(stub, (agent) => [
+		const methods = await inAgent('callable-set', (agent) => [
 			...agent.getCallableMethods().keys(),
 		])
 
 		// Exact, so reaching the browser is a decision rather than a side effect
-		// of adding a method: `recordOffers` and `createOffer` stay off it,
-		// because the Guide writes those and the writer never authors one.
+		// of adding a method: `recordOffers` stays off it, because the Guide
+		// writes Offers and the writer never authors one.
 		// `listNotes`, `listRounds` and `listOffers` are off it too — a client
 		// reads all three from its synced collections (§12), not over RPC.
 		expect(methods.sort()).toEqual([
@@ -206,22 +200,19 @@ describe('Offers in the Article Agent', () => {
 	// clock barely advances — so `created_at` cannot order them and `seq` does.
 	it('lists a batch recorded in one turn in the order it was recorded', async () => {
 		await openAgentSocket('offer-batch')
-		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-batch'))
+		const titles = ['first', 'second', 'third', 'fourth']
 
-		const titles = await runInDurableObject(stub, async (agent) => {
-			const recorded: (string | undefined)[] = []
-			for (const title of ['first', 'second', 'third', 'fourth']) {
-				const offer = await agent.createOffer({ type: 'link', source: { title } })
-				recorded.push(offer.source?.title)
-			}
+		const recorded = await recordOffers(
+			'offer-batch',
+			titles.map((title) => ({ type: 'link', source: { title } })),
+		)
 
-			return {
-				recorded,
-				listed: agent.listOffers().map((offer) => offer.source?.title),
-			}
-		})
-
-		expect(titles.listed).toEqual(titles.recorded)
+		expect(recorded.map((entry) => entry.offer.source?.title)).toEqual(titles)
+		await expect(
+			listOffers('offer-batch').then((offers) =>
+				offers.map((offer) => offer.source?.title),
+			),
+		).resolves.toEqual(titles)
 	})
 
 	it('keeps its Offers through a hibernation cycle', async () => {
@@ -232,9 +223,7 @@ describe('Offers in the Article Agent', () => {
 
 		// The socket hibernates rather than closing, so the next call wakes the
 		// Article Agent with its in-memory state gone and onStart run again.
-		await evictDurableObject(
-			env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-hibernation')),
-		)
+		await evictDurableObject(agentStub('offer-hibernation'))
 
 		const offers = await listOffers('offer-hibernation')
 

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -269,6 +269,21 @@ describe('Offers in the Article Agent', () => {
 		await expect(listOffers('offer-reoffered')).resolves.toHaveLength(1)
 	})
 
+	// Two tool calls in one step run concurrently, and `commit` yields — so the
+	// dedupe has to read and write under one queue rather than once per call.
+	it('records one Offer when two concurrent turns offer the same source', async () => {
+		await openAgentSocket('offer-concurrent')
+
+		const [first, second] = await inAgent('offer-concurrent', (agent) =>
+			Promise.all([agent.recordOffers([reference]), agent.recordOffers([reference])]),
+		)
+
+		expect(first[0].duplicate).toBe(false)
+		expect(second[0].duplicate).toBe(true)
+		expect(second[0].offer.id).toBe(first[0].offer.id)
+		await expect(listOffers('offer-concurrent')).resolves.toHaveLength(1)
+	})
+
 	it('records one turn offering the same source twice as one Offer', async () => {
 		await openAgentSocket('offer-batch-duplicate')
 

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -26,6 +26,15 @@ function recordOffers(name: string, batch: unknown): Promise<RecordedOffer[]> {
 	return runInDurableObject(stub, (agent) => agent.recordOffers(batch))
 }
 
+/** Every Offer, read inside the Agent. `listOffers` is not `@callable`: a
+ * client reads its synced `offer` collection (§12), which `sync.test.ts`
+ * covers. */
+function listOffers(name: string): Promise<Offer[]> {
+	const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName(name))
+
+	return runInDurableObject(stub, (agent) => agent.listOffers())
+}
+
 /** A Plan that parses: one Section, and one Reference placed at it. */
 const plan = makePlan({
 	title: 'The permit queue',
@@ -125,11 +134,10 @@ describe('Offers in the Article Agent', () => {
 		// Exact, so reaching the browser is a decision rather than a side effect
 		// of adding a method: `recordOffers` and `createOffer` stay off it,
 		// because the Guide writes those and the writer never authors one.
-		// `listNotes` and `listRounds` are off it too — a client reads Notes and
-		// Rounds from its synced collections (§12), not over RPC.
+		// `listNotes`, `listRounds` and `listOffers` are off it too — a client
+		// reads all three from its synced collections (§12), not over RPC.
 		expect(methods.sort()).toEqual([
 			'listBlocks',
-			'listOffers',
 			'resolveNote',
 			'restoreNote',
 			'restoreOffer',
@@ -141,7 +149,7 @@ describe('Offers in the Article Agent', () => {
 	})
 
 	it('records an Offer as Undecided and lists it', async () => {
-		const writer = await openAgentSocket('offer-create')
+		await openAgentSocket('offer-create')
 
 		const offer = await createOffer('offer-create', quote)
 
@@ -150,7 +158,7 @@ describe('Offers in the Article Agent', () => {
 			disposition: 'undecided',
 			decidedAt: null,
 		})
-		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual([offer])
+		await expect(listOffers('offer-create')).resolves.toEqual([offer])
 	})
 
 	// No socket first: parsed before any row is written, so it refuses without
@@ -200,13 +208,15 @@ describe('Offers in the Article Agent', () => {
 		await openAgentSocket('offer-batch')
 		const stub = env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-batch'))
 
-		const titles = await runInDurableObject(stub, (agent) => {
-			const recorded = ['first', 'second', 'third', 'fourth'].map((title) =>
-				agent.createOffer({ type: 'link', source: { title } }),
-			)
+		const titles = await runInDurableObject(stub, async (agent) => {
+			const recorded: (string | undefined)[] = []
+			for (const title of ['first', 'second', 'third', 'fourth']) {
+				const offer = await agent.createOffer({ type: 'link', source: { title } })
+				recorded.push(offer.source?.title)
+			}
 
 			return {
-				recorded: recorded.map((offer) => offer.source?.title),
+				recorded,
 				listed: agent.listOffers().map((offer) => offer.source?.title),
 			}
 		})
@@ -226,7 +236,7 @@ describe('Offers in the Article Agent', () => {
 			env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-hibernation')),
 		)
 
-		const offers = await writer.call<Offer[]>('listOffers')
+		const offers = await listOffers('offer-hibernation')
 
 		expect(offers.map((offer) => [offer.id, offer.disposition])).toEqual([
 			[kept.id, 'undecided'],
@@ -235,12 +245,12 @@ describe('Offers in the Article Agent', () => {
 	})
 
 	it('records a research turn as a batch, in the order the model gave it', async () => {
-		const writer = await openAgentSocket('offer-batch-record')
+		await openAgentSocket('offer-batch-record')
 
 		const recorded = await recordOffers('offer-batch-record', [quote, reference])
 
 		expect(recorded.map((entry) => entry.duplicate)).toEqual([false, false])
-		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual(
+		await expect(listOffers('offer-batch-record')).resolves.toEqual(
 			recorded.map((entry) => entry.offer),
 		)
 	})
@@ -251,12 +261,7 @@ describe('Offers in the Article Agent', () => {
 		await expect(
 			recordOffers('offer-batch-refused', [quote, { type: 'quote' }]),
 		).rejects.toThrow(/of type quote carries a text/)
-		await expect(
-			runInDurableObject(
-				env.ArticleAgent.get(env.ArticleAgent.idFromName('offer-batch-refused')),
-				(agent) => agent.listOffers(),
-			),
-		).resolves.toEqual([])
+		await expect(listOffers('offer-batch-refused')).resolves.toEqual([])
 	})
 
 	it('recognises a source turned up again as the Offer it already carries', async () => {
@@ -272,7 +277,7 @@ describe('Offers in the Article Agent', () => {
 		expect(again.duplicate).toBe(true)
 		expect(again.offer.id).toBe(first.offer.id)
 		expect(again.offer.disposition).toBe('accepted')
-		await expect(writer.call<Offer[]>('listOffers')).resolves.toHaveLength(1)
+		await expect(listOffers('offer-reoffered')).resolves.toHaveLength(1)
 	})
 
 	it('records one turn offering the same source twice as one Offer', async () => {
@@ -354,7 +359,7 @@ describe('Accepting an Offer into the Plan', () => {
 			text: 'We did not decide.',
 			nodeId: 'n1',
 		})
-		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual([ruled])
+		await expect(listOffers('accept-and-edit')).resolves.toEqual([ruled])
 	})
 
 	it('Declines and restores without the Plan hearing about it', async () => {
@@ -384,7 +389,7 @@ describe('Accepting an Offer into the Plan', () => {
 
 		const held = await readPlan('accept-no-ruling')
 		expect(held.references.map((copy) => copy.provenance.offerId)).toEqual([offer.id])
-		await expect(writer.call<Offer[]>('listOffers')).resolves.toEqual([offer])
+		await expect(listOffers('accept-no-ruling')).resolves.toEqual([offer])
 
 		// Accepting again sends the ruling. `acceptOffer` finds the copy on the
 		// Provenance and builds no op, so the Plan is not written a second time.

--- a/test/worker/sync.test.ts
+++ b/test/worker/sync.test.ts
@@ -2,17 +2,26 @@ import { SELF } from 'cloudflare:test'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { Round } from '../../src/shared/review'
-import type { NoteRow } from '../../src/shared/sync'
+import type { NoteRow, OfferRow } from '../../src/shared/sync'
 import { answers, ask, response, settled } from './review-fixtures'
 import { inAgent, scriptModel } from './scripted'
 import { isBatch, openSyncSocket, postWrite } from './sync-socket'
 
 /**
  * The party-db room composed into the Article Agent — architecture.md §12: a
- * subscriber sees Notes and Rounds land as the Guide commits them and nothing
- * else, an app socket sees no batches, a reconnect catches up from `?since`,
- * and a client collection write is refused.
+ * subscriber sees Notes, Rounds and Offers land as the Guide commits them and
+ * nothing else, an app socket sees no batches, a reconnect catches up from
+ * `?since`, and a client collection write is refused.
  */
+
+/** What one research turn offers. */
+const found = [
+	{
+		type: 'quote' as const,
+		text: 'We did not decide to stop building.',
+		source: { title: 'Permit throughput in six mid-sized cities', year: 2023 },
+	},
+]
 
 /** Run one scripted Review to its settled Round. */
 async function reviewed(name: string): Promise<Round> {
@@ -151,5 +160,57 @@ describe('the sync socket', () => {
 		// The guards held: the row the Guide wrote is still proposed.
 		const notes = await inAgent('sync-no-writes', (agent) => agent.listNotes())
 		expect(notes[0].disposition).toBe('proposed')
+	})
+})
+
+describe('the Offer collection on the sync socket', () => {
+	it('carries a research turn to a subscriber that never asked for it', async () => {
+		await SELF.fetch('https://harness.test/agents/article-agent/sync-offers')
+		const reader = await openSyncSocket('sync-offers')
+		expect((await reader.next('offer')).ops).toEqual([])
+
+		// A research turn writes behind the client's back — nothing on the app
+		// socket announces it, and nothing has to.
+		const [recorded] = await inAgent('sync-offers', (agent) => agent.recordOffers(found))
+
+		const written = await reader.next('offer')
+		expect(written.ops[0]).toMatchObject({
+			type: 'insert',
+			value: { id: recorded.offer.id, disposition: 'undecided', decided_at: null },
+		})
+		// The source column travels as the JSON text it stores.
+		const row = written.ops[0].value as OfferRow
+		expect(JSON.parse(row.source ?? 'null')).toEqual(found[0].source)
+	})
+
+	it('carries a ruling back to every subscriber', async () => {
+		await SELF.fetch('https://harness.test/agents/article-agent/sync-rulings')
+		const [recorded] = await inAgent('sync-rulings', (agent) => agent.recordOffers(found))
+
+		// Two clients on one Article: the one that did not rule hears it too.
+		const ruling = await openSyncSocket('sync-rulings')
+		const other = await openSyncSocket('sync-rulings')
+		await ruling.next('offer')
+		await other.next('offer')
+
+		await inAgent('sync-rulings', (agent) =>
+			agent.setOfferDisposition(recorded.offer.id, 'declined'),
+		)
+
+		for (const reader of [ruling, other]) {
+			const declined = await reader.next('offer')
+			expect(declined.ops[0]).toMatchObject({
+				type: 'update',
+				value: { id: recorded.offer.id, disposition: 'declined' },
+			})
+		}
+
+		await inAgent('sync-rulings', (agent) => agent.restoreOffer(recorded.offer.id))
+
+		const restored = await other.next('offer')
+		expect(restored.ops[0]).toMatchObject({
+			type: 'update',
+			value: { disposition: 'undecided', decided_at: null },
+		})
 	})
 })


### PR DESCRIPTION
The second pass #92 set up. The `offer` table joins `note` and `round` as a
collection: the Ledger reads a live query, `createOffer` and the two ruling
RPCs write through `commit()`, and a research turn's rows reach every
connected client with nothing announcing them.

What that deleted is the measure of the pass — `listOffers` as a `@callable`,
the Ledger's load-once contract and its local row patching, the `reload`
callback, and `recordedOfferIds`, which read fresh ids out of the transcript
so the Chat could ask for them.

The dedupe in `recordOffers` is unchanged: it reads before writing, and reads
stay plain SQL.

Claude-Session: https://claude.ai/code/session_01TdJk7NX83xopM8Kduv6Mrm
Co-authored-by: Claude <noreply@anthropic.com>