### PR TITLE
Drop the collection pin and close an idle Article's socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ai": "^7.0.55",
     "hono": "^4.13.0",
     "lucide-react": "^1.30.0",
-    "party-db": "0.0.2",
+    "party-db": "0.0.4",
     "partyserver": "^0.5.10",
     "partysocket": "^1.3.0",
     "react": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^1.30.0
         version: 1.30.0(react@19.2.8)
       party-db:
-        specifier: 0.0.2
-        version: 0.0.2(@standard-schema/spec@1.1.0)(@tanstack/db@0.6.17(typescript@5.9.3))(partyserver@0.5.10(@cloudflare/workers-types@5.20260804.1))(partysocket@1.3.0(react@19.2.8))
+        specifier: 0.0.4
+        version: 0.0.4(@standard-schema/spec@1.1.0)(@tanstack/db@0.6.17(typescript@5.9.3))(partyserver@0.5.10(@cloudflare/workers-types@5.20260804.1))(partysocket@1.3.0(react@19.2.8))(zod@4.4.3)
       partyserver:
         specifier: ^0.5.10
         version: 0.5.10(@cloudflare/workers-types@5.20260804.1)
@@ -3156,18 +3156,21 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  party-db@0.0.2:
-    resolution: {integrity: sha512-rWuKo9obEuetIJNfxY/1Ea4bbuQKLJQF8i/iLad4YnSLNiImMizss+BTzXXc5WW8BTXAKqT8m8SRS7z4+IZzwA==}
+  party-db@0.0.4:
+    resolution: {integrity: sha512-uK4mod/5hJH1pLqaVS/qLBbvZok3z5Z8F9vtO4HTiWk2CrAYzQtnI3elr0cSz2yvWNNgW9qoy0L98/kt28BkSw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@standard-schema/spec': ^1.1.0
       '@tanstack/db': ^0.6.10
       partyserver: ^0.5.8
       partysocket: ^1.3.0
+      zod: ^4.0.0
     peerDependenciesMeta:
       partyserver:
         optional: true
       partysocket:
+        optional: true
+      zod:
         optional: true
 
   partyserver@0.5.10:
@@ -6804,13 +6807,14 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  party-db@0.0.2(@standard-schema/spec@1.1.0)(@tanstack/db@0.6.17(typescript@5.9.3))(partyserver@0.5.10(@cloudflare/workers-types@5.20260804.1))(partysocket@1.3.0(react@19.2.8)):
+  party-db@0.0.4(@standard-schema/spec@1.1.0)(@tanstack/db@0.6.17(typescript@5.9.3))(partyserver@0.5.10(@cloudflare/workers-types@5.20260804.1))(partysocket@1.3.0(react@19.2.8))(zod@4.4.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@tanstack/db': 0.6.17(typescript@5.9.3)
     optionalDependencies:
       partyserver: 0.5.10(@cloudflare/workers-types@5.20260804.1)
       partysocket: 1.3.0(react@19.2.8)
+      zod: 4.4.3
 
   partyserver@0.5.10(@cloudflare/workers-types@5.20260804.1):
     dependencies:

--- a/src/client/lib/sync.ts
+++ b/src/client/lib/sync.ts
@@ -19,10 +19,8 @@ export type ArticleSync = {
 	offer: Collection<OfferRow>
 }
 
-/** One client per Article, held while a screen reads it. party-db ships a
- * transport `close()` since 0.0.3 (party-db#56), so a session that visits many
- * Articles no longer keeps a socket per Article open for its whole life — the
- * client closes once the last reader has been gone for `IDLE_CLOSE_MS`. */
+/** One client per Article, held open while a screen reads it and closed once
+ * the last reader leaves. */
 type Held = {
 	sync: ArticleSync
 	close: () => void
@@ -32,29 +30,14 @@ type Held = {
 
 const held = new Map<string, Held>()
 
-/** How long an Article's client stays open with no reader. Long enough that
- * leaving an Article and coming back reuses the client rather than
- * reconnecting, and that React's development remount never closes one. */
 const IDLE_CLOSE_MS = 10_000
 
-/** The Article's collections — a lookup, not a connect, so it is safe in
- * render. `retainArticleSync` is what keeps the client open. */
+/** A lookup, not a connect, so it is safe in render. */
 export function articleSync(articleId: string): ArticleSync {
 	return entry(articleId).sync
 }
 
-/**
- * Hold an Article's client open while a screen is reading it. Call from an
- * effect and return the release:
- *
- *     useEffect(() => retainArticleSync(articleId), [articleId])
- *
- * A collection may still be garbage-collected between renders — TanStack DB
- * drops one once its last subscriber leaves — and that is fine from 0.0.4 on:
- * party-db asks the room for the collection's snapshot when it registers again
- * (party-db#47), so a reopened panel refills itself. That is what retired the
- * standing `subscribeChanges` pin this file used to carry.
- */
+/** Holds the Article's client open until the returned release is called. */
 export function retainArticleSync(articleId: string): () => void {
 	const article = entry(articleId)
 	article.readers += 1
@@ -89,8 +72,7 @@ function entry(articleId: string): Held {
 		idle: undefined,
 	}
 	held.set(articleId, article)
-	// nothing is reading it yet: a render that never mounts must not leave a
-	// socket open for the rest of the session.
+	// nothing has retained it yet: a render that never mounts closes on this timer.
 	closeWhenIdle(articleId, article)
 
 	return article
@@ -101,7 +83,7 @@ function closeWhenIdle(articleId: string, article: Held): void {
 	article.idle = setTimeout(() => {
 		if (article.readers > 0) return
 		held.delete(articleId)
-		// one way: the next reader builds a fresh client, socket and collections.
+		// closing is one way: the next reader builds a fresh client.
 		article.close()
 	}, IDLE_CLOSE_MS)
 }

--- a/src/client/lib/sync.ts
+++ b/src/client/lib/sync.ts
@@ -19,12 +19,55 @@ export type ArticleSync = {
 	offer: Collection<OfferRow>
 }
 
-/** Held for the session: party-db has no transport close yet (party-db#46),
- * so one client per Article is the bound on open sockets — the carry in
- * architecture.md §11. */
-const held = new Map<string, ArticleSync>()
+/** One client per Article, held while a screen reads it. party-db ships a
+ * transport `close()` since 0.0.3 (party-db#56), so a session that visits many
+ * Articles no longer keeps a socket per Article open for its whole life — the
+ * client closes once the last reader has been gone for `IDLE_CLOSE_MS`. */
+type Held = {
+	sync: ArticleSync
+	close: () => void
+	readers: number
+	idle: ReturnType<typeof setTimeout> | undefined
+}
 
+const held = new Map<string, Held>()
+
+/** How long an Article's client stays open with no reader. Long enough that
+ * leaving an Article and coming back reuses the client rather than
+ * reconnecting, and that React's development remount never closes one. */
+const IDLE_CLOSE_MS = 10_000
+
+/** The Article's collections — a lookup, not a connect, so it is safe in
+ * render. `retainArticleSync` is what keeps the client open. */
 export function articleSync(articleId: string): ArticleSync {
+	return entry(articleId).sync
+}
+
+/**
+ * Hold an Article's client open while a screen is reading it. Call from an
+ * effect and return the release:
+ *
+ *     useEffect(() => retainArticleSync(articleId), [articleId])
+ *
+ * A collection may still be garbage-collected between renders — TanStack DB
+ * drops one once its last subscriber leaves — and that is fine from 0.0.4 on:
+ * party-db asks the room for the collection's snapshot when it registers again
+ * (party-db#47), so a reopened panel refills itself. That is what retired the
+ * standing `subscribeChanges` pin this file used to carry.
+ */
+export function retainArticleSync(articleId: string): () => void {
+	const article = entry(articleId)
+	article.readers += 1
+	clearTimeout(article.idle)
+	article.idle = undefined
+
+	return () => {
+		article.readers -= 1
+		if (article.readers === 0) closeWhenIdle(articleId, article)
+	}
+}
+
+function entry(articleId: string): Held {
 	const existing = held.get(articleId)
 	if (existing !== undefined) return existing
 
@@ -33,21 +76,32 @@ export function articleSync(articleId: string): ArticleSync {
 		party: 'article-agent',
 		room: articleId,
 	})
-	const { db } = createPartyDb(transport, syncCollections)
+	const { db, close } = createPartyDb(transport, syncCollections)
 
-	const sync: ArticleSync = {
-		note: db.note as Collection<NoteRow>,
-		round: db.round as Collection<RoundRow>,
-		offer: db.offer as Collection<OfferRow>,
+	const article: Held = {
+		sync: {
+			note: db.note as Collection<NoteRow>,
+			round: db.round as Collection<RoundRow>,
+			offer: db.offer as Collection<OfferRow>,
+		},
+		close,
+		readers: 0,
+		idle: undefined,
 	}
+	held.set(articleId, article)
+	// nothing is reading it yet: a render that never mounts must not leave a
+	// socket open for the rest of the session.
+	closeWhenIdle(articleId, article)
 
-	// Pin every collection: TanStack DB garbage-collects a collection once its
-	// last subscriber leaves, and a party-db collection that restarts gets no
-	// second snapshot (party-db#47; the other §11 carry). Iterated rather than
-	// listed, so a collection cannot join `ArticleSync` unpinned.
-	for (const collection of Object.values(sync)) collection.subscribeChanges(() => {})
+	return article
+}
 
-	held.set(articleId, sync)
-
-	return sync
+function closeWhenIdle(articleId: string, article: Held): void {
+	clearTimeout(article.idle)
+	article.idle = setTimeout(() => {
+		if (article.readers > 0) return
+		held.delete(articleId)
+		// one way: the next reader builds a fresh client, socket and collections.
+		article.close()
+	}, IDLE_CLOSE_MS)
 }

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -95,8 +95,6 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 	// a connect, so it is safe in render.
 	const sync = articleSync(articleId)
 
-	// ...and the screen holding it is what keeps that socket open: the client
-	// closes a short while after the last Article screen leaves.
 	useEffect(() => retainArticleSync(articleId), [articleId])
 
 	return {

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -9,7 +9,7 @@ import type { ReviewRequest, Round } from '../../shared/review'
 import { usePlanChannel } from '../plan/usePlan'
 import type { Article, DraftStore, NoteStore, OfferStore } from './article'
 import { parseFrame } from './frames'
-import { articleSync } from './sync'
+import { articleSync, retainArticleSync } from './sync'
 
 /**
  * Opens one Article Agent and hands out the three things that ride its one
@@ -94,6 +94,10 @@ export function useArticleAgent(articleId: string): ArticleConnection {
 	// The party-db socket, cached per Article in `lib/sync.ts` — a lookup, not
 	// a connect, so it is safe in render.
 	const sync = articleSync(articleId)
+
+	// ...and the screen holding it is what keeps that socket open: the client
+	// closes a short while after the last Article screen leaves.
+	useEffect(() => retainArticleSync(articleId), [articleId])
 
 	return {
 		article: { offers, draft, notes, sync, plan: channel.connection },


### PR DESCRIPTION
Upgrades party-db 0.0.2 → 0.0.4 and retires the two workarounds architecture.md §11 records against 0.0.2.

## The pin

`lib/sync.ts` held a standing `subscribeChanges(() => {})` on every collection so TanStack DB's garbage collection never ran — a collection that was cleaned up and re-registered got no second snapshot, so a reopened panel stayed blank and `isReady` never fired.

party-db 0.0.4 fixes that (party-db#47): a second `register` sends `{ snapshot: <channel> }` up the socket and the room answers that connection with a `reset` snapshot, so the collection refills and `isReady` fires again. Every reader here goes through `useLiveQuery` (`useNotes`, `useOfferLedger`), which subscribes on mount and unsubscribes on unmount — exactly the cycle the fix covers. The pin goes, and with it the rows every Article held in memory for the whole session.

## The socket

`held` was a map that only grew, because 0.0.2 had no way to hang up a client. 0.0.3 shipped a transport `close()` (party-db#56), so an Article's client is now retained while a screen reads it and closed once the last reader has been gone for ten seconds:

- `articleSync(articleId)` stays a lookup, safe in render.
- `retainArticleSync(articleId)` is the hold; `useArticleAgent` calls it from an effect keyed on `articleId`.
- The ten-second delay is load-bearing: it keeps leaving an Article and coming back — and React's development remount under `StrictMode` — from tearing the socket down and reconnecting.
- A client built by a render that never mounts is closed on the same timer, so an abandoned render can't leak a socket.
- Closing is one way, so the entry is dropped from `held` first: the next reader builds a fresh client, socket and collections.

## Checks

`pnpm lint`, `pnpm format:check`, `pnpm typecheck` clean. `vitest run --project shared --project client --project worker`: 34 files, 458 tests passing.

The `stories` project did not run here — this environment has Playwright's chromium build 1194 and the pinned Playwright wants 1234, so the browser launch fails before any test body. Nothing in that project touches this change: `.storybook/mock/MockArticle.tsx` builds its collections with `createCollection(localOnlyCollectionOptions(...))`, never `articleSync`. CI runs it.

## Worth a look

The ten-second idle window is a guess at "long enough to survive navigation, short enough to matter". If Articles are usually revisited, raise it; if a session opens many and returns to none, lower it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HbbVEQdMjfNHZ1C5vLCXmx

---
_Generated by [Claude Code](https://claude.ai/code/session_01HbbVEQdMjfNHZ1C5vLCXmx)_