### PR TITLE
Add fingerprint column and unique index to deduplicate offers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -32,7 +32,9 @@
     {
       // `this.sql` is a statement written as a tagged template, so a write
       // discards the rows it returns. Only the Agents SDK spells it that way.
-      "files": ["src/server/**"],
+      // One worker test reaches the same tag, to stand the `offer` table up in
+      // the shape a deployed Article has.
+      "files": ["src/server/**", "test/worker/article-agent.test.ts"],
       "rules": { "no-unused-expressions": ["error", { "allowTaggedTemplates": true }] }
     }
   ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -648,6 +648,26 @@ issue #11. `startReview` writes a Round row, answers with it, and carries on und
   across an `await` (#9), which a field could not — in-memory state does not survive
   hibernation, and a check-then-write races itself.
 
+**One Offer per source per Article**, guarded by the fingerprint map and enforced by
+the table: a UNIQUE index over a stored `fingerprint` column. The map in `recordOffers`
+gives the answer the Guide reads — the row already there, still carrying the disposition
+the writer gave it — and the index is what makes it hold when two turns of one step
+interleave across `commit`'s await (#96), which the map alone cannot: it is read from the
+table, so a call that has not committed yet is invisible to the one beside it. The
+recovery is a loop rather than a catch, because party-db commits a call in one
+transaction and the refused row takes the turn's other rows down with it. Neither
+`recordOffers` nor `createRound` reads the rejection's message to classify it — both
+re-read and let the table say who won.
+
+**The column is required, and the migration is what buys that.** An `offer` table that
+predates it is read out on the next wake, dropped, rebuilt by the same DDL a new Article
+gets, and refilled under the ids and rulings the writer left. The refill is
+`INSERT OR IGNORE`, so an Article already holding two rows for one source keeps the row
+the writer saw first and loses its twin. ALTERing the column in would have wanted a
+default for the rows already there, and would have left that pair unindexable — so the
+column would be nullable, and the null would reach the dedupe and every reader past it.
+One-time migration code is cheaper than a case every read carries.
+
 **Notes, Rounds and Offers are party-db collections, hosted by the Article Agent
 itself.** This is #84's hosting question, answered: the Agent cannot subclass
 `PartyDbServer` — it already extends `AIChatAgent` — so it holds a `PartyDbCore` built

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -648,25 +648,28 @@ issue #11. `startReview` writes a Round row, answers with it, and carries on und
   across an `await` (#9), which a field could not — in-memory state does not survive
   hibernation, and a check-then-write races itself.
 
-**One Offer per source per Article**, guarded by the fingerprint map and enforced by
-the table: a UNIQUE index over a stored `fingerprint` column. The map in `recordOffers`
-gives the answer the Guide reads — the row already there, still carrying the disposition
-the writer gave it — and the index is what makes it hold when two turns of one step
-interleave across `commit`'s await (#96), which the map alone cannot: it is read from the
-table, so a call that has not committed yet is invisible to the one beside it. The
-recovery is a loop rather than a catch, because party-db commits a call in one
-transaction and the refused row takes the turn's other rows down with it. Neither
-`recordOffers` nor `createRound` reads the rejection's message to classify it — both
-re-read and let the table say who won.
+**One Offer per source per Article**, enforced by a UNIQUE index over a stored
+`fingerprint` column rather than by the map §5 describes. Syncing the Offers is what
+forced that: `recordOffers` has to reach `commit()`, party-db's queue defers the commit to
+a microtask even against embedded SQLite, and the AI SDK runs a step's parallel tool calls
+concurrently — so two turns of one step both read before either wrote. The map is built
+from the table, so an uncommitted call is invisible to the one beside it. This is
+`round_one_running` one table over, on a sharper constraint: the Review guard needs a
+hibernation to race, and this one needs only an await. If the Offers stop syncing, the
+dedupe is a synchronous read-and-insert again and the index can go.
 
-**The column is required, and the migration is what buys that.** An `offer` table that
-predates it is read out on the next wake, dropped, rebuilt by the same DDL a new Article
-gets, and refilled under the ids and rulings the writer left. The refill is
-`INSERT OR IGNORE`, so an Article already holding two rows for one source keeps the row
-the writer saw first and loses its twin. ALTERing the column in would have wanted a
-default for the rows already there, and would have left that pair unindexable — so the
-column would be nullable, and the null would reach the dedupe and every reader past it.
-One-time migration code is cheaper than a case every read carries.
+**A refused commit is re-read, not parsed.** `commit()` throws the adapter's error as it
+comes — party-db classifies rejections only on its HTTP write path, and its embedded
+SQLite adapter implements none of the optional `classifyError` hook the Postgres one
+fills in. The alternative is matching a SQLite message string in app code, which changes
+with the adapter. So `recordOffers` and `createRound` both re-read and let the table say
+who won, and so should the next guard. A typed rejection out of `commit()` retires this.
+
+**A Durable Object's SQLite migrates on the wake.** `migrations_dir` in `wrangler.jsonc`
+belongs to the D1 binding, and there are as many Article databases as there are Articles.
+No wrangler mechanism reaches inside one, so `onStart` is the only code that runs against
+them all — and it runs on every wake, which is what makes a new column need a
+`pragma_table_info` guard where a new table needs only `IF NOT EXISTS`.
 
 **Notes, Rounds and Offers are party-db collections, hosted by the Article Agent
 itself.** This is #84's hosting question, answered: the Agent cannot subclass
@@ -701,6 +704,14 @@ three types, implemented over `commit()` so the ruled row syncs. Nothing announc
 Review settling or a turn recording any more — the rows landing is the announcement,
 which is what deleted the `review_finished` frame, the Notes Panel's poll, its reload
 counter, and the Ledger's.
+
+**One call is one transaction, so a batch recovers whole and not by the row.** party-db
+runs a call's ops in one transaction, with the oplog's compaction inside it, so the oplog
+never has a torn floor — a half-landed batch would leave a subscriber's delta describing
+rows the table does not have. The cost falls on the two batched writes above: one refused
+row takes the call's other rows with it, so a caller that meets a rejection re-decides the
+whole batch. `recordOffers` re-dedupes against what landed and commits the remainder.
+Per-op rejection in party-db would make that loop a catch again.
 
 **The wire rows are the table rows.** `src/shared/sync.ts` declares the three collections'
 schemas as the columns stand — snake_case, JSON columns as the text they store — and owns

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -111,15 +111,17 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * request, or RPC reaches this class — so the `!` holds. */
 	db!: PartyDbCore
 
-	/** Orders `recordOffers` against itself — see the dedupe there. */
-	private recording: Promise<unknown> = Promise.resolve()
-
 	/** Runs on every wake, so every statement here has to be idempotent. A new
 	 * table can join this one. A new column cannot go in bare — SQLite has no
 	 * ADD COLUMN IF NOT EXISTS, so the second wake throws on a duplicate and
 	 * takes the Chat and the Plan down with it. `pragma_table_info` is what makes
 	 * a guarded ALTER possible when a column does have to change. */
 	async onStart(): Promise<void> {
+		// Read out and dropped, so the statement below builds the current shape
+		// over an `offer` table that predates the fingerprint column. Empty on
+		// every wake but the one that first meets an Article written before it.
+		const carried = this.drainOldOfferTable()
+
 		this.sql`
 			CREATE TABLE IF NOT EXISTS offer (
 				seq INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -129,10 +131,18 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 				text TEXT,
 				source TEXT,
 				note TEXT,
+				fingerprint TEXT NOT NULL,
 				created_at INTEGER NOT NULL,
 				decided_at INTEGER
 			)
 		`
+
+		// At most one row may carry a given fingerprint — §12 for the argument.
+		this.sql`
+			CREATE UNIQUE INDEX IF NOT EXISTS offer_one_per_fingerprint
+			ON offer (fingerprint)
+		`
+		this.restoreOffers(carried)
 
 		// One row per Block, ordered by a fractional index the client assigns.
 		// `json` is the editor's own document JSON for that Block, which is why
@@ -220,6 +230,64 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 		const cutOff = this.sql<{ id: string }>`SELECT id FROM round WHERE state = 'running'`
 		if (cutOff.length > 0) {
 			await this.failRound(cutOff[0].id, 'The Review was cut off by a restart.')
+		}
+	}
+
+	/**
+	 * One half of the fingerprint column's migration: every Offer on an `offer`
+	 * table that predates the column, with the table dropped behind them.
+	 * `restoreOffers` puts them back once `onStart` has rebuilt it.
+	 *
+	 * Dropping and rebuilding rather than ALTERing keeps the column NOT NULL. An
+	 * ALTER would need a default for the rows already there, and an Article
+	 * carrying the double-record the column exists to stop could not take the
+	 * index at all — so the null case would reach the dedupe and every reader
+	 * past it. The migration pays that instead, once (§12).
+	 */
+	private drainOldOfferTable(): OfferRow[] {
+		// `pragma_table_info` answers nothing for a table that does not exist,
+		// which is what a new Article reaches this with.
+		const columns = this.sql<{ name: string }>`
+			SELECT name FROM pragma_table_info('offer')
+		`
+		if (columns.length === 0) return []
+		if (columns.some((column) => column.name === 'fingerprint')) return []
+
+		// `this.sql` asserts the row type rather than checking it, and these rows
+		// are one column short of it until the map supplies what the old table
+		// never stored.
+		const carried = this.sql<OfferRow>`SELECT * FROM offer ORDER BY seq`
+		this.sql`DROP TABLE offer`
+
+		return carried.map((row) => ({ ...row, fingerprint: offerFingerprint(toOffer(row)) }))
+	}
+
+	/**
+	 * The other half: the drained Offers, back on the rebuilt table under the
+	 * ids and rulings the writer left them with.
+	 *
+	 * `OR IGNORE` is what makes the migration aggressive. An Article written
+	 * before the index could hold two rows for one source, and the index refuses
+	 * the second — so the row the writer saw first survives, in `seq` order, and
+	 * its twin is gone rather than carried as a case the dedupe has to know
+	 * about.
+	 *
+	 * Raw SQL against a synced table, which §12 forbids the app: this runs
+	 * before the party-db core is built, and every row it writes is one the
+	 * oplog already announced when the Guide first recorded it. `seq` is not
+	 * carried — the table assigns fresh ones in the same order, and nothing
+	 * outside the table holds an Offer's.
+	 */
+	private restoreOffers(carried: OfferRow[]): void {
+		for (const row of carried) {
+			this.sql`
+				INSERT OR IGNORE INTO offer
+					(id, type, disposition, text, source, note, fingerprint, created_at, decided_at)
+				VALUES (
+					${row.id}, ${row.type}, ${row.disposition}, ${row.text}, ${row.source},
+					${row.note}, ${row.fingerprint}, ${row.created_at}, ${row.decided_at}
+				)
+			`
 		}
 	}
 
@@ -372,14 +440,27 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * them with one or two milliseconds between them.
 	 *
 	 * Not `@callable` — a client reads its synced collection (§12); this reader
-	 * serves the dedupe below, this class, and its tests. */
+	 * serves this class and its tests. */
 	listOffers(): Offer[] {
-		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY seq`.map(toOffer)
+		return this.offerRows().map(toOffer)
+	}
+
+	/** The same rows as `listOffers`, before `toOffer` drops the columns the
+	 * app does not read — which the dedupe needs, since the fingerprint is one
+	 * of them. */
+	private offerRows(): OfferRow[] {
+		return this.sql<OfferRow>`SELECT * FROM offer ORDER BY seq`
 	}
 
 	/**
 	 * One research turn. An entry this Article already carries comes back as it
 	 * stands, keeping the disposition the writer gave it — §5.
+	 *
+	 * The map below gives that answer; `offer_one_per_fingerprint` is what makes
+	 * it hold when two turns of one step read before either has committed (§12).
+	 * The loop is the recovery: party-db commits the whole call in one
+	 * transaction, so the refused row rolls the turn's other rows back with it
+	 * and they have to be re-deduped and re-committed.
 	 *
 	 * Not `@callable`: the research tool is the only caller and it runs inside
 	 * this Agent (§3, rule 4).
@@ -387,58 +468,51 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	async recordOffers(batch: unknown): Promise<RecordedOffer[]> {
 		const found = offerBatchSchema.parse(batch)
 
-		// Queued against every other call, the way party-db serialises its own
-		// writes. The dedupe below reads the table and then commits, and
-		// `commit` always yields — so two turns offering one source would each
-		// read before the other's rows landed and write it twice. Parsing stays
-		// outside the queue: a batch that does not parse writes nothing.
-		const run = this.recording.then(
-			() => this.writeOffers(found),
-			() => this.writeOffers(found),
-		)
-		this.recording = run.catch(() => {})
+		// Built once, before the loop: an entry that lands on a later pass keeps
+		// the id and the timestamp this turn first gave it.
+		const pending = found.map(offerRow)
 
-		return run
-	}
+		for (let attempt = 0; ; attempt++) {
+			const held = new Map(this.offerRows().map((row) => [row.fingerprint, toOffer(row)]))
 
-	/**
-	 * One turn's rows, written under `recordOffers`'s queue.
-	 *
-	 * The queue orders calls inside one isolate, which is the only place two can
-	 * overlap: a call in flight holds the Agent awake, so nothing interleaves
-	 * across a hibernation. A guard that did not depend on that would be a
-	 * stored fingerprint column with a UNIQUE index, the way `round_one_running`
-	 * backs `startReview`.
-	 */
-	private async writeOffers(found: ReferenceContent[]): Promise<RecordedOffer[]> {
-		// Added to as the batch is built, so a turn dedupes against itself. A
-		// read, so no commit: §12's commit-only rule covers writes.
-		const held = new Map(
-			this.listOffers().map((offer) => [offerFingerprint(offer), offer]),
-		)
+			const ops: { type: 'insert'; value: OfferRow }[] = []
+			const recorded = pending.map((row): RecordedOffer => {
+				const already = held.get(row.fingerprint)
+				if (already !== undefined) return { offer: already, duplicate: true }
 
-		const ops: { type: 'insert'; value: OfferRow }[] = []
-		const recorded = found.map((material): RecordedOffer => {
-			const fingerprint = offerFingerprint(material)
-			const already = held.get(fingerprint)
-			if (already !== undefined) return { offer: already, duplicate: true }
+				const offer = toOffer(row)
+				// Added to as the batch is built, so a turn dedupes against itself.
+				held.set(row.fingerprint, offer)
+				ops.push({ type: 'insert', value: row })
 
-			const value = offerRow(material)
-			const offer = toOffer(value)
-			held.set(fingerprint, offer)
-			ops.push({ type: 'insert', value })
+				return { offer, duplicate: false }
+			})
 
-			return { offer, duplicate: false }
-		})
+			// One commit for the turn, the way `writeReview` writes a Round's Notes:
+			// seventeen findings cost one batch, one oplog entry and one frame per
+			// subscriber rather than seventeen of each. A batch with no ops would
+			// still reach every subscriber, so a turn that found nothing new
+			// commits nothing.
+			if (ops.length === 0) return recorded
 
-		// One commit for the turn, the way `writeReview` writes a Round's Notes:
-		// seventeen findings cost one batch, one oplog entry and one frame per
-		// subscriber rather than seventeen of each. A batch with no ops would
-		// still reach every subscriber, so a turn that found nothing new
-		// commits nothing.
-		if (ops.length > 0) await this.db.commit([{ channel: 'offer', ops }])
+			try {
+				await this.db.commit([{ channel: 'offer', ops }])
 
-		return recorded
+				return recorded
+			} catch (error) {
+				// Re-read to ask what refused this: a fingerprint this pass tried
+				// to write that the table now holds is another turn committing
+				// across the await. `createRound` recovers the same way, and it
+				// keeps both off the wording of a SQLite error.
+				const taken = new Set(this.offerRows().map((row) => row.fingerprint))
+				const lost = ops.some((op) => taken.has(op.value.fingerprint))
+
+				// Each pass turns at least the losing entry into a duplicate, so
+				// the batch bounds the passes. Stated rather than trusted, and the
+				// rejection is what surfaces rather than a summary of it.
+				if (!lost || attempt === pending.length) throw error
+			}
+		}
 	}
 
 	/** Mark an Offer as having been Accepted or Declined by the client. */

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -456,11 +456,9 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * One research turn. An entry this Article already carries comes back as it
 	 * stands, keeping the disposition the writer gave it — §5.
 	 *
-	 * The map below gives that answer; `offer_one_per_fingerprint` is what makes
-	 * it hold when two turns of one step read before either has committed (§12).
-	 * The loop is the recovery: party-db commits the whole call in one
-	 * transaction, so the refused row rolls the turn's other rows back with it
-	 * and they have to be re-deduped and re-committed.
+	 * The map below gives that answer, and `offer_one_per_fingerprint` is what
+	 * makes it hold when two turns of one step read before either committed. The
+	 * loop is the recovery a whole-call transaction forces — §12 for both.
 	 *
 	 * Not `@callable`: the research tool is the only caller and it runs inside
 	 * this Agent (§3, rule 4).
@@ -500,10 +498,9 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 
 				return recorded
 			} catch (error) {
-				// Re-read to ask what refused this: a fingerprint this pass tried
-				// to write that the table now holds is another turn committing
-				// across the await. `createRound` recovers the same way, and it
-				// keeps both off the wording of a SQLite error.
+				// A fingerprint this pass tried to write that the table now holds
+				// is another turn committing across the await. Re-reading is how
+				// the table says so, rather than the rejection's wording (§12).
 				const taken = new Set(this.offerRows().map((row) => row.fingerprint))
 				const lost = ops.some((op) => taken.has(op.value.fingerprint))
 

--- a/src/shared/sync.ts
+++ b/src/shared/sync.ts
@@ -2,7 +2,7 @@ import { definePartyCollection } from 'party-db'
 import { z } from 'zod'
 
 import { type Note, type NoteAnchor, noteDispositions } from './note'
-import { dispositions, type Offer } from './offer'
+import { dispositions, type Offer, offerFingerprint } from './offer'
 import { referenceTypeSchema, type Source } from './plan/schema'
 import { reviewDepths, type Round, type RoundPassage, roundStates } from './review'
 
@@ -61,6 +61,9 @@ export const offerRowSchema = z.object({
 	/** JSON text of a `Source`. */
 	source: z.string().nullable(),
 	note: z.string().nullable(),
+	/** Under a UNIQUE index, so the table itself refuses a second row for one
+	 * source — §12. `fromOffer` is where every row gets one. */
+	fingerprint: z.string(),
 	created_at: z.number(),
 	decided_at: z.number().nullable(),
 })
@@ -129,6 +132,7 @@ export function fromOffer(offer: Offer): OfferRow {
 		text: offer.text ?? null,
 		source: offer.source === undefined ? null : JSON.stringify(offer.source),
 		note: offer.note ?? null,
+		fingerprint: offerFingerprint(offer),
 		created_at: offer.createdAt,
 		decided_at: offer.decidedAt,
 	}

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -31,6 +31,17 @@ function listOffers(name: string): Promise<Offer[]> {
 	return inAgent(name, (agent) => agent.listOffers())
 }
 
+/** The `offer` table as it stood before the fingerprint column, so a test can
+ * wake an Agent onto the shape a deployed Article has. Raw SQL against a synced
+ * table, which §12 forbids the app — this stands a schema up rather than writing
+ * a row the app would write. */
+function toOldOfferTable(name: string): Promise<void> {
+	return inAgent(name, (agent) => {
+		agent.sql`DROP INDEX IF EXISTS offer_one_per_fingerprint`
+		agent.sql`ALTER TABLE offer DROP COLUMN fingerprint`
+	})
+}
+
 /** A Plan that parses: one Section, and one Reference placed at it. */
 const plan = makePlan({
 	title: 'The permit queue',
@@ -269,8 +280,9 @@ describe('Offers in the Article Agent', () => {
 		await expect(listOffers('offer-reoffered')).resolves.toHaveLength(1)
 	})
 
-	// Two tool calls in one step run concurrently, and `commit` yields — so the
-	// dedupe has to read and write under one queue rather than once per call.
+	// Two tool calls in one step run concurrently, and `commit` yields — so both
+	// turns read before the other's rows landed. The unique index on the
+	// fingerprint is what stops the second one writing a twin.
 	it('records one Offer when two concurrent turns offer the same source', async () => {
 		await openAgentSocket('offer-concurrent')
 
@@ -282,6 +294,101 @@ describe('Offers in the Article Agent', () => {
 		expect(second[0].duplicate).toBe(true)
 		expect(second[0].offer.id).toBe(first[0].offer.id)
 		await expect(listOffers('offer-concurrent')).resolves.toHaveLength(1)
+	})
+
+	// party-db commits a call in one transaction, so the rejected row takes the
+	// turn's other rows down with it. The losing turn has to come back with the
+	// source it alone found.
+	it('records the rest of a losing turn when one of its entries is taken', async () => {
+		await openAgentSocket('offer-concurrent-batch')
+
+		const [first, second] = await inAgent('offer-concurrent-batch', (agent) =>
+			Promise.all([
+				agent.recordOffers([reference]),
+				agent.recordOffers([reference, quote]),
+			]),
+		)
+
+		expect(first.map((entry) => entry.duplicate)).toEqual([false])
+		expect(second.map((entry) => entry.duplicate)).toEqual([true, false])
+		expect(second[0].offer.id).toBe(first[0].offer.id)
+		await expect(
+			listOffers('offer-concurrent-batch').then((offers) => offers.map((one) => one.id)),
+		).resolves.toEqual([first[0].offer.id, second[1].offer.id])
+	})
+
+	// The fingerprint column arrived after the table did, so a deployed Article
+	// wakes with the old shape and its Offers have to come through the rebuild.
+	// `onStart` runs on every wake, so the migration has to be idempotent: a
+	// throw there is caught by the SDK, and the Agent carries on with the rest
+	// of `onStart` — the party-db core included — never built.
+	it("carries an Article's Offers across the fingerprint column", async () => {
+		const writer = await openAgentSocket('offer-migration')
+		const kept = await createOffer('offer-migration', quote)
+		const declined = await createOffer('offer-migration', reference)
+		await writer.call('setOfferDisposition', declined.id, 'declined')
+
+		await toOldOfferTable('offer-migration')
+
+		// Two wakes over the same table: the first migrates it, the second meets
+		// a table it has nothing to do to. Each socket is what runs `onStart`,
+		// the way a writer opening the Article does.
+		await evictDurableObject(agentStub('offer-migration'))
+		await openAgentSocket('offer-migration')
+		await evictDurableObject(agentStub('offer-migration'))
+		await openAgentSocket('offer-migration')
+
+		// Same ids, same order, same rulings.
+		await expect(
+			listOffers('offer-migration').then((offers) =>
+				offers.map((one) => [one.id, one.disposition]),
+			),
+		).resolves.toEqual([
+			[kept.id, 'undecided'],
+			[declined.id, 'declined'],
+		])
+
+		// And the migrated rows carry the fingerprint, so the dedupe finds them.
+		const recorded = await recordOffers('offer-migration', [quote, reference])
+
+		expect(recorded.map((entry) => entry.duplicate)).toEqual([true, true])
+		expect(recorded.map((entry) => entry.offer.id)).toEqual([kept.id, declined.id])
+	})
+
+	// An Article written before the index could hold two rows for one source.
+	// The index cannot build over the pair, so the migration keeps the row the
+	// writer saw first and drops its twin — and carries on, which is why the
+	// Offer after the twin is what this asserts on.
+	it('keeps the older row when an Article carries a double-record', async () => {
+		await openAgentSocket('offer-migration-twin')
+		const first = await createOffer('offer-migration-twin', reference)
+
+		// Written the way the race wrote it: two rows, one source, and a third
+		// Offer behind them that the migration must still reach.
+		await toOldOfferTable('offer-migration-twin')
+		await inAgent('offer-migration-twin', (agent) => {
+			agent.sql`
+				INSERT INTO offer (id, type, disposition, text, source, note, created_at, decided_at)
+				SELECT 'twin', type, disposition, text, source, note, created_at, decided_at
+				FROM offer WHERE id = ${first.id}
+			`
+			agent.sql`
+				INSERT INTO offer (id, type, disposition, text, source, note, created_at, decided_at)
+				VALUES ('behind', 'link', 'undecided', NULL, ${JSON.stringify({ title: 'Behind the twin' })}, NULL, ${Date.now()}, NULL)
+			`
+		})
+
+		await evictDurableObject(agentStub('offer-migration-twin'))
+		await openAgentSocket('offer-migration-twin')
+
+		await expect(
+			listOffers('offer-migration-twin').then((offers) => offers.map((one) => one.id)),
+		).resolves.toEqual([first.id, 'behind'])
+
+		const [again] = await recordOffers('offer-migration-twin', [reference])
+
+		expect(again.duplicate).toBe(true)
+		expect(again.offer.id).toBe(first.id)
 	})
 
 	it('records one turn offering the same source twice as one Offer', async () => {


### PR DESCRIPTION
Replaces the in-memory queue-based deduplication of offers with a database-enforced unique constraint. This allows concurrent turns to safely record offers without race conditions.

## Summary

The offer deduplication mechanism is moving from a promise queue (`this.recording`) to a stored `fingerprint` column with a UNIQUE index on the `offer` table. This shift enables proper handling of concurrent offer recording across hibernation boundaries, where in-memory state cannot survive.

## Key changes

- **Add fingerprint column and index**: The `offer` table now includes a `fingerprint` TEXT NOT NULL column with a UNIQUE index (`offer_one_per_fingerprint`). This enforces one offer per source at the database level.

- **Migration for existing articles**: New `drainOldOfferTable()` and `restoreOffers()` methods handle the schema migration. Articles deployed before this change will have their offers read out, the old table dropped, the new schema created, and offers restored with computed fingerprints on the next wake. The restoration uses `INSERT OR IGNORE` to keep the first-seen row when duplicates exist.

- **Retry loop in recordOffers**: Replaces the queue-based `writeOffers()` with a loop that retries on constraint violations. When two concurrent turns try to record the same source, the unique index rejects the second attempt. The losing turn re-reads the table to identify which entries were taken, marks them as duplicates, and retries the remaining entries.

- **Updated schema and sync types**: The `OfferRow` type now includes the `fingerprint` field, and `offerRowSchema` documents its role in the UNIQUE index.

## Notable implementation details

- The migration is idempotent: running `onStart` multiple times on the same schema is safe. A table without the fingerprint column is detected via `pragma_table_info`, migrated once, and subsequent wakes skip the migration.

- The retry loop bounds itself by the batch size: each pass converts at least one losing entry into a duplicate, so the loop cannot exceed `pending.length` iterations before throwing.

- Raw SQL is used in tests (`toOldOfferTable`) to simulate the pre-migration schema, allowing verification that the migration preserves offer ids, dispositions, and order.

https://claude.ai/code/session_01G86VPb6f9HkhzJ44NEHRuS