### PR TITLE
Split architecture.md into module docs, and rewrite the prose

### DIFF
--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -9,7 +9,7 @@ project into party-db rows at phase 2 without a rewrite.
 
 **Amended:** this paragraph first said the schema serves `generateObject` as a second
 caller. It does not — the Chat proposes and the client applies, so nothing the model emits
-is ever parsed as a Plan. Corrected in `docs/architecture.md` §4 and recorded on #24, where
+is ever parsed as a Plan. Corrected in `docs/plan.md` and recorded on #24, where
 the op payloads are built.
 
 ```

--- a/docs/adr/0002-the-plan-data-model.md
+++ b/docs/adr/0002-the-plan-data-model.md
@@ -80,7 +80,7 @@ carry, so deleting a node unplaces its References in the same Proposal.
 
 **Amended:** the second half of that reason is general and was stated here only because
 `nodeId` is where it first came up. #24 applied it to the rest of the Plan — a node's
-Adjectives took both an absent key and an empty list — and `docs/architecture.md` §4 now
+Adjectives took both an absent key and an empty list — and `docs/plan.md` now
 carries it as a rule of the data model.
 
 ## Provenance names what sort of thing a Reference came from
@@ -191,7 +191,7 @@ rather than greying the Proposal out.
 `apply.ts`, and settled the question this section left open. The op payloads reuse the piece
 schemas as they stand, `strictObject` and all, so a model that adds one field fails the tool
 call and retries with the validation error rather than having the field stripped. What that
-costs, and what to do if a model thrashes the retry, is in `docs/architecture.md` §6.
+costs, and what to do if a model thrashes the retry, is in `docs/plan.md`.
 
 ## Consequences
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,6 +87,11 @@ Recorded in [ADR 0001](./adr/0001-phase-1-storage-shape.md).
    Rounds and Offers are published as collections instead, so reads are live queries and the
    Guide's writes go through `commit()` — see [`sync.md`](./sync.md). Rulings still go over
    RPC, per rule 2. The Draft is the table left; [`draft.md`](./draft.md) says why it can wait.
+5. The writer does not author an Offer, a Round, or a Note today. This is an observation
+   rather than a rule, and it is worth stating because one thing rests on it: `recordOffers`
+   runs inside the Article Agent rather than over RPC, since nothing on the client needs to
+   write an Offer. Nothing else depends on it, so letting the writer author a Note would cost
+   that one call and no more.
 
 ## 4. Seams
 
@@ -162,12 +167,14 @@ Access gates the Worker, so an unauthenticated request never arrives. 1a needs n
 one Team, both people read everything, and no record is per-user.
 
 We avoid reading `Cf-Access-Jwt-Assertion` while we can, because localhost has no Access gate
-and therefore no header, which keeps development simple.
+and therefore no header, which keeps development simple. That is a convenience rather than a
+constraint, and we can change the DX later if we want to.
 
 At 1b, party-db's `authorize` runs in the partyserver lobby and needs a verified identity
 before the object wakes. Access injects the assertion as a header where party-db expects
 `?token=` on connect, so `authorize` reads the header. Issue #12 tracks whether the header
-survives a WebSocket upgrade into the Durable Object. If it does not, we move to WorkOS.
+survives a WebSocket upgrade into the Durable Object. WorkOS is the documented upgrade if
+it does not.
 
 Attributing Chat messages to people is wanted and deferred past 1a. The Agents SDK stores a
 role rather than a person, so this needs a field on the `UIMessage` or a parallel table.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,52 +1,27 @@
 # Architecture
 
-This document records the patterns that bind more than one module. A rule earns a place here
-when it can be written as: _this module does that, so this other one has to do this, or that
-breaks._ Written that way a constraint carries its own expiry — when the first half stops
-being true, the second half is up for review.
+This file records the rules that bind more than one module. A rule belongs here if it takes
+the form "P does Q, because R requires S" — that way, when R changes, the rule is up for
+review. Anything true of one module alone belongs in that module's file:
+[`plan.md`](./plan.md), [`chat.md`](./chat.md), [`sync.md`](./sync.md),
+[`llm.md`](./llm.md), [`draft.md`](./draft.md), [`articles.md`](./articles.md),
+[`reviews.md`](./reviews.md), [`ui.md`](./ui.md), [`carries.md`](./carries.md),
+[`deploy.md`](./deploy.md), [`context.md`](./context.md), [`later.md`](./later.md), and
+[`adr/`](./adr/).
 
-A fact about one module's insides goes in that module's file. A convention with no failure
-behind it is a helper function or a lint rule, not an entry here. The reasoning behind each
-decision lives in the wayfinding map, issue #5, and its closed tickets.
+## 1. Scale
 
-## The doc map
+One Team holds two people. There is no signup flow. Both people may read everything.
 
-| File                           | Holds                                                               |
-| ------------------------------ | ------------------------------------------------------------------- |
-| [`context.md`](./context.md)   | The vocabulary, which governs the code, the UI, and every file here |
-| [`plan.md`](./plan.md)         | The Plan blob, the ops, the applier, the refusals                   |
-| [`chat.md`](./chat.md)         | The Chat, the Offers Ledger, the Proposal tool machinery            |
-| [`reviews.md`](./reviews.md)   | Reviews, Rounds, and Notes                                          |
-| [`draft.md`](./draft.md)       | The Draft and the guide loop — phase 2                              |
-| [`articles.md`](./articles.md) | The article index and the two Article Views                         |
-| [`sync.md`](./sync.md)         | party-db inside the Article Agent                                   |
-| [`llm.md`](./llm.md)           | The model, search, and the prompt packs                             |
-| [`ui.md`](./ui.md)             | UI decisions, and the Storybook stories it includes by reference    |
-| [`carries.md`](./carries.md)   | Settings we hold and defects we work around                         |
-| [`deploy.md`](./deploy.md)     | What has to be set outside the repository                           |
-| [`adr/`](./adr/)               | Decision records for the storage shape, the Plan, and the editor    |
-| [`later.md`](./later.md)       | Parked ideas. Use sparingly                                         |
+Two people rarely edit one Article at the same time, so we accept last-write-wins on the
+Draft and a single-writer design for the Plan. Most of section 3 follows from this. If the
+Team grows, revisit section 3 first.
 
-## 1. Build order
+Where two options are close, take the one that puts a usable writing product in front of you
+soonest. Cost and throughput arguments decide only when they threaten that.
 
-Three stages of usefulness. Build with all three in mind and ship them in order. A refactor
-at a stage boundary is accepted rather than designed around.
-
-| Stage  | What ships              | What it adds                                                                                                    |
-| ------ | ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **1a** | The Chat and the Plan   | One Article Agent per Article. Useful alone.                                                                    |
-| **1b** | The House               | The Lexicon, the standing rules, the Skills, and House-scoped Voice and Adjectives. Only useful once 1a exists. |
-| **2**  | The Draft and the Guide | The writing surface, Guidance notes, Reviews.                                                                   |
-
-**Scale**: one Team of two people. No signup flow. "Only one editor at a time on a Draft" is
-an acceptable constraint.
-
-**Tiebreaker**: where options are close, take the one that puts a product you can write with
-in front of you soonest. Arguments from scale, cost, or throughput decide only when they
-threaten that.
-
-Phase 2 is decided at low resolution now so 1a cannot paint itself into a corner —
-[`draft.md`](./draft.md).
+The build order and its stages are project management, not architecture. They live in issue
+#5 with the rest of the wayfinding map.
 
 ## 2. Shape
 
@@ -65,186 +40,149 @@ Browser — React + Vite + TanStack Router
                                               Workers AI binding → the model
 ```
 
-**Cloudflare throughout.** Workers, Durable Objects, D1, R2, Workers AI.
+We run on Cloudflare throughout: Workers, Durable Objects, D1, R2, and Workers AI.
 
-**One Article Agent per Article**, built on the Cloudflare Agents SDK. It holds everything
-about one Article. It is named in full as "Article Agent" to distinguish it from the general
-term or a different agent we might add later.
+Each Article gets one Article Agent, built on the Cloudflare Agents SDK, which holds
+everything about that Article. We write the name in full to distinguish it from the general
+term and from any agent we add later.
 
-**House Style** arrives at 1b as a single party-db room persisted to D1, holding the writer's
-own standing material — the Lexicon, the standing rules, the Skills, and House-scoped Voice
-and Adjectives. It is small, read frequently, and simple CRUD over a few collections, so its
-API is the PartyDB collections talking to a `PartyDbServer`. What the House is for is
-[`context.md`](./context.md).
+The House arrives at 1b as one party-db room persisted to D1. It holds the Lexicon, the
+standing rules, the Skills, and House-scoped Voice and Adjectives. It is small and its API is
+plain CRUD, so a `PartyDbServer` serves it directly. [`context.md`](./context.md) says what
+the House is for.
 
-**Plain D1 tables** hold Archived Plans, Drafts, and Finals, read through a Worker endpoint
-rather than synced. D1 also carries the backup story, because a Durable Object's storage has
-no export path and D1 has `wrangler d1 export`.
+Plain D1 tables hold Archived Plans, Drafts, and Finals. A Worker endpoint reads them; they
+are not synced. D1 also carries the backup story, because a Durable Object's storage has no
+export path and D1 has `wrangler d1 export`.
 
-**Hono serves the HTTP** in the same Worker: the Agents SDK's chat route, the article index,
-party-db's lobby and write path at 1b, archived reads, and export.
+Hono serves the HTTP routes in the same Worker: the Agents SDK's chat route, the article
+index, party-db's lobby and write path at 1b, archived reads, and export.
 
-**React + Vite with TanStack Router**, served as static assets from the Worker. **TanStack
-Start does not join it** — its value is a typed server boundary in both directions, and the
-Agents SDK owns the actions while the two sockets own the reads, leaving about five HTTP
-calls in total. **TanStack Query** serves the article index and the archived and export
-reads; live data is already reactive through Article Agent state and party-db's TanStack DB
-collections.
+The client is React and Vite with TanStack Router, served as static assets from the Worker.
+We left out TanStack Start, because its value is a typed server boundary in both directions,
+and here the Agents SDK owns the actions while the two sockets own the reads — about five
+HTTP calls remain. TanStack Query serves those. Live data is already reactive through Article
+Agent state and party-db's TanStack DB collections.
 
 Recorded in [ADR 0001](./adr/0001-phase-1-storage-shape.md).
 
 ## 3. Where writes go
 
-1. **Article Agent state holds the Plan, and the client is its writer.** `setState` replaces
-   the entire blob, so a write meant to change one Section rewrites every field from whatever
-   version the client last read. A second writer's changes vanish with no conflict and no
-   error, which is what keeps the blob to one writer.
-2. **Every other per-Article record is a SQLite row in the Article Agent**, read and written
-   over `@callable` RPC on the WebSocket the client already holds. That covers the Draft's
-   Blocks, and Offers, Notes, and Rounds. Row writes touch named columns, so the Guide can
-   append a Round while the writer Declines an Offer and neither erases the other. Adding a
-   per-Article record type needs no endpoint, no store, and no sync library.
-3. **A request is an action when it runs a model, and CRUD otherwise.** Actions: sending a
-   Chat turn, running a Review, running research. CRUD: editing a Section, editing a
-   Reference, Accepting a Proposal, Declining an Offer, retitling the Article. Accepting is
-   CRUD even though a model produced the thing being accepted, because applying it is a plain
-   write.
-4. **The blob is a reactive store; a table is on-demand until it is published as a party-db
-   collection.** A bare row in a Durable Object's SQLite has no sync — `@callable` RPC is
-   request and response, so nothing tells a client it changed. That still suits Blocks, which
-   the client both writes and reads. Notes, Rounds and Offers are published as party-db
-   collections instead: reads are synced live queries, the Guide's writes go through
-   `commit()`, and rule 2's write path still holds for what the writer sends up — rulings stay
-   RPC. Which table joins them next is decided per table; the Draft is the one left, and
-   [`draft.md`](./draft.md) says why it can wait.
+1. The client is the only writer of Article Agent state, which holds the Plan. `setState`
+   replaces the whole blob, so any write rewrites every field from the version the client
+   last read. A second writer's changes would vanish with no conflict and no error.
+2. Every other per-Article record is a SQLite row in the Article Agent, read and written over
+   `@callable` RPC on the WebSocket the client already holds. That covers the Draft's Blocks,
+   the Offers, the Notes, and the Rounds. A row write touches named columns, so the Guide can
+   append a Round while the writer Declines an Offer, and neither erases the other. Adding a
+   record type needs no endpoint, no store, and no sync library.
+3. A request is an action when it runs a model, and CRUD otherwise. The actions are sending a
+   Chat turn, running a Review, and running research. The CRUD is editing a Section, editing
+   a Reference, Accepting a Proposal, Declining an Offer, and retitling the Article. Accepting
+   counts as CRUD even though a model produced the thing being accepted, because applying it
+   is a plain write.
+4. A SQLite row reaches the client on demand until we publish its table as a party-db
+   collection. `@callable` RPC is request and response, so nothing tells a connected client
+   that a row changed. That suits Blocks, which the client writes and reads itself. Notes,
+   Rounds and Offers are published as collections instead, so reads are live queries and the
+   Guide's writes go through `commit()` — see [`sync.md`](./sync.md). Rulings still go over
+   RPC, per rule 2. The Draft is the table left; [`draft.md`](./draft.md) says why it can wait.
 
-## 4. The seams
+## 4. Seams
 
-Each entry names two sides and what has to hold between them.
+### 4.1 The Chat proposes Plan changes and the writer applies them
 
-### 4.1 The model proposes; the client applies
+The Chat cannot write the Plan. It surfaces Proposals, and Accepting one calls `edit(ops)` —
+the same call every Plan edit makes — so the ops run through `createPlanWriter` against the
+Plan the writer is looking at. Rule 1 above is the reason.
 
-The Chat surfaces Proposals and the writer rules on them. Accepting is `edit(ops)`, the same
-call every Plan edit makes, and the ops go through `createPlanWriter` rather than a `setState`
-of their own. The writer holds the Plan the writer sees, so the Plan gets updated in a way
-that makes sense to the writer even when server and client have drifted apart (§3, rule 1).
+We reach for this shape across the app: the server passes work to the client as Notes, Offers,
+and Proposals, and the client writes them into the record. It answers two questions at once —
+how to surface a change, and how to merge it — with one pattern, and it keeps the writer in
+charge of the Plan and the Draft.
 
-This is the shape we reach for across the app: **pass work from server to client as notes,
-Offers, and Proposals, and let the client write them into the record.** It is a UX answer
-where the alternative is a conflict-resolution answer, and it buys the reader two fewer
-decisions — how to surface the change, and how to merge it — for the price of one pattern.
+Two rules follow. The applier is the only write path, so no Panel can make a change the
+applier would refuse. And `chatProposalSchema` withholds the three Reference ops from the
+model, because research must reach the Plan by being Accepted from an Offer; the applier
+still takes all thirteen ops, because the writer's own paste goes through it.
 
-Two consequences worth stating here rather than in a module:
+See [`plan.md`](./plan.md) for the ops and the applier.
 
-- **The applier is the one write path**, so a Panel cannot make a change the applier would
-  refuse, and a structural edit carries the consequences the ops already state.
-- **`chatProposalSchema` leaves the three Reference ops out of the tool the model sees.**
-  Research reaches the Plan by being Accepted from an Offer, so handing a model
-  `createReference` would be a way round the Ledger. The applier takes all thirteen ops,
-  because the writer's own paste goes through it too.
+### 4.2 One refusal serves two readers
 
-The ops, the applier, and the refusal types are [`plan.md`](./plan.md).
+The applier lives in `src/shared`, so its refusal has to answer the model and the writer at
+once. `refusal.message` goes back to the model with a Decline. `refusalText.ts` builds the
+writer's sentence at the edge from `refusal.reason` plus the Plan, so it can name a Section
+the way the Outline numbers it. See [`plan.md`](./plan.md).
 
-### 4.2 A refusal has two readers
+### 4.3 Sync rides a second socket, and server writes go through `commit()`
 
-The applier lives in `src/shared`, so its refusal has to serve the model and the writer at
-once. `refusal.message` is the model's, sent back with a Decline. The writer's sentence is
-built at the edge from `refusal.reason`, a closed code, plus the records it is about — the
-Panel holds the Plan, so it can name a Section the way the Outline numbers it, where the
-applier only has an id.
-
-So **one English string lives in `src/shared`**, aimed at an LLM, and the writer's half is a
-table over a closed union. `refusalText.ts` is total over `RefusalReason`, so a new refusal
-site stops it compiling until it says what the new one reads as.
-
-### 4.3 The Article Agent syncs over a second socket
-
-The `useAgent` socket carries `cf_agent_*` control frames for state, RPC, and scheduling,
-which the SDK's own client handles. Namespacing party-db frames onto it was the expensive
-alternative, so the sync traffic rides a second socket to the same Durable Object instead.
-Two sockets cost nothing that multiplexing would not.
-
-Four seams hold that composition together, and **every server write to a synced table goes
-through `commit()`** — a raw write reaches a fresh snapshot and never an already-connected
-client, because only the oplog feeds the stream. Both are [`sync.md`](./sync.md).
+The `useAgent` socket carries the SDK's `cf_agent_*` control frames, so party-db connects to
+the same Durable Object over a second socket rather than sharing that one. To reach an
+already-connected client, a server write must go through `commit()`, because only the oplog
+feeds the stream. See [`sync.md`](./sync.md).
 
 ### 4.4 One connection per Article, opened above the Panels
 
-`useArticleAgent` makes the single `useAgent` call and hands out three things: the Plan
-channel, the Offer store built on the same socket's RPC, and the client itself, which is what
-`useAgentChat` takes. The Panels read it through `ArticleProvider` rather than connecting
-themselves. A Panel opening its own would be a second socket, a second `createPlanWriter`, and
-a second debounce timer against a blob whose whole design is that it has one writer.
+`useArticleAgent` makes the single `useAgent` call and hands out the Plan channel, the Offer
+store built on that socket's RPC, and the client that `useAgentChat` takes. The Panels read
+those through `ArticleProvider` instead of connecting themselves. A Panel that opened its own
+connection would add a second socket, a second `createPlanWriter`, and a second debounce
+timer against a blob that rule 1 gives one writer.
 
-### 4.5 An Accepted Offer is copied, and the Provenance is the link
+### 4.5 The writer Accepts Offers, which become References and keep their Provenance
 
-The Plan's copy is the writer's to edit; the original Offer stays as the record of what was
-produced. A later correction therefore arrives as a new Proposal rather than silently
-rewriting a citation the writer already approved. Asking whether an Offer is already in the
-Plan runs on the Provenance rather than on content, because the writer edits their copy and
-content stops matching the moment they do.
+An Accepted Offer is copied into the Plan, and the writer may then edit that Reference
+freely. The Offer row stays as the record of what the Chat produced, so a later correction
+arrives as a new Proposal instead of silently rewriting a citation the writer approved. To
+tell whether an Offer already reached the Plan we compare Provenance rather than content,
+because the writer's edits break a content match.
 
-**Accepting is two writes against two stores, and nothing makes them atomic**, so the order is
-fixed: the Plan copy first, then the ruling. A failed second write leaves an Undecided Offer,
-which the writer can Accept again. The other order leaves the row reading Accepted with the
-Plan holding nothing — invisible on the Ledger and unrecoverable from it. Details in
-[`chat.md`](./chat.md).
+Accepting writes the Plan first and rules the Offer second. If the ruling fails, the Offer
+stays Undecided and the writer can Accept again. See [`chat.md`](./chat.md).
 
-### 4.6 The title lives in two places, and the Plan write goes first
+### 4.6 Article titles live in the D1 index and in the Article Agent
 
-The Plan holds the real title; the article index holds a copy written by the same client
-action that renames the Article — `useTitleCopy`, debounced beside the Plan's own writer. A
-Plan that lands with a failed copy leaves a stale row that the next rename corrects. The other
-order would leave the list ahead of the Plan with nothing to walk it back.
-
-That is §4.5's argument applied to the second pair of writes in the app. The index itself is
+The Plan holds the real title. The index holds a copy, written by the same client action that
+renames the Article — `useTitleCopy`, debounced beside the Plan's own writer. The Plan write
+goes first, so a failed copy leaves a stale row that the next rename corrects. See
 [`articles.md`](./articles.md).
 
-### 4.7 `src/shared` is the contract, and it imports neither side
+### 4.7 `src/shared` holds the code both sides import
 
-**Three source roots**: `src/client`, `src/server`, and `src/shared` for the modules both
-sides import — the Plan schema, the Proposal ops, and the applier. Nothing in `src/shared`
-touches a Worker binding or React, and each tsconfig lists the root once rather than naming
-each domain. The Article Agent validates the same Plan the client does, off the same file, so
-a Proposal the Agent would reject is refused at the edge where there is a reason to show.
+`src/client`, `src/server`, and `src/shared` are the three source roots. `src/shared` holds
+the Plan schema, the Proposal ops, the applier, and the collection schemas in `sync.ts`.
+Nothing there may touch a Worker binding or React, so both sides can import it. That is what
+lets the Article Agent validate a Plan against the same file the client used, and lets the
+client refuse a Proposal at the edge where it has a reason to show.
 
-`src/shared/sync.ts` is the other half of this: the wire rows are the table rows, declared
-once ([`sync.md`](./sync.md)).
+### 4.8 Cloudflare Access gates the edge; identity arrives at 1b
 
-### 4.8 Auth gates the edge, and identity arrives at 1b
+Access gates the Worker, so an unauthenticated request never arrives. 1a needs no auth code:
+one Team, both people read everything, and no record is per-user.
 
-**Cloudflare Access** gates the Worker at the edge, so an unauthenticated request does not
-arrive. **1a is single-author and its auth is zero code** — one Team, both people read
-everything, no per-user records, so nothing parses a token.
+We avoid reading `Cf-Access-Jwt-Assertion` while we can, because localhost has no Access gate
+and therefore no header, which keeps development simple.
 
-**We avoid reading `Cf-Access-Jwt-Assertion` while we can**, because localhost has no Access
-gate and so no header, which keeps development simple. The DX can change later.
+At 1b, party-db's `authorize` runs in the partyserver lobby and needs a verified identity
+before the object wakes. Access injects the assertion as a header where party-db expects
+`?token=` on connect, so `authorize` reads the header. Issue #12 tracks whether the header
+survives a WebSocket upgrade into the Durable Object. If it does not, we move to WorkOS.
 
-**Identity arrives at 1b**, when party-db's `authorize` runs in the partyserver lobby and
-needs a verified identity before the object wakes. Access injects the assertion as a header
-where party-db expects `?token=` on connect, so `authorize` reads the header. Whether the
-header survives a WebSocket upgrade into the Durable Object is unproven — issue #12. If it
-fails, WorkOS is the documented upgrade.
+Attributing Chat messages to people is wanted and deferred past 1a. The Agents SDK stores a
+role rather than a person, so this needs a field on the `UIMessage` or a parallel table.
 
-**Attributing Chat messages to people is wanted and deferred past 1a.** The Agents SDK stores
-a role, not a person, so it needs a field on the `UIMessage` or a parallel table. A stable
-person id is small and should persist, which is what `metadata` is for
-([`chat.md`](./chat.md)).
+### 4.9 Accept and Decline mean the same thing for a Note, an Offer, and a Proposal
 
-### 4.9 Accept and Decline are the same two words everywhere
-
-A Note, an Offer, and a Proposal are all things the writer rules on, so they are ruled on with
-the same two words. The three records still differ in shape — an Offer starts `undecided`, a
-Note starts `proposed`, and a Proposal stores no disposition at all and dies with its turn —
-and whether that is worth reconciling is issue #79.
+The writer rules on all three the same way, so we use the same two words. The records still
+differ in shape: an Offer starts `undecided`, a Note starts `proposed`, and a Proposal stores
+no disposition and dies with its turn. Issue #79 asks whether to reconcile them.
 
 ## 5. Out of scope
 
-- **The tracking model** — affirmed Boundaries and text-relocating operations, which would
-  make Section membership a fact the app operates on rather than something the Guide infers.
-- **Multi-user scoping beyond one Team of two** — House sharing, per-publication sets,
+- The tracking model: affirmed Boundaries and text-relocating operations, which would make
+  Section membership a fact the app operates on rather than something the Guide infers.
+- Multi-user scoping beyond one Team of two: House sharing, per-publication sets, and
   collaboration.
-- **Any harness that evaluates the Guide's output.** The Guide writes Guidance notes, and v1
-  ships nothing that scores them.
-- **Future ideas** parked in [`later.md`](./later.md): the public showcase, the arc note,
-  Review lenses, exemplar pieces, a copy-edit pass, and Transition word-count attribution.
+- Any harness that scores the Guide's output.
+- The ideas parked in [`later.md`](./later.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,21 +1,31 @@
 # Architecture
 
-This document records the current and planned/decided architecture of the application,
-particularly for patterns that are used to coordinate or bind more than one module.
-The reasoning behind each decision lives in the wayfinding map, issue #5, and its closed
-tickets.
+This document records the patterns that bind more than one module. A rule earns a place here
+when it can be written as: _this module does that, so this other one has to do this, or that
+breaks._ Written that way a constraint carries its own expiry — when the first half stops
+being true, the second half is up for review.
 
-This document should make very clear what is a rule (and what it's for), vs. descriptions
-of how we're doing things now, so as not to over-specify and constrain future innovation.
+A fact about one module's insides goes in that module's file. A convention with no failure
+behind it is a helper function or a lint rule, not an entry here. The reasoning behind each
+decision lives in the wayfinding map, issue #5, and its closed tickets.
 
-- Vocabulary is fixed in [`context.md`](./context.md) and governs the code, the UI,
-  and this file.
-- UI decisions and patterns go in [`ui.md`](./ui.md) or the Storybook stories it includes
-  by reference.
-- Certain key architecture decisions are recorded in the [`adr`](./adr/) folder.
-- What a feature is and how it behaves goes in its own file — [`reviews.md`](./reviews.md).
-- What has to be set outside the repository is [`deploy.md`](./deploy.md).
-- Use [`later.md`](./later.md) sparingly.
+## The doc map
+
+| File                           | Holds                                                               |
+| ------------------------------ | ------------------------------------------------------------------- |
+| [`context.md`](./context.md)   | The vocabulary, which governs the code, the UI, and every file here |
+| [`plan.md`](./plan.md)         | The Plan blob, the ops, the applier, the refusals                   |
+| [`chat.md`](./chat.md)         | The Chat, the Offers Ledger, the Proposal tool machinery            |
+| [`reviews.md`](./reviews.md)   | Reviews, Rounds, and Notes                                          |
+| [`draft.md`](./draft.md)       | The Draft and the guide loop — phase 2                              |
+| [`articles.md`](./articles.md) | The article index and the two Article Views                         |
+| [`sync.md`](./sync.md)         | party-db inside the Article Agent                                   |
+| [`llm.md`](./llm.md)           | The model, search, and the prompt packs                             |
+| [`ui.md`](./ui.md)             | UI decisions, and the Storybook stories it includes by reference    |
+| [`carries.md`](./carries.md)   | Settings we hold and defects we work around                         |
+| [`deploy.md`](./deploy.md)     | What has to be set outside the repository                           |
+| [`adr/`](./adr/)               | Decision records for the storage shape, the Plan, and the editor    |
+| [`later.md`](./later.md)       | Parked ideas. Use sparingly                                         |
 
 ## 1. Build order
 
@@ -35,6 +45,9 @@ an acceptable constraint.
 in front of you soonest. Arguments from scale, cost, or throughput decide only when they
 threaten that.
 
+Phase 2 is decided at low resolution now so 1a cannot paint itself into a corner —
+[`draft.md`](./draft.md).
+
 ## 2. Shape
 
 ```
@@ -42,10 +55,10 @@ Browser — React + Vite + TanStack Router
   ├─ Chat Panel   ─┐
   ├─ Plan Panel    ├── useAgent WebSocket ───► Article Agent (one per Article)
   ├─ Draft Panel   ├── party-db WebSocket ──►   ├─ Agents SDK store: the Chat transcript
-  └─ Notes Panel  ─┘    (same Agent, §12)       ├─ Agent state (one JSON blob): the Plan
+  └─ Notes Panel  ─┘    (same Agent, §4.3)      ├─ Agent state (one JSON blob): the Plan
                                                 ├─ SQLite rows: Blocks
                                                 ├─ party-db collections over its SQLite:
-                                                │    Notes, Rounds, Offers (synced, §12)
+                                                │    Notes, Rounds, Offers (synced)
                    ── party-db WebSocket ──►  The House (one party-db room, → D1)   [1b]
                    ── HTTP (Hono) ─────────►  The article index (→ D1)
                                               Archived reads, export
@@ -55,36 +68,37 @@ Browser — React + Vite + TanStack Router
 **Cloudflare throughout.** Workers, Durable Objects, D1, R2, Workers AI.
 
 **One Article Agent per Article**, built on the Cloudflare Agents SDK. It holds everything
-about one Article. It is named in full as "Article Agent" to distinguish from the general
+about one Article. It is named in full as "Article Agent" to distinguish it from the general
 term or a different agent we might add later.
 
 **House Style** arrives at 1b as a single party-db room persisted to D1, holding the writer's
-own standing material: the Lexicon, the standing rules, the Skills, and House-scoped Voice
-and Adjectives. The House is small, read frequently, simple CRUD over a few
-collections, so the API is just the PartyDB collections talking to the PartyDbServer.
-
-**The House holds style and process guides that the writer authors and reuses.** These are
-things like research skills/formats, preferred writing Voice, definitions for key Adjectives,
-such as "punchy" or "serious", favourite authors and publications -- things that the Article
-Agent will use to either gather research, make suggestions, or review the draft.
+own standing material — the Lexicon, the standing rules, the Skills, and House-scoped Voice
+and Adjectives. It is small, read frequently, and simple CRUD over a few collections, so its
+API is the PartyDB collections talking to a `PartyDbServer`. What the House is for is
+[`context.md`](./context.md).
 
 **Plain D1 tables** hold Archived Plans, Drafts, and Finals, read through a Worker endpoint
 rather than synced. D1 also carries the backup story, because a Durable Object's storage has
 no export path and D1 has `wrangler d1 export`.
 
-**Three source roots**: `src/client`, `src/server`, and `src/shared` for the modules both
-sides import — the Plan schema, the Proposal ops, and the applier. Nothing in `src/shared`
-touches a Worker binding or React, and each tsconfig lists the root once rather than
-naming each domain.
+**Hono serves the HTTP** in the same Worker: the Agents SDK's chat route, the article index,
+party-db's lobby and write path at 1b, archived reads, and export.
+
+**React + Vite with TanStack Router**, served as static assets from the Worker. **TanStack
+Start does not join it** — its value is a typed server boundary in both directions, and the
+Agents SDK owns the actions while the two sockets own the reads, leaving about five HTTP
+calls in total. **TanStack Query** serves the article index and the archived and export
+reads; live data is already reactive through Article Agent state and party-db's TanStack DB
+collections.
 
 Recorded in [ADR 0001](./adr/0001-phase-1-storage-shape.md).
 
 ## 3. Where writes go
 
-1. **Article Agent state holds only the Plan, and only the client writes it.** `setState`
-   replaces the entire blob, so a write meant to change one Section rewrites every
-   field from whatever version the client last read. A second writer's changes vanish with
-   no conflict and no error.
+1. **Article Agent state holds the Plan, and the client is its writer.** `setState` replaces
+   the entire blob, so a write meant to change one Section rewrites every field from whatever
+   version the client last read. A second writer's changes vanish with no conflict and no
+   error, which is what keeps the blob to one writer.
 2. **Every other per-Article record is a SQLite row in the Article Agent**, read and written
    over `@callable` RPC on the WebSocket the client already holds. That covers the Draft's
    Blocks, and Offers, Notes, and Rounds. Row writes touch named columns, so the Guide can
@@ -93,649 +107,138 @@ Recorded in [ADR 0001](./adr/0001-phase-1-storage-shape.md).
 3. **A request is an action when it runs a model, and CRUD otherwise.** Actions: sending a
    Chat turn, running a Review, running research. CRUD: editing a Section, editing a
    Reference, Accepting a Proposal, Declining an Offer, retitling the Article. Accepting is
-   CRUD even though a model produced the thing being accepted, because applying it is a
-   plain write.
-4. **The Guide writes only Notes.** Guidance notes and Rounds are its own output,
-   which the writer doesn't (currently) author.
-5. **Accepting copies into the Plan and keeps the Provenance.** The Plan's copy is the
-   writer's to edit; the original stays as the record of what was produced. A later
-   correction therefore arrives as a new Proposal rather than silently rewriting a citation
-   the writer already approved.
-
-**The blob is a reactive store; a table is on-demand until it is published as a
-party-db collection.** A bare row in a Durable Object's SQLite has no sync — `@callable`
-RPC is request and response, so nothing tells a client it changed. That still suits
-Blocks, which the client both writes and reads. Notes, Rounds and Offers are published as
-party-db collections instead (§12): reads are synced live queries, the Guide's writes go
-through `commit()`, and rule 2's write path still holds for what the writer sends up —
-rulings stay RPC. Which table joins them next is decided per table; the Draft is the one
-left, and §10 says why it can wait.
-
-## 4. The Plan
-
-One JSON blob in Article Agent state. Full shape and rationale in
-[ADR 0002](./adr/0002-the-plan-data-model.md).
-
-```
-plan: {
-  title, totalTarget,
-  voice, adjectives: [],
-  outline: [ { id, title, intent?, target?, voice?, adjectives?: [], children: [] } ],
-  references: [ { id, type, provenance, text?, source?, nodeId, note? } ],
-}
-```
-
-- **The Outline is a nested tree**, sibling order carried by array position, every Section with
-  a stable ID that never changes. What the writer reads is that position, worked out in
-  `outlineEntries`: the bare `ordinal` for a gutter of them and for a phrase that composes
-  one ("Section 2"), and `sectionLabel` for the standalone form ("§2"). Both come from the
-  one walk, so no two Panels can number a Section differently.
-- **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
-  Section or nowhere yet.
-- **References are type Link or Quote**, and Reference is the umbrella over either type. The
-  type is **assigned, not derived from the contents**, so an Offer and the Reference it was
-  Accepted into carry the same `type`. Amended in
-  [ADR 0002](./adr/0002-the-plan-data-model.md).
-- **Voice cascades; Adjectives compose.** Both resolve down the same path — House, then
-  Article, then Section, **at read time** — and they differ when two Scopes each state one.
-  The nearest Voice wins outright. Adjectives accumulate instead: a "slow" Section inside a
-  "fast" Article carries both, and the resolved list runs widest first, so the nearest lands
-  last and reads as the strongest. Restating a term moves it to the end, which lets the
-  writer say it again for emphasis.
-- **The word-count total is stored rather than derived/summed.** The parts may disagree with
-  the whole; the gap is information about under/over allocation.
-- **One spelling per state.** A field that may be absent says "nothing here" by being
-  absent, and not also by an empty string or an empty list — the blob is written whole,
-  compared whole-field by a Proposal's `expected`, and sent whole in every prompt pack, so
-  two Plans that mean the same thing should be the same, field for field. The schema enforces
-  this today: an empty `adjectives` on a Section is refused. Some fields always carry their
-  key and indicate "nothing here" with a value; others are absent when empty, but we make
-  sure to accept only one or the other. **Choosing for a new field: a question the record is
-  always asked carries its key and answers with a value, and a Section's own refinement is
-  absent until it is set.** `nodeId`, `totalTarget`, and `children` are the first kind — every
-  Reference has a placement even when unplaced. `intent`, `target`, and `voice` are the
-  second. Read which one a field takes off `src/shared/plan/schema.ts` rather than from a
-  list here.
-
-**The schema guards client writes.** `validateStateChange` parses the whole Plan on every
-write, and the model's outputs do not go through it — the Chat proposes and the client
-applies, so the blob has only client writes. What the model does meet are the **piece**
-schemas, `outlineNodeSchema`, `referenceSchema`, and `sourceSchema`, reused inside a
-Proposal's op payloads. It lives in `src/shared/plan/` with the Scope resolver and the
-word-count arithmetic.
-
-Four invariants sit above the object shape, checked in the same parse: a Section id is
-unique among Sections, a Reference id is unique among References, no two References were
-copied from one Offer, and a placed Reference names a node that exists. The last one means
-an op that deletes a node unplaces its References in the same Proposal, because the Plan is
-written whole and validated whole.
-
-**Size**: a normal Plan runs about 40 KB. The soft ceiling is around 100 KB, where
-re-broadcasting on every write gets noticeable; the hard wall is 2 MB, the Durable Object
-limit on a single row or value. Growth comes from References carrying long passages. The
-relief valve is moving References into SQLite rows, which is the phase 2 move anyway.
-**Debounce `setState` while the writer types**, or 40 KB goes over the wire per keystroke.
-
-## 5. Chat and the Offers Ledger
-
-The Chat turns up Offers — Links and Quotes — as rows in the Article Agent's `offer`
-collection, synced to every connected client (§12). The
-**Ledger** is a View over all the Offers surfaced in this Chat. Offers can be
-**Undecided**, **Accepted**, or **Declined** (restorable). In this way, the Ledger is used
-as a direct sibling to, or alternative to, showing the chat transcript. We toggle it on or
-off within the Chat Panel to view something specific about the Chat. It doesn't attempt to
-do the job of any other Panels; when Offers are Accepted, they get promoted into the Plan
-as new References, and this is the end of the Offer Ledger's job. It's just throwing the
-new Reference over the wall to the next Panel, moving curated pieces of knowledge from the
-first Panel to the second. The Plan Panel's references are their own editable clones,
-so the Offers don't really have to keep track.
-
-**The research tool carries an `execute`**, where the Proposal tool does not. An Offer is an
-inert row rather than something the writer rules on mid-turn, so suspending the call would
-buy nothing and cost the turn — a research turn returns seventeen items, and an unruled tool
-batch stalls the Chat with no orphan timeout (§11). The suspend-or-execute rule is per tool
-rather than for the registry.
-
-**Deduplication runs in two places, and neither compares the Plan's content.** A research
-turn calls `recordOffers`, which runs inside the Article Agent rather than over RPC — the
-writer never authors an Offer, so nothing on the client may. It fingerprints each entry —
-the type, the text, and the source, never the note — and hands back the row already there
-rather than writing a second one, still carrying the disposition the writer gave it.
-Asking whether an Offer is already in the Plan runs on the Provenance instead: the writer
-edits their copy, and content stops matching the moment they do.
-
-**Accepting is two writes against two stores, and nothing makes them atomic.** The copy goes
-first, with a `createReference` op through the applier like every other Plan edit, then
-`setOfferDisposition` over RPC. This way round a failure does not create an un-recoverable
-middle state. The Plan write is local so as long as it succeeds, the RPC can fail and the
-only consequence is an Undecided Offer in the Ledger. If the writer attempts to Accept it
-again, `acceptOffer` returns `null` and builds no op at all.
-
-**The other order strands the writer, which is why the order is fixed.** Ruling first leaves
-the row reading Accepted with the Plan holding nothing. That state is invisible on the
-Ledger, because the Ledger shows a ruled Offer as settled and does not read the Plan to
-check. It is also unfixable from the Ledger, because there is no control that re-runs the
-copy for an Offer already Accepted. Nothing recovers it, and nothing surfaces it.
-
-**A refused copy stops the ruling for the same reason.** `edit` hands back the applier's
-refusal, and `useOfferLedger` reads it: sending the ruling anyway would land the app in
-exactly that stranded state. The writer gets the applier's sentence instead, built at the
-edge from `refusal.reason` like every other one (§6).
-
-**Nothing announces a research turn's rows.** They land through the sync as the Guide
-commits them, on the Ledger of every connected client — which is what deleted
-`listOffers` as a `@callable`, the Ledger's load-once contract, and the reload the Chat
-threaded through when it read fresh ids out of the transcript. The Chat still reads that
-tool output, for the Offer cards it draws in the transcript.
-
-**The writer pastes their own References straight into the Plan**, and those carry
-`provenance: { type: 'writer' }` rather than an Offer id. They never enter the Ledger: an
-Offer is something the Chat turned up and handed over to rule on, and there is nothing to
-rule on in a passage the writer typed.
-
-**One Offer becomes one Reference**, and `planSchema` refuses a Plan carrying two copies
-of one. `referenceForOffer` answers with the first match on the strength of it, and that
-answer is what makes a retried Accept build no op — so a second copy would turn every retry
-into another copy.
-
-**A retrieved Offer is the same row as a recalled one.** `provenance` is `writer` or `offer`
-and says nothing about whether the Chat looked the source up or remembered it (§7). How to
-mark that on an Offer and on the Reference it becomes is open, and waits on #40.
-
-**Proposals are not Offers.** See below.
-
-## 6. Chat and Proposals
-
-**The Chat is standard, and we adopt rather than invent.** Chat with research, tool calls,
-approved edits, and an output artifact is well-trodden territory.
-
-**The Article Agent extends `AIChatAgent`** from `@cloudflare/ai-chat`, which is where that
-class now lives — importing `agents/ai-chat-agent` throws and says so. It routes a turn to
-`onChatMessage`, and the Chat rides the socket the Plan and the RPC already share. The
-transcript stays in the Agents SDK's own store.
-
-**The Chat Panel is `src/client/chat/`.** `useArticleChat` is the wiring — the transcript,
-the composer, and the two rulings — and `ChatPanel` is the surface, taking a transcript and
-the rulings the way `PlanPanel` takes a Plan and one `edit`. The rule itself is
-`ruleProposal`, a pure function the app and the showcase both run, so a story cannot rule
-differently from the product.
-
-**The Chat can make proposals; only the writer (client) can apply them to the Plan.** The
-Chat doesn't get to write to the Plan directly; it surfaces Proposals; the writer can click
-to Accept or Decline them. Accepting is `edit(ops)`, the same call every Plan edit makes.
-The Proposal's ops go through `createPlanWriter` rather than a
-`setState` of their own: the writer holds the Plan the writer sees, so the Plan always gets
-updated in a way that will make sense to the writer, even if server and client are out of
-sync (§3, rule 1).
-
-**A refused Accept answers nothing and leaves the card open.** The card shows the applier's
-sentence, the writer may fix the Plan and Accept again, and Declining sends that sentence
-back — so the model learns the Plan moved rather than that the writer said no.
-
-**Proposals are `execute`-less tools** (AI SDK v7). A tool with no `execute` suspends for the
-client, which is the Proposal. Four API details, each easy to get wrong:
-
-- Use `addToolOutput`, not the deprecated `addToolResult`, and call it **without `await`** —
-  the docs warn twice about deadlock.
-- `addToolApprovalResponse` takes `part.approval.id`, not `toolCallId`.
-- Do **not** use `needsApproval` or `toolApproval`. Both gate a server-side `execute` this
-  product does not have.
-- A rejection returns `is_error: true` with the reason in the content.
-
-**Send the Plan in `body`, never in `metadata`.** `body` is request-only and never enters the
-transcript; `metadata` persists on the `UIMessage` and re-rides every turn.
-
-### Proposal shape
-
-A list of ops, applied all-or-nothing.
-
-```
-proposal: [
-  { op: 'createNode', parentId, beforeId, node: { id, title, intent, children: [] } },
-  { op: 'setTarget',  nodeId, expected: null, value: 400 },
-]
-```
-
-- **`expected` is content-addressed staleness** — it names the value the Proposal thinks is
-  there, not a version. Compared **whole-field**, because Plan fields are short.
-- **Structural ops anchor on IDs and carry no `expected`.** Exactly one of `afterId` or
-  `beforeId`, so the model anchors to whichever neighbour its insertion relates to: a Section
-  leading into §3 says `before: §3` and survives §2 being deleted. `afterId: null` means
-  first child, `beforeId: null` means last child.
-- **If any op's `expected` fails, the whole Proposal is Stale.** The UI must say why rather
-  than greying it out — whole-field comparison is conservative and will refuse a Proposal
-  against a field the writer has since touched.
-
-**Thirteen ops**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
-`deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
-`placeReference`, `createReference`, `deleteReference`, `setReference`.
-
-**The Chat is offered ten of them.** The three Reference ops are how the writer pastes a
-Reference in themselves, and `chatProposalSchema` leaves them out of the tool the model
-sees — research reaches the Plan by being Accepted from an Offer, and handing a model
-`createReference` would be a way round the Ledger (§5). The applier takes all thirteen,
-because the writer's own paste goes through it too.
-
-A content op reads `nodeId: null` as the Article Scope, so setting the
-Article's Voice and setting one node's Voice are one op rather than two. Two ops carry a
-consequence worth stating: **`deleteNode` unplaces every Reference placed at the node it
-removes or at any node below it**, because the Plan is written whole and a Reference naming a
-node that is gone does not parse; and **`mergeNodes` keeps the target's own fields**, moving the source's children
-and placed References onto it, so a Proposal that wants the source's intent note carried over
-says so with a `setIntent` op in the same batch.
-
-**The applier refuses with a reason**, in `src/shared/plan/apply.ts`. `applyProposal` returns
-either a new Plan or a refusal naming which op failed, its position in the Proposal, and what
-it expected against what it found. It sorts refusals into four types, listed on `RefusalType`
-where they cannot drift away from the union. It also parses the Plan it produces, so a
-Proposal the Article Agent would reject is refused here, where there is a reason to show,
-rather than there, where there is none.
-
-**A refusal has two readers, the LLM and the human.** `refusal.message` is for the model's:
-a Declined Proposal sends it back, so it names the op and the ids and may run long. The
-writer's sentence is built at the edge from `refusal.reason` — a closed code
-naming exactly what went wrong — plus the records it is about, in
-`src/client/plan/refusalText.ts`. The Panel that shows it holds the Plan, so it can name a
-Section the way the Outline numbers it, where the applier only has an id.
-
-Two things follow. **One English string lives in `src/shared`**, aimed at a an LLM. The
-writer's half is a table over a closed union, so if we used a second language, it would be a
-second table rather than a sweep through the applier. `refusalText.ts` is total over
-`RefusalReason`, so a new refusal site stops it compiling until it says what the new one
-reads as.
-
-**The op payloads are strict, and a rejected tool call retries with the validation error.**
-The piece schemas the payloads reuse are `strictObject`, so a model that adds one field fails
-the whole tool call rather than having the field stripped. Stripping would produce a Proposal
-the model did not make and the writer would rule on it without seeing what was dropped. The
-cost is real: a model that adds the same field every time thrashes the retry instead of
-converging, and the answer to that is naming the field in the schema, not loosening every
-payload to strip.
-
-**Staleness is not a multi-client problem.** It comes from the gap between generating a
-Proposal and applying it, and inference is slower than typing, so it exists with one writer
-in one tab. We are currently quite strict about marking Proposals as stale, but as time goes
-on we may want to come up with heuristics that allow us to be a bit more forgiving.
-
-## 7. Inference
-
-**Currently using `@cf/zai-org/glm-5.2` on Workers AI**, over the `env.AI` binding. 262k
-context, tool calling and streaming supported, Workers Paid plan required. Swapping it is one
-string, and #16 names the fallback and why it is a swap rather than a spike.
-
-**Currently, one model serves every call** — the Chat, the ambient Guidance notes, the
-Review. No routing machinery, no per-call-type model selection is included here.
-
-**The AI SDK follows from "Cloudflare throughout" (§2) rather than being chosen against
-alternatives.** `@cloudflare/ai-chat` declares `ai` and `@ai-sdk/react` as peer dependencies,
-and `workers-ai-provider` is an AI SDK provider whose `createWorkersAI` returns an `ai`
-`LanguageModel` over the `env.AI` binding. So the SDK arrives with both packages, and dropping
-it would mean dropping `AIChatAgent` and calling the binding by hand. It stays
-provider-agnostic, which is what keeps the model swap above down to one string.
-
-**The swappable boundary is the model instance, not a wrapper API.** AI SDK v7 already
-provides `generateText`, `streamText`, and `generateObject`; a wrapper would duplicate it and
-break the `execute`-less tool machinery.
-
-```ts
-// src/server/llm/model.ts — the whole boundary
-import { createWorkersAI } from 'workers-ai-provider'
-export const model = (env: Env) =>
-  createWorkersAI({ binding: env.AI })('@cf/zai-org/glm-5.2')
-```
-
-**Search is Exa**, in `src/server/llm/search.ts` — the one place a provider is named, as
-`llm/model.ts` is for the model. **No key means no search tool**, and the guide is told to
-answer from memory instead: the registry and the guide rules read one value, so they cannot
-disagree about what the turn can reach. **A search that fails answers rather than throws**,
-because a rejected `execute` ends a turn that still owes the writer a reply.
-
-**Model output is validated, never parsed out of prose.** A Proposal is a tool call and a
-Review is `generateObject` against a zod schema — both checked in the Article Agent, with one
-retry carrying the validation error. A Review's prose lives _inside_ that schema rather than
-being scanned for structure.
-
-The Gateway and the keys are deployment configuration — [`deploy.md`](./deploy.md).
-
-**Prompt packs put the stable part first** — system prompt, then Lexicon entries in play,
-then the standing rules, then everything that changes. The Plan and the Draft change all the
-time, so they go at the end.
-
-**Where the writer has just spoken, their message is the last thing the model reads**, and
-the Plan sits in front of it. A model weights the final message as the one to answer, so a
-pack ending on the Plan's JSON risks a turn that discusses the Plan rather than the question
-the writer asked. This is the rule the Chat pack is built around.
-
-**The exception is a turn that resumes after a tool call**, where the transcript ends with a
-tool result rather than the writer. A tool result answers the assistant message before it,
-and the Plan is a user message, so slotting it in front would split that pair — which the AI
-SDK refuses outright with `MissingToolResultsError`, before the model is called at all. The
-Plan goes last in that case, and there is no writer message to keep last anyway.
-`chatPackMessages` and `planSlot` in `src/server/llm/prompt.ts` are the whole of it.
-
-Whether the stable-first ordering saves anything on Workers AI is unmeasured — the argument
-for it is structural, and the arithmetic is in #16.
-
-Each row below reads in pack order, stable to volatile.
-
-| Pack       | Contents                                                                                    |
-| ---------- | ------------------------------------------------------------------------------------------- |
-| Chat turn  | The Chat transcript, then the Plan, then the writer's own last message                      |
-| Proposal   | The affected span, plus adjacent Section titles and intent notes. Nothing else              |
-| Guide pass | The Plan, then the Draft or active Section with neighbours, then recent deltas. **No Chat** |
-| Review     | The same, plus the existing Notes. **No Chat**                                              |
-
-Research reaches a Review only by being Accepted into the Plan. The Ledger is the bridge, and
-curation is forced rather than assumed.
-
-**Cost does not constrain the design** — #16 priced a guide pass at about a tenth of a cent.
-
-## 8. Frontend
-
-**React + Vite with TanStack Router**, served as static assets from the Worker. **TanStack
-Start does not join it** — its value is a typed server boundary in both directions, and the
-Agents SDK owns the actions while the two sockets own the reads, leaving about five HTTP
-calls in total.
-
-**Hono** serves those in the same Worker: the Agents SDK's chat route, the article index,
-party-db's lobby and write path at 1b, archived reads, and export.
-
-**TanStack Query** serves the article index and the archived and export reads. Live data is
-already reactive through Article Agent state and party-db's TanStack DB collections — the
-Notes Panel's and the Offer ledger's today (§12), the House's at 1b.
-
-**The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
-narrow screen, and which are all more or less their own little interfaces, with very specific
-and explicit, user-gated interactions between them. `usePanels` holds which are open, keeps
-them in the one order, drawn by a `Rail` component in the navbar. It also sets how wide each
-one gets: Notes takes a fixed slice as the margin rail, and the Draft takes twice what a
-supporting Panel does out of what is left, so the prose keeps the room whatever is beside it.
-
-**Use Loading states instead of drawing empty values.** An empty title, a zero count and four
-empty columns are answers, and a screen that puts one on the page before it has read anything
-has said something untrue. Whatever is still coming says so — `Skeleton` where the shape is
-known, a sentence like "Opening the Plan…" where it is not, and a route's `pendingComponent`
-where the whole screen is waiting. This is why the Article bar takes `title: string | null`:
-`''` is the title the writer cleared, and it cannot also mean "not read yet".
-
-**Navigation is a `Link`.** Tanstack Router provides this component for us, with the very
-helpful `defaultPreload: 'intent'` which allows us to trigger functions, such as waking up a
-different Article Agent's Durable Object to improve loading times.
-
-**The Articles Area is the list at `/` and the Board View at `/board`**, over the one index
-read, under a pathless layout route that holds both.
-
-**The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
-in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
-`expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to
-`setState`. One write path means the Panel cannot make a change the applier would refuse,
-and a structural edit gets the consequences the ops already state — deleting a Section
-unplaces its References. The writer's own edits never go Stale: staleness is the gap
-between generating a Proposal and applying it, and there is no gap here.
-
-**One writer holds the Plan and the debounce**, in `src/client/plan/writer.ts`. It applies
-each edit locally, sends after a pause for the four ops a keystroke produces, and sends at
-once for everything else. An update arriving from the Article Agent over an unsent edit is
-the echo of an older write and is dropped — the client is the Plan's only writer, so there
-is nothing else it can be.
-
-**The Article Agent's WebSocket is multiplexed, and party-db does not share it.** The
-`useAgent` socket carries `cf_agent_*` control frames for state, RPC, and scheduling,
-which the SDK's own client handles. The sync traffic rides a second socket to the same
-Durable Object instead (§12) — namespacing party-db frames onto the shared one was the
-expensive alternative, and two sockets cost nothing that multiplexing would not.
-
-**One connection per Article, opened above the Panels.** `useArticleAgent` makes the single
-`useAgent` call and hands out three things: the Plan channel, the Offer store built on the
-same socket's RPC, and the client itself, which is what `useAgentChat` takes. The Panels read
-it through `ArticleProvider` rather than connecting themselves. A Panel opening its own would
-be a second socket, a second `createPlanWriter`, and a second debounce timer against a blob
-whose whole design is that it has one writer.
-
-## 9. Auth
-
-**Cloudflare Access** gates the Worker at the edge. An unauthenticated request never arrives.
-
-**1a is single-author and its auth is zero code.** One Team, both people read everything, no
-per-user records, so nothing parses a token.
-
-**The article index is a real D1 table** — a small table read through Hono routes in the
-same Worker, on the path §2 already has for the Archived reads. It does not wait for the
-House. An Article created on one machine appears on the other, which is what makes the index
-worth having at all. Issue #29 built it.
-
-**It is a list, not a store.** One row carries `{ id, title, status, createdAt, updatedAt,
-archivedAt }` and nothing else, so the Article Agent stays the source of truth for the
-contents of the Article, and nothing on the index path reaches into one.
-
-**The title is the one field that lives in two places.** The Plan holds the real one, and the
-index holds a copy written by the same client action that renames the Article —
-`useTitleCopy`, debounced beside the Plan's own writer. **The Plan write goes first**, so a
-Plan that lands with a failed copy leaves a stale row that the next rename corrects; the
-other order would leave the list ahead of the Plan with nothing to walk it back. That is §5's
-argument about Accepting an Offer, applied to the second pair of writes in the app.
-
-**`status` is the writer's word, not an inference.** 1a has no Draft to measure, so the
-Article screen carries the one control that sets it and the Board View reads it. `updatedAt`
-is when the row last changed — a rename, a status, or Archiving — and not when the Article
-was last worked on, because a Plan edit goes to the Article Agent and never touches this
-table.
-
-**An Archived Article stays on the same table** and says so with `archivedAt`, rather than
-moving to one of its own. Both Views filter the one list the index answers with: the list
-shows Archived Articles as a group at its foot, and the Board View leaves them out. Moving
-the Chat to R2 is still §11's, still unbuilt, and independent of this flag.
-
-**Avoiding the `Cf-Access-Jwt-Assertion` header makes localhost dev easier.** Localhost has
-no Access gate at all, so in development there is no header and no gate. We can change our
-DX later if we want to; for now this practice keeps things simple.
+   CRUD even though a model produced the thing being accepted, because applying it is a plain
+   write.
+4. **The blob is a reactive store; a table is on-demand until it is published as a party-db
+   collection.** A bare row in a Durable Object's SQLite has no sync — `@callable` RPC is
+   request and response, so nothing tells a client it changed. That still suits Blocks, which
+   the client both writes and reads. Notes, Rounds and Offers are published as party-db
+   collections instead: reads are synced live queries, the Guide's writes go through
+   `commit()`, and rule 2's write path still holds for what the writer sends up — rulings stay
+   RPC. Which table joins them next is decided per table; the Draft is the one left, and
+   [`draft.md`](./draft.md) says why it can wait.
+
+## 4. The seams
+
+Each entry names two sides and what has to hold between them.
+
+### 4.1 The model proposes; the client applies
+
+The Chat surfaces Proposals and the writer rules on them. Accepting is `edit(ops)`, the same
+call every Plan edit makes, and the ops go through `createPlanWriter` rather than a `setState`
+of their own. The writer holds the Plan the writer sees, so the Plan gets updated in a way
+that makes sense to the writer even when server and client have drifted apart (§3, rule 1).
+
+This is the shape we reach for across the app: **pass work from server to client as notes,
+Offers, and Proposals, and let the client write them into the record.** It is a UX answer
+where the alternative is a conflict-resolution answer, and it buys the reader two fewer
+decisions — how to surface the change, and how to merge it — for the price of one pattern.
+
+Two consequences worth stating here rather than in a module:
+
+- **The applier is the one write path**, so a Panel cannot make a change the applier would
+  refuse, and a structural edit carries the consequences the ops already state.
+- **`chatProposalSchema` leaves the three Reference ops out of the tool the model sees.**
+  Research reaches the Plan by being Accepted from an Offer, so handing a model
+  `createReference` would be a way round the Ledger. The applier takes all thirteen ops,
+  because the writer's own paste goes through it too.
+
+The ops, the applier, and the refusal types are [`plan.md`](./plan.md).
+
+### 4.2 A refusal has two readers
+
+The applier lives in `src/shared`, so its refusal has to serve the model and the writer at
+once. `refusal.message` is the model's, sent back with a Decline. The writer's sentence is
+built at the edge from `refusal.reason`, a closed code, plus the records it is about — the
+Panel holds the Plan, so it can name a Section the way the Outline numbers it, where the
+applier only has an id.
+
+So **one English string lives in `src/shared`**, aimed at an LLM, and the writer's half is a
+table over a closed union. `refusalText.ts` is total over `RefusalReason`, so a new refusal
+site stops it compiling until it says what the new one reads as.
+
+### 4.3 The Article Agent syncs over a second socket
+
+The `useAgent` socket carries `cf_agent_*` control frames for state, RPC, and scheduling,
+which the SDK's own client handles. Namespacing party-db frames onto it was the expensive
+alternative, so the sync traffic rides a second socket to the same Durable Object instead.
+Two sockets cost nothing that multiplexing would not.
+
+Four seams hold that composition together, and **every server write to a synced table goes
+through `commit()`** — a raw write reaches a fresh snapshot and never an already-connected
+client, because only the oplog feeds the stream. Both are [`sync.md`](./sync.md).
+
+### 4.4 One connection per Article, opened above the Panels
+
+`useArticleAgent` makes the single `useAgent` call and hands out three things: the Plan
+channel, the Offer store built on the same socket's RPC, and the client itself, which is what
+`useAgentChat` takes. The Panels read it through `ArticleProvider` rather than connecting
+themselves. A Panel opening its own would be a second socket, a second `createPlanWriter`, and
+a second debounce timer against a blob whose whole design is that it has one writer.
+
+### 4.5 An Accepted Offer is copied, and the Provenance is the link
+
+The Plan's copy is the writer's to edit; the original Offer stays as the record of what was
+produced. A later correction therefore arrives as a new Proposal rather than silently
+rewriting a citation the writer already approved. Asking whether an Offer is already in the
+Plan runs on the Provenance rather than on content, because the writer edits their copy and
+content stops matching the moment they do.
+
+**Accepting is two writes against two stores, and nothing makes them atomic**, so the order is
+fixed: the Plan copy first, then the ruling. A failed second write leaves an Undecided Offer,
+which the writer can Accept again. The other order leaves the row reading Accepted with the
+Plan holding nothing — invisible on the Ledger and unrecoverable from it. Details in
+[`chat.md`](./chat.md).
+
+### 4.6 The title lives in two places, and the Plan write goes first
+
+The Plan holds the real title; the article index holds a copy written by the same client
+action that renames the Article — `useTitleCopy`, debounced beside the Plan's own writer. A
+Plan that lands with a failed copy leaves a stale row that the next rename corrects. The other
+order would leave the list ahead of the Plan with nothing to walk it back.
+
+That is §4.5's argument applied to the second pair of writes in the app. The index itself is
+[`articles.md`](./articles.md).
+
+### 4.7 `src/shared` is the contract, and it imports neither side
+
+**Three source roots**: `src/client`, `src/server`, and `src/shared` for the modules both
+sides import — the Plan schema, the Proposal ops, and the applier. Nothing in `src/shared`
+touches a Worker binding or React, and each tsconfig lists the root once rather than naming
+each domain. The Article Agent validates the same Plan the client does, off the same file, so
+a Proposal the Agent would reject is refused at the edge where there is a reason to show.
+
+`src/shared/sync.ts` is the other half of this: the wire rows are the table rows, declared
+once ([`sync.md`](./sync.md)).
+
+### 4.8 Auth gates the edge, and identity arrives at 1b
+
+**Cloudflare Access** gates the Worker at the edge, so an unauthenticated request does not
+arrive. **1a is single-author and its auth is zero code** — one Team, both people read
+everything, no per-user records, so nothing parses a token.
+
+**We avoid reading `Cf-Access-Jwt-Assertion` while we can**, because localhost has no Access
+gate and so no header, which keeps development simple. The DX can change later.
 
 **Identity arrives at 1b**, when party-db's `authorize` runs in the partyserver lobby and
-needs a verified identity before the object wakes. Access injects
-`Cf-Access-Jwt-Assertion` as a header where party-db expects `?token=` on connect, so
-`authorize` reads the header. Whether the header survives a WebSocket upgrade into the
-Durable Object is unproven — issue #12. If it fails, WorkOS is the documented upgrade.
+needs a verified identity before the object wakes. Access injects the assertion as a header
+where party-db expects `?token=` on connect, so `authorize` reads the header. Whether the
+header survives a WebSocket upgrade into the Durable Object is unproven — issue #12. If it
+fails, WorkOS is the documented upgrade.
 
 **Attributing Chat messages to people is wanted and deferred past 1a.** The Agents SDK stores
 a role, not a person, so it needs a field on the `UIMessage` or a parallel table. A stable
-person id is the one case where `metadata` persistence is wanted; §6's warning is about
-payload size and staleness, not about `metadata` as such.
+person id is small and should persist, which is what `metadata` is for
+([`chat.md`](./chat.md)).
 
-## 10. Phase 2, at low resolution
+### 4.9 Accept and Decline are the same two words everywhere
 
-Decided now so 1a cannot paint itself into a corner. The Draft is built and persists; the
-Guide, the Notes Panel, and everything that reads the prose are not.
+A Note, an Offer, and a Proposal are all things the writer rules on, so they are ruled on with
+the same two words. The three records still differ in shape — an Offer starts `undecided`, a
+Note starts `proposed`, and a Proposal stores no disposition at all and dies with its turn —
+and whether that is worth reconciling is issue #79.
 
-- **The Draft is one row per Block**, meaning per paragraph. Not one row for the whole Draft,
-  and not one row per Section — a row per Section would make Section Boundaries a storage
-  fact, and they are approximate and inferred. A list or a blockquote is one Block too: a
-  Block is a top-level child of the document, whatever kind it is.
-- **The Draft is edited locally** and persisted to the server. A server-authoritative
-  ProseMirror step stream is ruled out — the client is the Draft's only writer, the same way
-  it is the Plan's.
-- **A Block is a row in the Article Agent's SQLite**, written over `@callable` RPC by rule 2,
-  and **a save carries a delta** rather than the whole Draft. The delta is what bounds a
-  stale tab: a client can only name a Block it has already seen, so a paragraph written
-  somewhere else is not one it can delete.
-- **Sync arrived early, and the Draft is what is left out.** party-db (`mhsnook/party-db`,
-  checked out at `~/code/party-db`) runs inside the Article Agent for Notes, Rounds and
-  Offers (§12); the House at 1b gets its own room. The Draft is not synced and can move
-  onto a collection later without changing shape. Until then two tabs on one Draft is
-  last-write-wins per Block, which is what §1's "only one editor at a time" costs.
-  Findings #7 and #18 stand and are not load-bearing yet.
-- **Notes is the fourth Panel**, and it is built — §12. What is still phase 2's is the
-  ambient half: notes that arrive while the writer works, and anything drawn beside the
-  prose.
-- **The guide loop is client-initiated. There is no server-side timer anywhere in v1.** The
-  client knows when typing stopped; the server cannot tell "still thinking" from "left the
-  room." An alarm earns its place only when work must happen while nobody is connected, and
-  there is no such work. A stale Proposal or an orphaned tool batch expires lazily on read.
-- **Guidance notes do not stream.** A Review is the thing that should.
-- **The Draft is a ProseMirror document, built with TipTap.** The reason is narrow: a
-  decoration is **drawn as part of the document's layout while staying out of its content**,
-  which is what the Guide needs for anything it shows beside the prose without writing it.
-  Marks decide nothing — every candidate stores a comment as one. So **a Proposal is a
-  decoration and an accepted annotation is a mark**: a proposed section break parts the
-  paragraphs and reaches no stored row, while a comment rides in the prose, because only a
-  mark survives the writer rewriting around it in a session that never drew the note. And
-  **a comment is not a Block reference** — it is a set of marked runs spanning any number of
-  Blocks, targeting the span from its first to its last.
-  `docs/adr/0003-the-draft-editor.md`.
-- **The writer types their own headings and section breaks.** Boundaries are inferred, so
-  nothing can place a title automatically; writer control is the tiebreaker, and what the
-  writer typed is then the strongest hint the inference has.
-
-## 11. Carries
-
-Settings and known defects. None is a decision to make; all are things to get right.
-
-- **Only the Chat goes cold when an Article is Archived.** Archive is a soft delete. The
-  Plan, the Draft, and the Final move to plain D1 tables and stay readable; the Chat goes to
-  R2, and un-archiving asks the writer whether to bring it back whole or truncate it. Not
-  built in v1.
-- **Set party-db's `oplogRetention` low, around 200** against its default of 10,000. For a
-  hot row the reconnect delta measured 400× the snapshot, and party-db has no large-delta
-  bail-out. Low retention pushes a returning client onto the cheap snapshot path. The
-  Article Agent's core sets 200; the House's room should too.
-- **The per-Article sync client is cached for the session, and its collections are
-  pinned.** party-db exposes no way to close a transport (party-db#46), and a collection
-  that restarts after TanStack DB's GC gets no second snapshot (party-db#47) — so
-  `articleSync` holds one client per Article and a standing subscription per collection.
-  Both carries undo when the upstream teardown lands.
-- **party-db never compares `previousValue`.** Any concurrent write clobbers the whole row.
-  The Block shape limits the blast radius; nothing removes it.
-- **party-db has no per-row access control.** `src/server/access.ts` warns that `access` and
-  `ownerColumn` are unenforced (party-db #33). Survivable while both people may read
-  everything, and not survivable the moment that stops being true.
-- **An expired Access session answers with a redirect rather than a 1008 close**, so
-  party-db's client reconnect-loops instead of firing `onAuthError`.
-- **`@callable` needs the `agents/vite` plugin, in both Vite configs.** Vite 8 transpiles
-  with oxc, which does not implement TC39 decorators (oxc#9170) and emits the `@` syntax
-  verbatim, so the Worker fails to parse with "SyntaxError: Invalid or unexpected token".
-  The plugin lowers them through Babel. `vitest.config.ts` needs it as well as
-  `vite.config.ts` — a worker test builds the Article Agent, and the two files do not
-  share plugins. **Do not reach for `experimentalDecorators`**: the SDK uses standard
-  decorators, and the legacy convention hands `callable()` the prototype instead of the
-  method, so nothing registers and every RPC call is refused at runtime with "is not
-  callable" — a silent failure where the missing plugin is a loud one.
-- **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
-  completeness server-side with **no orphan timeout**, so a Proposal the writer neither
-  Accepts nor Declines stalls the Chat silently. The composer counts the suspended calls and
-  says what it is waiting on rather than sitting dead; nothing expires them.
-- **Local development is half solved.** `pnpm db:migrate` puts the article index's schema
-  into the local D1 and the worker tests apply the same files themselves, so a build ticket
-  can run what it writes against a real table. What is still missing is seeded data: an
-  Article with a Plan and a transcript already in it, so a screen can be opened rather than
-  built up by hand every time.
-
-## 12. Notes and the Review
-
-What the feature is and how it behaves is [`reviews.md`](./reviews.md). The rules here
-bind more than one module; issue #92 is the pilot that set the sync ones.
-
-**The Article Agent runs the Review, and the client does not.** A Review is long-running
-and produces a batch, so a client-run one is lost the moment the writer closes the tab —
-issue #11. `startReview` writes a Round row, answers with it, and carries on under
-`waitUntil`. Two things follow:
-
-- **`state` is a column.** `running` has to survive the writer leaving, and a Review that
-  fails with nobody connected has to leave its reason on the row rather than on a call.
-  A `running` row seen at wake is one a restart cut off — the Review itself holds the
-  Agent awake — so `onStart` fails it, freeing the guard below.
-- **One Review at a time per Article**, guarded by the running row and enforced by the
-  table: a partial unique index allows at most one `running` row. The pre-check in
-  `startReview` gives the friendly refusal; the index holds when two calls interleave
-  across an `await` (#9), which a field could not — in-memory state does not survive
-  hibernation, and a check-then-write races itself.
-
-**One Offer per source per Article**, enforced by a UNIQUE index over a stored
-`fingerprint` column rather than by the map §5 describes. Syncing the Offers is what
-forced that: `recordOffers` has to reach `commit()`, party-db's queue defers the commit to
-a microtask even against embedded SQLite, and the AI SDK runs a step's parallel tool calls
-concurrently — so two turns of one step both read before either wrote. The map is built
-from the table, so an uncommitted call is invisible to the one beside it. This is
-`round_one_running` one table over, on a sharper constraint: the Review guard needs a
-hibernation to race, and this one needs only an await. If the Offers stop syncing, the
-dedupe is a synchronous read-and-insert again and the index can go.
-
-**A refused commit is re-read, not parsed.** `commit()` throws the adapter's error as it
-comes — party-db classifies rejections only on its HTTP write path, and its embedded
-SQLite adapter implements none of the optional `classifyError` hook the Postgres one
-fills in. The alternative is matching a SQLite message string in app code, which changes
-with the adapter. So `recordOffers` and `createRound` both re-read and let the table say
-who won, and so should the next guard. A typed rejection out of `commit()` retires this.
-
-**A Durable Object's SQLite migrates on the wake.** `migrations_dir` in `wrangler.jsonc`
-belongs to the D1 binding, and there are as many Article databases as there are Articles.
-No wrangler mechanism reaches inside one, so `onStart` is the only code that runs against
-them all — and it runs on every wake, which is what makes a new column need a
-`pragma_table_info` guard where a new table needs only `IF NOT EXISTS`.
-
-**Notes, Rounds and Offers are party-db collections, hosted by the Article Agent
-itself.** This is #84's hosting question, answered: the Agent cannot subclass
-`PartyDbServer` — it already extends `AIChatAgent` — so it holds a `PartyDbCore` built
-over its own SQLite (party-db#43), and §3 rule 2 stands as written. No room Durable
-Object sits beside it. The composition is four seams, all keyed on party-db's own
-`?proto=party-db` marker:
-
-- **A second socket, not a shared one.** `partyTransport` connects to the same Durable
-  Object over partyserver's `/parties/article-agent/:name` route, beside the `useAgent`
-  socket (§8). A reconnecting client passes `?since` and gets the delta it missed; a
-  fresh one gets a snapshot.
-- **Marked connects go to the core and skip the Agents SDK handshake** —
-  `shouldSendProtocolMessages` turns the identity/state/MCP frames off for them.
-- **Every broadcast leaves sync subscribers out.** The Agent overrides `broadcast`, which
-  is the one path the SDK's own frames (state sync, Chat streams) and the app's
-  (`plan_refused`) all pass through. A sync subscriber hears `SequencedBatch` frames and
-  nothing else.
-- **The client write path is closed.** A party-db write POST answers 403: rulings are
-  server-side state-machine moves, and party-db has no per-row policy layer to hold their
-  guards yet (party-db#33). Forwarding to `handleWrite` is the whole change when a
-  client-authored collection arrives.
-
-**Every server write to a synced table goes through `commit()`, never raw SQL.** A raw
-write reaches a fresh snapshot and never an already-connected client, because only the
-oplog feeds the stream. Reads stay plain SQL, the fingerprint dedupe in `recordOffers`
-among them: the oplog carries writes. The Guide writes a Round's Notes and its settle in
-one commit, and a research turn commits its Offers in one too — a subscriber that hears
-the Round settle already holds its Notes, and a turn that found seventeen things costs
-one batch rather than seventeen. Rulings stay `@callable` RPC for their guards on all
-three types, implemented over `commit()` so the ruled row syncs. Nothing announces a
-Review settling or a turn recording any more — the rows landing is the announcement,
-which is what deleted the `review_finished` frame, the Notes Panel's poll, its reload
-counter, and the Ledger's.
-
-**One call is one transaction, so a batch recovers whole and not by the row.** party-db
-runs a call's ops in one transaction, with the oplog's compaction inside it, so the oplog
-never has a torn floor — a half-landed batch would leave a subscriber's delta describing
-rows the table does not have. The cost falls on the two batched writes above: one refused
-row takes the call's other rows with it, so a caller that meets a rejection re-decides the
-whole batch. `recordOffers` re-dedupes against what landed and commits the remainder.
-Per-op rejection in party-db would make that loop a catch again.
-
-**The wire rows are the table rows.** `src/shared/sync.ts` declares the three collections'
-schemas as the columns stand — snake_case, JSON columns as the text they store — and owns
-the one mapping to the shapes the app reads. JSON-typed fields would arrive unparsed
-anyway: party-db's column codec reads Zod v3 internals and this repo is on Zod v4
-(party-db#45).
-
-**A Note's anchor is settled once, at write time, against the Plan and Draft the model was
-shown.** An anchor the client cannot resolve reads as the whole piece and breaks nothing,
-so the write is taken and the anchor settled rather than the Note refused — issue #42's
-line, applied where nothing is load-bearing. What happens to an anchor afterwards is
-`reviews.md`.
-
-**Accept and Decline are the same two words for a Note, an Offer, and a Proposal**, because
-the writer rules on all three the same way. The three records still differ in shape — an
-Offer starts `undecided`, a Note starts `proposed`, a Proposal stores no disposition at all
-and dies with its turn — and whether that is worth reconciling is issue #79.
-
-**A Review does not stream, and §10 says it should.** Its Notes now arrive live as rows,
-but the Round's prose lands whole; the streaming version is `streamObject` over the
-Agent's `onRequest` — issue #77. The cost is smaller than it looks, because the Round is
-durable: the wait is a row rather than a call being held open.
-
-## 13. Out of scope
+## 5. Out of scope
 
 - **The tracking model** — affirmed Boundaries and text-relocating operations, which would
   make Section membership a fact the app operates on rather than something the Guide infers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,8 +20,8 @@ Team grows, revisit section 3 first.
 Where two options are close, take the one that puts a usable writing product in front of you
 soonest. Cost and throughput arguments decide only when they threaten that.
 
-The build order and its stages are project management, not architecture. They live in issue
-#5 with the rest of the wayfinding map.
+The build order and its stages are project management, not architecture. Stage 1a shipped as
+issues #21 to #29. Stage 1b is #53, the House. Stage 2 is #54, the Draft and the Guide.
 
 ## 2. Shape
 

--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,0 +1,30 @@
+# The article index
+
+The list of Articles at `/` and the Board View at `/board`, over one D1 table read through
+Hono routes in the same Worker. The rule that binds it to the Article Agent is
+[`architecture.md`](./architecture.md). Issue #29 built it.
+
+**It is a list, not a store.** One row carries `{ id, title, status, createdAt, updatedAt,
+archivedAt }` and nothing else, so the Article Agent stays the source of truth for the
+contents of an Article, and nothing on the index path reaches into one.
+
+**It does not wait for the House.** An Article created on one machine appears on the other,
+which is what makes the index worth having at all.
+
+**`status` is the writer's word, not an inference.** 1a has no Draft to measure, so the
+Article screen carries the one control that sets it and the Board View reads it.
+
+**`updatedAt` is when the row last changed** — a rename, a status, or Archiving — and not
+when the Article was last worked on, because a Plan edit goes to the Article Agent and never
+touches this table.
+
+**An Archived Article stays on the same table** and says so with `archivedAt`, rather than
+moving to one of its own. Both Views filter the one list the index answers with: the list
+shows Archived Articles as a group at its foot, and the Board View leaves them out.
+
+**Archive is a soft delete, and only the Chat goes cold.** The Plan, the Draft, and the Final
+move to plain D1 tables and stay readable; the Chat goes to R2, and un-archiving asks the
+writer whether to bring it back whole or truncate it. Not built in v1, and independent of the
+`archivedAt` flag.
+
+**Both Views read one index call**, under a pathless layout route that holds them.

--- a/docs/articles.md
+++ b/docs/articles.md
@@ -1,30 +1,28 @@
 # The article index
 
-The list of Articles at `/` and the Board View at `/board`, over one D1 table read through
-Hono routes in the same Worker. The rule that binds it to the Article Agent is
-[`architecture.md`](./architecture.md). Issue #29 built it.
+One D1 table, read through Hono routes in the same Worker, backing the list at `/` and the
+Board View at `/board`. Both Views read one index call under a pathless layout route. Issue
+#29 built it.
 
-**It is a list, not a store.** One row carries `{ id, title, status, createdAt, updatedAt,
-archivedAt }` and nothing else, so the Article Agent stays the source of truth for the
-contents of an Article, and nothing on the index path reaches into one.
+A row carries `{ id, title, status, createdAt, updatedAt, archivedAt }` and nothing else, so
+the Article Agent stays the source of truth for an Article's contents and nothing on the index
+path reaches into one.
 
-**It does not wait for the House.** An Article created on one machine appears on the other,
-which is what makes the index worth having at all.
+The index does not wait for the House. An Article created on one machine appears on the other,
+which is what makes the index worth having.
 
-**`status` is the writer's word, not an inference.** 1a has no Draft to measure, so the
-Article screen carries the one control that sets it and the Board View reads it.
+`status` records the writer's word rather than an inference. 1a has no Draft to measure, so
+the Article screen carries the one control that sets it and the Board View reads it.
 
-**`updatedAt` is when the row last changed** — a rename, a status, or Archiving — and not
-when the Article was last worked on, because a Plan edit goes to the Article Agent and never
-touches this table.
+`updatedAt` records when the row last changed — a rename, a status, or Archiving. It does not
+record when the writer last worked on the Article, because a Plan edit goes to the Article
+Agent and never touches this table.
 
-**An Archived Article stays on the same table** and says so with `archivedAt`, rather than
-moving to one of its own. Both Views filter the one list the index answers with: the list
-shows Archived Articles as a group at its foot, and the Board View leaves them out.
+An Archived Article stays on this table and says so with `archivedAt`, rather than moving to a
+table of its own. Both Views filter the one list: the list shows Archived Articles as a group
+at its foot, and the Board View leaves them out.
 
-**Archive is a soft delete, and only the Chat goes cold.** The Plan, the Draft, and the Final
-move to plain D1 tables and stay readable; the Chat goes to R2, and un-archiving asks the
-writer whether to bring it back whole or truncate it. Not built in v1, and independent of the
-`archivedAt` flag.
-
-**Both Views read one index call**, under a pathless layout route that holds them.
+Archiving is a soft delete, and only the Chat goes cold. The Plan, the Draft, and the Final
+move to plain D1 tables and stay readable. The Chat goes to R2, and un-archiving asks the
+writer whether to bring it back whole or truncate it. This is not built in v1 and is
+independent of the `archivedAt` flag.

--- a/docs/carries.md
+++ b/docs/carries.md
@@ -1,0 +1,17 @@
+# Carries
+
+Settings we have to hold and defects we have to work around. None is a decision to make; all
+are things to get right. party-db's own carries are [`sync.md`](./sync.md).
+
+- **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
+  completeness server-side with no orphan timeout, so a Proposal the writer neither Accepts
+  nor Declines stalls the Chat silently. The composer counts the suspended calls and says
+  what it is waiting on rather than sitting dead; nothing expires them.
+- **`@callable` needs the `agents/vite` plugin, in both Vite configs.** The reasoning, and
+  the warning about `experimentalDecorators`, are comments in `vite.config.ts` beside the
+  plugin they are about.
+- **Local development is half solved.** `pnpm db:migrate` puts the article index's schema
+  into the local D1, and the worker tests apply the same files themselves, so a build ticket
+  can run what it writes against a real table. What is missing is seeded data: an Article
+  with a Plan and a transcript already in it, so a screen can be opened rather than built up
+  by hand every time.

--- a/docs/carries.md
+++ b/docs/carries.md
@@ -1,17 +1,15 @@
 # Carries
 
-Settings we have to hold and defects we have to work around. None is a decision to make; all
-are things to get right. party-db's own carries are [`sync.md`](./sync.md).
+Settings we hold and defects we work around. party-db's own carries are
+[`sync.md`](./sync.md).
 
-- **An abandoned tool batch parks indefinitely.** Cloudflare's `ai-chat` enforces batch
-  completeness server-side with no orphan timeout, so a Proposal the writer neither Accepts
-  nor Declines stalls the Chat silently. The composer counts the suspended calls and says
-  what it is waiting on rather than sitting dead; nothing expires them.
-- **`@callable` needs the `agents/vite` plugin, in both Vite configs.** The reasoning, and
-  the warning about `experimentalDecorators`, are comments in `vite.config.ts` beside the
-  plugin they are about.
-- **Local development is half solved.** `pnpm db:migrate` puts the article index's schema
-  into the local D1, and the worker tests apply the same files themselves, so a build ticket
-  can run what it writes against a real table. What is missing is seeded data: an Article
-  with a Plan and a transcript already in it, so a screen can be opened rather than built up
-  by hand every time.
+- Nothing expires an abandoned tool batch. Cloudflare's `ai-chat` enforces batch completeness
+  server-side with no orphan timeout, so a Proposal the writer neither Accepts nor Declines
+  stalls the Chat silently. The composer counts the suspended calls and says what it is
+  waiting on, rather than sitting dead.
+- `@callable` needs the `agents/vite` plugin in both Vite configs. `vite.config.ts` carries
+  the reasoning and the warning about `experimentalDecorators`, beside the plugin.
+- Local development has no seed data. `pnpm db:migrate` puts the article index's schema into
+  the local D1, and the worker tests apply the same files themselves, so a build ticket can
+  run what it writes against a real table. What is missing is an Article with a Plan and a
+  transcript already in it, so a screen can be opened rather than built up by hand.

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,0 +1,132 @@
+# The Chat, Offers, and Proposals
+
+What the Chat is and how it behaves, both halves — `src/client/chat/` for the Panel and the
+Ledger, `src/server/article-agent.ts` for `recordOffers` and the tool registry. The
+cross-module rules it obeys are [`architecture.md`](./architecture.md); the Plan ops a
+Proposal carries are [`plan.md`](./plan.md); the words are [`context.md`](./context.md).
+
+**The Chat is standard, and we adopt rather than invent.** Chat with research, tool calls,
+approved edits, and an output artifact is well-trodden territory.
+
+**The Article Agent extends `AIChatAgent`** from `@cloudflare/ai-chat`, which is where that
+class now lives — importing `agents/ai-chat-agent` throws and says so. It routes a turn to
+`onChatMessage`, and the Chat rides the socket the Plan and the RPC already share. The
+transcript stays in the Agents SDK's own store.
+
+**The Chat Panel is `src/client/chat/`.** `useArticleChat` is the wiring — the transcript,
+the composer, and the two rulings — and `ChatPanel` is the surface, taking a transcript and
+the rulings the way `PlanPanel` takes a Plan and one `edit`. The rule itself is
+`ruleProposal`, a pure function the app and the showcase both run, so a story cannot rule
+differently from the product.
+
+## The Offers Ledger
+
+The Chat turns up Offers — Links and Quotes — as rows in the Article Agent's `offer`
+collection, synced to every connected client ([`sync.md`](./sync.md)). The **Ledger** is a
+View over all the Offers surfaced in this Chat. Offers can be **Undecided**, **Accepted**,
+or **Declined** (restorable).
+
+The Ledger is a sibling to the chat transcript rather than a replacement for it, toggled on
+or off within the Chat Panel to see something specific about the Chat. It does not do the
+job of another Panel: when an Offer is Accepted it is promoted into the Plan as a new
+Reference, and the Ledger's job ends there. It throws the new Reference over the wall to the
+next Panel, moving curated pieces of knowledge from the first Panel to the second. The Plan
+Panel's References are their own editable clones, so the Offers do not have to track them.
+
+**The writer pastes their own References straight into the Plan**, and those carry
+`provenance: { type: 'writer' }` rather than an Offer id. They do not enter the Ledger: an
+Offer is something the Chat turned up and handed over to rule on, and there is nothing to
+rule on in a passage the writer typed.
+
+**Nothing announces a research turn's rows.** They land through the sync as the Guide
+commits them, on the Ledger of every connected client — which is what deleted `listOffers`
+as a `@callable`, the Ledger's load-once contract, and the reload the Chat threaded through
+when it read fresh ids out of the transcript. The Chat still reads that tool output, for the
+Offer cards it draws in the transcript.
+
+**A retrieved Offer is the same row as a recalled one.** `provenance` is `writer` or `offer`
+and says nothing about whether the Chat looked the source up or remembered it. How to mark
+that on an Offer and on the Reference it becomes is open, and waits on #40.
+
+## Deduplication
+
+**One Offer per source per Article**, and neither half of the check compares the Plan's
+content. Asking whether an Offer is already in the Plan runs on the Provenance instead: the
+writer edits their copy, and content stops matching the moment they do.
+
+The fingerprint is the type, the text, and the source, and not the note. Two mechanisms
+carry the constraint, and both are load-bearing:
+
+- **The map in `recordOffers` is the working path.** It runs inside the Article Agent rather
+  than over RPC — the writer never authors an Offer, so nothing on the client may. It builds
+  a fingerprint map from the table, dedupes the incoming batch against it, and hands back
+  the row already there rather than writing a second one, still carrying the disposition the
+  writer gave it.
+- **`offer_one_per_fingerprint` is the guard the map cannot be.** `recordOffers` has to
+  reach `commit()`; party-db's queue defers the commit to a microtask even against embedded
+  SQLite, and the AI SDK runs a step's parallel tool calls concurrently — so two calls of one
+  step can both read before either wrote, and the map is built from the table, so an
+  uncommitted call is invisible to the one beside it. A UNIQUE index over a stored
+  `fingerprint` column refuses the second write. `recordOffers` then re-reads, re-dedupes
+  against what landed, and commits the remainder.
+
+This is `round_one_running` one table over ([`reviews.md`](./reviews.md)), on a sharper
+constraint: the Review guard needs a hibernation to race, and this one needs only an await.
+If the Offers stop syncing, the dedupe is a synchronous read-and-insert again and the index
+can go.
+
+**One Offer becomes one Reference**, and `planSchema` refuses a Plan carrying two copies of
+one. `referenceForOffer` answers with the first match on the strength of it, and that answer
+is what makes a retried Accept build no op — so a second copy would turn every retry into
+another copy.
+
+## Accepting an Offer
+
+**Accepting is two writes against two stores, and nothing makes them atomic.** The copy goes
+first, with a `createReference` op through the applier like every other Plan edit, then
+`setOfferDisposition` over RPC. This way round a failure does not create an unrecoverable
+middle state. The Plan write is local, so as long as it succeeds the RPC can fail and the
+only consequence is an Undecided Offer in the Ledger. If the writer Accepts again,
+`acceptOffer` returns `null` and builds no op at all.
+
+**The other order strands the writer, which is why the order is fixed.** Ruling first leaves
+the row reading Accepted with the Plan holding nothing. That state is invisible on the
+Ledger, because the Ledger shows a ruled Offer as settled and does not read the Plan to
+check. It is also unfixable from the Ledger, because no control re-runs the copy for an
+Offer already Accepted. Nothing recovers it, and nothing surfaces it.
+
+**A refused copy stops the ruling for the same reason.** `edit` hands back the applier's
+refusal, and `useOfferLedger` reads it: sending the ruling anyway would land the app in
+exactly that stranded state. The writer gets the applier's sentence instead, built at the
+edge from `refusal.reason` like every other one ([`plan.md`](./plan.md)).
+
+## Proposals
+
+**Proposals are not Offers.** An Offer is a piece of research to rule on; a Proposal is a
+change to the Plan to rule on. The Chat can make Proposals, and the writer applies them —
+Accepting is `edit(ops)`, the same call every Plan edit makes.
+
+**A refused Accept answers nothing and leaves the card open.** The card shows the applier's
+sentence, the writer may fix the Plan and Accept again, and Declining sends that sentence
+back — so the model learns the Plan moved rather than that the writer said no.
+
+**Proposals are `execute`-less tools** (AI SDK v7). A tool with no `execute` suspends for the
+client, which is the Proposal. Four call-site details, each easy to get wrong:
+
+- Use `addToolOutput`, not the deprecated `addToolResult`, and call it **without `await`** —
+  the docs warn twice about deadlock.
+- `addToolApprovalResponse` takes `part.approval.id`, not `toolCallId`.
+- `needsApproval` and `toolApproval` both gate a server-side `execute` this product does not
+  have, so neither does anything here.
+- A rejection returns `is_error: true` with the reason in the content.
+
+**The research tool carries an `execute`, where the Proposal tool does not.** An Offer is an
+inert row rather than something the writer rules on mid-turn, so suspending the call would
+buy nothing and cost the turn — a research turn returns seventeen items, and an unruled tool
+batch stalls the Chat with no orphan timeout ([`carries.md`](./carries.md)). Suspend-or-execute
+is decided per tool rather than for the registry.
+
+**The Plan goes in `body` rather than `metadata`.** `body` is request-only and does not enter
+the transcript; `metadata` persists on the `UIMessage` and re-rides every turn, and the Plan
+is both large and stale by the next turn. A small value that should persist — a person id,
+say — is what `metadata` is for.

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -26,7 +26,8 @@ Ledger from ids in the transcript. The Chat still reads the tool output to draw 
 cards.
 
 `provenance` records `writer` or `offer`. It does not say whether the Chat searched for a
-source or recalled it from memory; issue #40 covers marking that.
+source or recalled it from memory. How to mark that on an Offer, and on the Reference it
+becomes, is open and waits on issue #40.
 
 ## Deduplication
 

--- a/docs/chat.md
+++ b/docs/chat.md
@@ -1,132 +1,93 @@
-# The Chat, Offers, and Proposals
+# Chat, Offers, and Proposals
 
-What the Chat is and how it behaves, both halves — `src/client/chat/` for the Panel and the
-Ledger, `src/server/article-agent.ts` for `recordOffers` and the tool registry. The
-cross-module rules it obeys are [`architecture.md`](./architecture.md); the Plan ops a
-Proposal carries are [`plan.md`](./plan.md); the words are [`context.md`](./context.md).
+Client code in `src/client/chat/`; server code in `src/server/article-agent.ts`. The Plan ops
+a Proposal carries are [`plan.md`](./plan.md).
 
-**The Chat is standard, and we adopt rather than invent.** Chat with research, tool calls,
-approved edits, and an output artifact is well-trodden territory.
-
-**The Article Agent extends `AIChatAgent`** from `@cloudflare/ai-chat`, which is where that
-class now lives — importing `agents/ai-chat-agent` throws and says so. It routes a turn to
+The Article Agent extends `AIChatAgent` from `@cloudflare/ai-chat`. Importing
+`agents/ai-chat-agent` throws, because the class moved. `AIChatAgent` routes a turn to
 `onChatMessage`, and the Chat rides the socket the Plan and the RPC already share. The
 transcript stays in the Agents SDK's own store.
 
-**The Chat Panel is `src/client/chat/`.** `useArticleChat` is the wiring — the transcript,
-the composer, and the two rulings — and `ChatPanel` is the surface, taking a transcript and
-the rulings the way `PlanPanel` takes a Plan and one `edit`. The rule itself is
-`ruleProposal`, a pure function the app and the showcase both run, so a story cannot rule
-differently from the product.
+`useArticleChat` holds the wiring — the transcript, the composer, and the two rulings — and
+`ChatPanel` renders it, the way `PlanPanel` takes a Plan and one `edit`. Both the app and the
+Storybook showcase call `ruleProposal`, so a story cannot rule differently from the product.
 
 ## The Offers Ledger
 
-The Chat turns up Offers — Links and Quotes — as rows in the Article Agent's `offer`
-collection, synced to every connected client ([`sync.md`](./sync.md)). The **Ledger** is a
-View over all the Offers surfaced in this Chat. Offers can be **Undecided**, **Accepted**,
-or **Declined** (restorable).
+The Ledger is a view on the Chat's Offers. An Offer is Undecided, Accepted, or Declined, and
+a Declined one can be restored. Accepting copies the Offer into the Plan as a Reference, and
+the Ledger's job ends there.
 
-The Ledger is a sibling to the chat transcript rather than a replacement for it, toggled on
-or off within the Chat Panel to see something specific about the Chat. It does not do the
-job of another Panel: when an Offer is Accepted it is promoted into the Plan as a new
-Reference, and the Ledger's job ends there. It throws the new Reference over the wall to the
-next Panel, moving curated pieces of knowledge from the first Panel to the second. The Plan
-Panel's References are their own editable clones, so the Offers do not have to track them.
+The Plan's References are editable clones, so the Ledger does not track them afterwards.
 
-**The writer pastes their own References straight into the Plan**, and those carry
-`provenance: { type: 'writer' }` rather than an Offer id. They do not enter the Ledger: an
-Offer is something the Chat turned up and handed over to rule on, and there is nothing to
-rule on in a passage the writer typed.
+Research rows arrive through the sync as the Guide commits them, so nothing announces them.
+That is why `listOffers` is no longer `@callable`, and why the Chat no longer reloads the
+Ledger from ids in the transcript. The Chat still reads the tool output to draw its Offer
+cards.
 
-**Nothing announces a research turn's rows.** They land through the sync as the Guide
-commits them, on the Ledger of every connected client — which is what deleted `listOffers`
-as a `@callable`, the Ledger's load-once contract, and the reload the Chat threaded through
-when it read fresh ids out of the transcript. The Chat still reads that tool output, for the
-Offer cards it draws in the transcript.
-
-**A retrieved Offer is the same row as a recalled one.** `provenance` is `writer` or `offer`
-and says nothing about whether the Chat looked the source up or remembered it. How to mark
-that on an Offer and on the Reference it becomes is open, and waits on #40.
+`provenance` records `writer` or `offer`. It does not say whether the Chat searched for a
+source or recalled it from memory; issue #40 covers marking that.
 
 ## Deduplication
 
-**One Offer per source per Article**, and neither half of the check compares the Plan's
-content. Asking whether an Offer is already in the Plan runs on the Provenance instead: the
-writer edits their copy, and content stops matching the moment they do.
+We allow one Offer per source per Article. The fingerprint covers the type, the text, and the
+source, and excludes the note. Neither check compares the Plan's content, because the writer
+edits their copy and a content match breaks as soon as they do; to ask whether an Offer
+already reached the Plan, compare Provenance.
 
-The fingerprint is the type, the text, and the source, and not the note. Two mechanisms
-carry the constraint, and both are load-bearing:
+`recordOffers` does the everyday work. It runs inside the Article Agent rather than over RPC,
+because the writer never authors an Offer. It builds a fingerprint map from the table,
+dedupes the incoming batch against it, and returns the existing row — with the disposition
+the writer gave it — instead of writing a second one.
 
-- **The map in `recordOffers` is the working path.** It runs inside the Article Agent rather
-  than over RPC — the writer never authors an Offer, so nothing on the client may. It builds
-  a fingerprint map from the table, dedupes the incoming batch against it, and hands back
-  the row already there rather than writing a second one, still carrying the disposition the
-  writer gave it.
-- **`offer_one_per_fingerprint` is the guard the map cannot be.** `recordOffers` has to
-  reach `commit()`; party-db's queue defers the commit to a microtask even against embedded
-  SQLite, and the AI SDK runs a step's parallel tool calls concurrently — so two calls of one
-  step can both read before either wrote, and the map is built from the table, so an
-  uncommitted call is invisible to the one beside it. A UNIQUE index over a stored
-  `fingerprint` column refuses the second write. `recordOffers` then re-reads, re-dedupes
-  against what landed, and commits the remainder.
+The UNIQUE index `offer_one_per_fingerprint` catches what the map cannot. `recordOffers` has
+to reach `commit()`; party-db defers that commit to a microtask even against embedded SQLite,
+and the AI SDK runs a step's parallel tool calls concurrently. Two calls in one step can
+therefore both read the table before either writes, and the map cannot see an uncommitted
+sibling. The index refuses the second write, and `recordOffers` then re-reads, re-dedupes
+against what landed, and commits the remainder.
 
-This is `round_one_running` one table over ([`reviews.md`](./reviews.md)), on a sharper
-constraint: the Review guard needs a hibernation to race, and this one needs only an await.
-If the Offers stop syncing, the dedupe is a synchronous read-and-insert again and the index
+If the Offers stop syncing, the dedupe becomes a synchronous read-and-insert and the index
 can go.
 
-**One Offer becomes one Reference**, and `planSchema` refuses a Plan carrying two copies of
-one. `referenceForOffer` answers with the first match on the strength of it, and that answer
-is what makes a retried Accept build no op — so a second copy would turn every retry into
-another copy.
+`planSchema` refuses a Plan holding two References copied from one Offer.
+`referenceForOffer` returns the first match, which is what makes a retried Accept build no op.
 
 ## Accepting an Offer
 
-**Accepting is two writes against two stores, and nothing makes them atomic.** The copy goes
-first, with a `createReference` op through the applier like every other Plan edit, then
-`setOfferDisposition` over RPC. This way round a failure does not create an unrecoverable
-middle state. The Plan write is local, so as long as it succeeds the RPC can fail and the
-only consequence is an Undecided Offer in the Ledger. If the writer Accepts again,
-`acceptOffer` returns `null` and builds no op at all.
+`accept()` writes the Plan first and rules the Offer second, because the copy needs nothing
+that the ruling returns.
 
-**The other order strands the writer, which is why the order is fixed.** Ruling first leaves
-the row reading Accepted with the Plan holding nothing. That state is invisible on the
-Ledger, because the Ledger shows a ruled Offer as settled and does not read the Plan to
-check. It is also unfixable from the Ledger, because no control re-runs the copy for an
-Offer already Accepted. Nothing recovers it, and nothing surfaces it.
-
-**A refused copy stops the ruling for the same reason.** `edit` hands back the applier's
-refusal, and `useOfferLedger` reads it: sending the ruling anyway would land the app in
-exactly that stranded state. The writer gets the applier's sentence instead, built at the
-edge from `refusal.reason` like every other one ([`plan.md`](./plan.md)).
+If the ruling fails, the Offer stays Undecided and the writer can Accept again. If the ruling
+ran first and the Plan write then failed, the Ledger would show a settled Offer with nothing
+in the Plan, and no control re-runs the copy. `useOfferLedger` also stops on a refused copy
+and shows the applier's sentence, for the same reason.
 
 ## Proposals
 
-**Proposals are not Offers.** An Offer is a piece of research to rule on; a Proposal is a
-change to the Plan to rule on. The Chat can make Proposals, and the writer applies them —
-Accepting is `edit(ops)`, the same call every Plan edit makes.
+A Proposal is a change to the Plan that the writer rules on. Accepting one calls `edit(ops)`,
+the same call every Plan edit makes.
 
-**A refused Accept answers nothing and leaves the card open.** The card shows the applier's
-sentence, the writer may fix the Plan and Accept again, and Declining sends that sentence
-back — so the model learns the Plan moved rather than that the writer said no.
+A refused Accept leaves the card open and shows the applier's sentence. The writer can fix the
+Plan and Accept again. Declining sends that sentence back, so the model learns that the Plan
+moved rather than that the writer said no.
 
-**Proposals are `execute`-less tools** (AI SDK v7). A tool with no `execute` suspends for the
-client, which is the Proposal. Four call-site details, each easy to get wrong:
+A Proposal is a tool with no `execute`, which under AI SDK v7 suspends for the client. Four
+call-site details are easy to get wrong:
 
-- Use `addToolOutput`, not the deprecated `addToolResult`, and call it **without `await`** —
-  the docs warn twice about deadlock.
-- `addToolApprovalResponse` takes `part.approval.id`, not `toolCallId`.
-- `needsApproval` and `toolApproval` both gate a server-side `execute` this product does not
-  have, so neither does anything here.
+- Call `addToolOutput`, not the deprecated `addToolResult`, and call it without `await`. The
+  docs warn twice about deadlock.
+- Pass `part.approval.id` to `addToolApprovalResponse`, not `toolCallId`.
+- Skip `needsApproval` and `toolApproval`. Both gate a server-side `execute` that this product
+  does not have.
 - A rejection returns `is_error: true` with the reason in the content.
 
-**The research tool carries an `execute`, where the Proposal tool does not.** An Offer is an
-inert row rather than something the writer rules on mid-turn, so suspending the call would
-buy nothing and cost the turn — a research turn returns seventeen items, and an unruled tool
-batch stalls the Chat with no orphan timeout ([`carries.md`](./carries.md)). Suspend-or-execute
-is decided per tool rather than for the registry.
+The research tool does carry an `execute`, because an Offer is an inert row rather than
+something the writer rules on mid-turn. Suspending that call would stall the Chat — a research
+turn returns seventeen items, and nothing times out an unruled tool batch
+([`carries.md`](./carries.md)). We decide suspend-or-execute per tool rather than for the
+registry.
 
-**The Plan goes in `body` rather than `metadata`.** `body` is request-only and does not enter
-the transcript; `metadata` persists on the `UIMessage` and re-rides every turn, and the Plan
-is both large and stale by the next turn. A small value that should persist — a person id,
-say — is what `metadata` is for.
+The client sends the Plan in `body` rather than `metadata`, because `metadata` persists on the
+`UIMessage` and re-rides every turn, and the Plan is large and stale by the next turn. A small
+value that should persist, such as a person id, is what `metadata` is for.

--- a/docs/draft.md
+++ b/docs/draft.md
@@ -1,0 +1,51 @@
+# The Draft
+
+Phase 2, at low resolution. Decided now so 1a cannot paint itself into a corner. The Draft
+is built and persists; the Guide, the ambient half of the Notes Panel, and everything else
+that reads the prose are not. The editor decision is
+[ADR 0003](./adr/0003-the-draft-editor.md).
+
+## Storage
+
+- **One row per Block**, meaning per paragraph. Not one row for the whole Draft, and not one
+  row per Section — a row per Section would make Section Boundaries a storage fact, and they
+  are approximate and inferred. A list or a blockquote is one Block too: a Block is a
+  top-level child of the document, whatever kind it is.
+- **The Draft is edited locally** and persisted to the server. A server-authoritative
+  ProseMirror step stream is ruled out — the client is the Draft's only writer, the same way
+  it is the Plan's.
+- **A Block is a row in the Article Agent's SQLite**, written over `@callable` RPC, and **a
+  save carries a delta** rather than the whole Draft. The delta is what bounds a stale tab: a
+  client can only name a Block it has already seen, so a paragraph written somewhere else is
+  not one it can delete.
+- **The Draft is not synced, and can move onto a party-db collection later without changing
+  shape** ([`sync.md`](./sync.md)). Until then two tabs on one Draft is last-write-wins per
+  Block, which is what "one editor at a time" costs. Findings #7 and #18 stand and are not
+  load-bearing yet.
+
+## The editor
+
+**The Draft is a ProseMirror document, built with TipTap.** The reason is narrow: a
+decoration is **drawn as part of the document's layout while staying out of its content**,
+which is what the Guide needs for anything it shows beside the prose without writing it.
+Marks decide nothing — every candidate stores a comment as one.
+
+So **a Proposal is a decoration and an accepted annotation is a mark**: a proposed section
+break parts the paragraphs and reaches no stored row, while a comment rides in the prose,
+because a mark is what survives the writer rewriting around it in a session that never drew
+the note. And **a comment is not a Block reference** — it is a set of marked runs spanning
+any number of Blocks, targeting the span from its first to its last.
+
+**The writer types their own headings and section breaks.** Boundaries are inferred, so
+nothing can place a title automatically; writer control is the tiebreaker, and what the
+writer typed is then the strongest hint the inference has.
+
+## The guide loop
+
+**The guide loop is client-initiated, and v1 carries no server-side timer.** The client knows
+when typing stopped; the server cannot tell "still thinking" from "left the room." An alarm
+earns its place when work must happen while nobody is connected, and there is no such work
+yet. A stale Proposal or an orphaned tool batch expires lazily on read.
+
+**Guidance notes do not stream.** A Review is the thing that should —
+[`reviews.md`](./reviews.md).

--- a/docs/draft.md
+++ b/docs/draft.md
@@ -1,51 +1,52 @@
 # The Draft
 
-Phase 2, at low resolution. Decided now so 1a cannot paint itself into a corner. The Draft
-is built and persists; the Guide, the ambient half of the Notes Panel, and everything else
-that reads the prose are not. The editor decision is
-[ADR 0003](./adr/0003-the-draft-editor.md).
+Phase 2, at low resolution, decided now so 1a cannot paint itself into a corner. The Draft is
+built and persists. The Guide, the ambient half of the Notes Panel, and everything else that
+reads the prose are not. Editor decision in [ADR 0003](./adr/0003-the-draft-editor.md).
 
 ## Storage
 
-- **One row per Block**, meaning per paragraph. Not one row for the whole Draft, and not one
-  row per Section — a row per Section would make Section Boundaries a storage fact, and they
-  are approximate and inferred. A list or a blockquote is one Block too: a Block is a
-  top-level child of the document, whatever kind it is.
-- **The Draft is edited locally** and persisted to the server. A server-authoritative
-  ProseMirror step stream is ruled out — the client is the Draft's only writer, the same way
-  it is the Plan's.
-- **A Block is a row in the Article Agent's SQLite**, written over `@callable` RPC, and **a
-  save carries a delta** rather than the whole Draft. The delta is what bounds a stale tab: a
-  client can only name a Block it has already seen, so a paragraph written somewhere else is
-  not one it can delete.
-- **The Draft is not synced, and can move onto a party-db collection later without changing
-  shape** ([`sync.md`](./sync.md)). Until then two tabs on one Draft is last-write-wins per
-  Block, which is what "one editor at a time" costs. Findings #7 and #18 stand and are not
-  load-bearing yet.
+The Draft stores one row per Block, meaning per paragraph. A row per Section would make
+Section Boundaries a storage fact, and they are approximate and inferred. A list or a
+blockquote is also one Block: a Block is a top-level child of the document, whatever kind it
+is.
+
+The client edits the Draft locally and persists it to the server. We ruled out a
+server-authoritative ProseMirror step stream, because the client is the Draft's only writer,
+the same way it is the Plan's.
+
+A Block is a row in the Article Agent's SQLite, written over `@callable` RPC. A save carries a
+delta rather than the whole Draft, which is what bounds a stale tab: a client can only name a
+Block it has already seen, so it cannot delete a paragraph written somewhere else.
+
+The Draft is not synced, and it can move onto a party-db collection later without changing
+shape ([`sync.md`](./sync.md)). Until then, two tabs on one Draft give last-write-wins per
+Block, which is what one-editor-at-a-time costs. Findings #7 and #18 stand and are not
+load-bearing yet.
 
 ## The editor
 
-**The Draft is a ProseMirror document, built with TipTap.** The reason is narrow: a
-decoration is **drawn as part of the document's layout while staying out of its content**,
-which is what the Guide needs for anything it shows beside the prose without writing it.
-Marks decide nothing — every candidate stores a comment as one.
+The Draft is a ProseMirror document built with TipTap. The reason is narrow: ProseMirror draws
+a decoration as part of the document's layout while keeping it out of the document's content,
+which is what the Guide needs to show anything beside the prose without writing it. Marks
+decide nothing, because every candidate editor stores a comment as one.
 
-So **a Proposal is a decoration and an accepted annotation is a mark**: a proposed section
-break parts the paragraphs and reaches no stored row, while a comment rides in the prose,
-because a mark is what survives the writer rewriting around it in a session that never drew
-the note. And **a comment is not a Block reference** — it is a set of marked runs spanning
-any number of Blocks, targeting the span from its first to its last.
+So a Proposal is a decoration and an accepted annotation is a mark. A proposed section break
+parts the paragraphs and reaches no stored row. A comment rides in the prose, because a mark
+survives the writer rewriting around it in a session that never drew the note.
 
-**The writer types their own headings and section breaks.** Boundaries are inferred, so
-nothing can place a title automatically; writer control is the tiebreaker, and what the
-writer typed is then the strongest hint the inference has.
+A comment is not a Block reference. It is a set of marked runs spanning any number of Blocks,
+targeting the span from its first to its last.
+
+The writer types their own headings and section breaks. Boundaries are inferred, so nothing
+can place a title automatically, and writer control is the tiebreaker. What the writer typed
+then becomes the strongest hint the inference has.
 
 ## The guide loop
 
-**The guide loop is client-initiated, and v1 carries no server-side timer.** The client knows
+The client initiates the guide loop, and v1 carries no server-side timer. The client knows
 when typing stopped; the server cannot tell "still thinking" from "left the room." An alarm
-earns its place when work must happen while nobody is connected, and there is no such work
-yet. A stale Proposal or an orphaned tool batch expires lazily on read.
+earns its place when work must happen while nobody is connected, and no such work exists yet.
+A stale Proposal or an orphaned tool batch expires lazily on read.
 
-**Guidance notes do not stream.** A Review is the thing that should —
-[`reviews.md`](./reviews.md).
+Guidance notes do not stream. A Review is the thing that should — [`reviews.md`](./reviews.md).

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,28 +1,27 @@
 # Inference
 
-The model, the search provider, and the prompt packs — `src/server/llm/`. The Gateway and
-the keys are [`deploy.md`](./deploy.md). What the model may propose is
-[`plan.md`](./plan.md).
+The model, the search provider, and the prompt packs, in `src/server/llm/`. Keys and the
+Gateway are [`deploy.md`](./deploy.md).
 
 ## The model
 
-**Currently `@cf/zai-org/glm-5.2` on Workers AI**, over the `env.AI` binding. 262k context,
-tool calling and streaming supported, Workers Paid plan required. Swapping it is one string,
-and #16 names the fallback and why it is a swap rather than a spike.
+We currently run `@cf/zai-org/glm-5.2` on Workers AI over the `env.AI` binding: 262k context,
+tool calling and streaming supported, Workers Paid plan required. Swapping it changes one
+string. Issue #16 names the fallback and why it is a swap rather than a spike.
 
-**One model serves every call today** — the Chat, the ambient Guidance notes, the Review. No
-routing machinery and no per-call-type selection.
+One model serves every call today — the Chat, the ambient Guidance notes, and the Review. We
+have no routing machinery and no per-call-type selection.
 
-**The AI SDK follows from "Cloudflare throughout" rather than being chosen against
-alternatives.** `@cloudflare/ai-chat` declares `ai` and `@ai-sdk/react` as peer dependencies,
-and `workers-ai-provider` is an AI SDK provider whose `createWorkersAI` returns an `ai`
-`LanguageModel` over the `env.AI` binding. So the SDK arrives with both packages, and
+The AI SDK follows from "Cloudflare throughout" rather than from a comparison.
+`@cloudflare/ai-chat` declares `ai` and `@ai-sdk/react` as peer dependencies, and
+`workers-ai-provider` is an AI SDK provider whose `createWorkersAI` returns an `ai`
+`LanguageModel` over the `env.AI` binding. The SDK therefore arrives with both packages, and
 dropping it would mean dropping `AIChatAgent` and calling the binding by hand. It stays
-provider-agnostic, which is what keeps the model swap above down to one string.
+provider-agnostic, which is what keeps the model swap down to one string.
 
-**The swappable boundary is the model instance, not a wrapper API.** AI SDK v7 already
-provides `generateText`, `streamText`, and `generateObject`; a wrapper would duplicate it and
-break the `execute`-less tool machinery.
+The swappable boundary is the model instance rather than a wrapper API. AI SDK v7 already
+provides `generateText`, `streamText`, and `generateObject`, so a wrapper would duplicate it
+and break the `execute`-less tool machinery.
 
 ```ts
 // src/server/llm/model.ts — the whole boundary
@@ -31,43 +30,43 @@ export const model = (env: Env) =>
   createWorkersAI({ binding: env.AI })('@cf/zai-org/glm-5.2')
 ```
 
-**Cost does not constrain the design** — #16 priced a guide pass at about a tenth of a cent.
+Cost does not constrain the design. Issue #16 priced a guide pass at about a tenth of a cent.
 
 ## Search
 
-**Search is Exa**, in `src/server/llm/search.ts` — the one place a provider is named, as
-`llm/model.ts` is for the model.
+`src/server/llm/search.ts` names Exa, as `llm/model.ts` names the model.
 
-- **No key means no search tool**, and the guide is told to answer from memory instead: the
-  registry and the guide rules read one value, so they cannot disagree about what the turn
-  can reach.
-- **A search that fails answers rather than throws**, because a rejected `execute` ends a
-  turn that still owes the writer a reply.
+The registry and the guide rules read one value, so they cannot disagree about what a turn can
+reach: without a key there is no search tool, and the guide is told to answer from memory.
 
-## Model output is validated rather than parsed out of prose
+A failed search returns an answer rather than throwing, because a rejected `execute` ends a
+turn that still owes the writer a reply.
 
-A Proposal is a tool call and a Review is `generateObject` against a zod schema — both
-checked in the Article Agent, with one retry carrying the validation error. A Review's prose
-lives _inside_ that schema rather than being scanned for structure.
+## Validation
+
+We validate model output rather than parsing it out of prose. A Proposal is a tool call and a
+Review is `generateObject` against a zod schema. The Article Agent checks both and retries
+once, carrying the validation error. A Review's prose lives inside that schema rather than
+being scanned for structure.
 
 ## Prompt packs
 
-**Stable part first** — system prompt, then Lexicon entries in play, then the standing rules,
-then everything that changes. The Plan and the Draft change all the time, so they go at the
-end. Whether this ordering saves anything on Workers AI is unmeasured; the argument for it is
-structural, and the arithmetic is in #16.
+Each pack puts the stable part first: the system prompt, then the Lexicon entries in play,
+then the standing rules, then everything that changes. The Plan and the Draft change all the
+time, so they go last. Whether this saves anything on Workers AI is unmeasured; the argument
+is structural, and the arithmetic is in issue #16.
 
-**Where the writer has just spoken, their message is the last thing the model reads**, and
-the Plan sits in front of it. A model weights the final message as the one to answer, so a
-pack ending on the Plan's JSON risks a turn that discusses the Plan rather than the question
-the writer asked. This is the rule the Chat pack is built around.
+A model weights the final message as the one to answer. So where the writer has just spoken,
+their message goes last and the Plan sits in front of it — a pack ending on the Plan's JSON
+risks a turn that discusses the Plan instead of answering the question. The Chat pack is built
+around this.
 
-**The exception is a turn that resumes after a tool call**, where the transcript ends with a
-tool result rather than the writer. A tool result answers the assistant message before it,
-and the Plan is a user message, so slotting it in front would split that pair — which the AI
-SDK refuses outright with `MissingToolResultsError`, before the model is called at all. The
-Plan goes last in that case, and there is no writer message to keep last anyway.
-`chatPackMessages` and `planSlot` in `src/server/llm/prompt.ts` are the whole of it.
+A turn that resumes after a tool call is the exception, because the transcript ends with a
+tool result. A tool result answers the assistant message before it, and the Plan is a user
+message, so slotting the Plan in front would split that pair. The AI SDK refuses that outright
+with `MissingToolResultsError`, before calling the model. The Plan goes last in that case, and
+no writer message needs the final slot anyway. `chatPackMessages` and `planSlot` in
+`src/server/llm/prompt.ts` are the whole of it.
 
 Each row reads in pack order, stable to volatile.
 
@@ -78,5 +77,5 @@ Each row reads in pack order, stable to volatile.
 | Guide pass | The Plan, then the Draft or active Section with neighbours, then recent deltas. **No Chat** |
 | Review     | The same, plus the existing Notes. **No Chat**                                              |
 
-Research reaches a Review by being Accepted into the Plan. The Ledger is the bridge, and
-curation is forced rather than assumed.
+Research reaches a Review by being Accepted into the Plan, so the Ledger forces curation
+rather than assuming it.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,0 +1,82 @@
+# Inference
+
+The model, the search provider, and the prompt packs — `src/server/llm/`. The Gateway and
+the keys are [`deploy.md`](./deploy.md). What the model may propose is
+[`plan.md`](./plan.md).
+
+## The model
+
+**Currently `@cf/zai-org/glm-5.2` on Workers AI**, over the `env.AI` binding. 262k context,
+tool calling and streaming supported, Workers Paid plan required. Swapping it is one string,
+and #16 names the fallback and why it is a swap rather than a spike.
+
+**One model serves every call today** — the Chat, the ambient Guidance notes, the Review. No
+routing machinery and no per-call-type selection.
+
+**The AI SDK follows from "Cloudflare throughout" rather than being chosen against
+alternatives.** `@cloudflare/ai-chat` declares `ai` and `@ai-sdk/react` as peer dependencies,
+and `workers-ai-provider` is an AI SDK provider whose `createWorkersAI` returns an `ai`
+`LanguageModel` over the `env.AI` binding. So the SDK arrives with both packages, and
+dropping it would mean dropping `AIChatAgent` and calling the binding by hand. It stays
+provider-agnostic, which is what keeps the model swap above down to one string.
+
+**The swappable boundary is the model instance, not a wrapper API.** AI SDK v7 already
+provides `generateText`, `streamText`, and `generateObject`; a wrapper would duplicate it and
+break the `execute`-less tool machinery.
+
+```ts
+// src/server/llm/model.ts — the whole boundary
+import { createWorkersAI } from 'workers-ai-provider'
+export const model = (env: Env) =>
+  createWorkersAI({ binding: env.AI })('@cf/zai-org/glm-5.2')
+```
+
+**Cost does not constrain the design** — #16 priced a guide pass at about a tenth of a cent.
+
+## Search
+
+**Search is Exa**, in `src/server/llm/search.ts` — the one place a provider is named, as
+`llm/model.ts` is for the model.
+
+- **No key means no search tool**, and the guide is told to answer from memory instead: the
+  registry and the guide rules read one value, so they cannot disagree about what the turn
+  can reach.
+- **A search that fails answers rather than throws**, because a rejected `execute` ends a
+  turn that still owes the writer a reply.
+
+## Model output is validated rather than parsed out of prose
+
+A Proposal is a tool call and a Review is `generateObject` against a zod schema — both
+checked in the Article Agent, with one retry carrying the validation error. A Review's prose
+lives _inside_ that schema rather than being scanned for structure.
+
+## Prompt packs
+
+**Stable part first** — system prompt, then Lexicon entries in play, then the standing rules,
+then everything that changes. The Plan and the Draft change all the time, so they go at the
+end. Whether this ordering saves anything on Workers AI is unmeasured; the argument for it is
+structural, and the arithmetic is in #16.
+
+**Where the writer has just spoken, their message is the last thing the model reads**, and
+the Plan sits in front of it. A model weights the final message as the one to answer, so a
+pack ending on the Plan's JSON risks a turn that discusses the Plan rather than the question
+the writer asked. This is the rule the Chat pack is built around.
+
+**The exception is a turn that resumes after a tool call**, where the transcript ends with a
+tool result rather than the writer. A tool result answers the assistant message before it,
+and the Plan is a user message, so slotting it in front would split that pair — which the AI
+SDK refuses outright with `MissingToolResultsError`, before the model is called at all. The
+Plan goes last in that case, and there is no writer message to keep last anyway.
+`chatPackMessages` and `planSlot` in `src/server/llm/prompt.ts` are the whole of it.
+
+Each row reads in pack order, stable to volatile.
+
+| Pack       | Contents                                                                                    |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| Chat turn  | The Chat transcript, then the Plan, then the writer's own last message                      |
+| Proposal   | The affected span, plus adjacent Section titles and intent notes. Nothing else              |
+| Guide pass | The Plan, then the Draft or active Section with neighbours, then recent deltas. **No Chat** |
+| Review     | The same, plus the existing Notes. **No Chat**                                              |
+
+Research reaches a Review by being Accepted into the Plan. The Ledger is the bridge, and
+curation is forced rather than assumed.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,174 @@
+# The Plan
+
+The Plan is one JSON blob in Article Agent state. This file is the module: the shape,
+the ops that change it, and the applier that refuses a bad change. The cross-module
+rules — who may write the blob, and how a Proposal reaches it — are
+[`architecture.md`](./architecture.md). The decision record is
+[ADR 0002](./adr/0002-the-plan-data-model.md).
+
+The code is `src/shared/plan/` (schema, ops, applier, Scope resolver, word-count
+arithmetic) and `src/client/plan/` (the edits, the writer, the refusal text).
+
+## Shape
+
+```
+plan: {
+  title, totalTarget,
+  voice, adjectives: [],
+  outline: [ { id, title, intent?, target?, voice?, adjectives?: [], children: [] } ],
+  references: [ { id, type, provenance, text?, source?, nodeId, note? } ],
+}
+```
+
+- **The Outline is a nested tree**, sibling order carried by array position, every Section
+  with a stable ID that stays put for the life of the Section. What the writer reads is that
+  position, worked out in `outlineEntries`: the bare `ordinal` for a gutter of them and for a
+  phrase that composes one ("Section 2"), and `sectionLabel` for the standalone form ("§2").
+  Both come from the one walk, so no two Panels can number a Section differently.
+- **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
+  Section or nowhere yet.
+- **References are type Link or Quote**, and Reference is the umbrella over either type. The
+  type is **assigned, not derived from the contents**, so an Offer and the Reference it was
+  Accepted into carry the same `type`. Amended in
+  [ADR 0002](./adr/0002-the-plan-data-model.md).
+- **Voice cascades; Adjectives compose.** Both resolve down the same path — House, then
+  Article, then Section, **at read time** — and they differ when two Scopes each state one.
+  The nearest Voice wins outright. Adjectives accumulate instead: a "slow" Section inside a
+  "fast" Article carries both, and the resolved list runs widest first, so the nearest lands
+  last and reads as the strongest. Restating a term moves it to the end, which lets the
+  writer say it again for emphasis.
+- **The word-count total is stored rather than derived/summed.** The parts may disagree with
+  the whole; the gap is information about under/over allocation.
+
+## One spelling per state
+
+A field that may be absent says "nothing here" by being absent, and not also by an empty
+string or an empty list. The blob is written whole, compared whole-field by a Proposal's
+`expected`, and sent whole in every prompt pack, so two Plans that mean the same thing
+should be the same, field for field. The schema enforces this today: an empty `adjectives`
+on a Section is refused.
+
+Some fields always carry their key and indicate "nothing here" with a value; others are
+absent when empty. **Choosing for a new field: a question the record is always asked carries
+its key and answers with a value, and a Section's own refinement is absent until it is set.**
+`nodeId`, `totalTarget`, and `children` are the first kind — every Reference has a placement
+even when unplaced. `intent`, `target`, and `voice` are the second. Read which one a field
+takes off `src/shared/plan/schema.ts` rather than from a list here.
+
+## The schema guards client writes
+
+`validateStateChange` parses the whole Plan on every write. The model's outputs do not go
+through it — the Chat proposes and the client applies, so the blob holds client writes only.
+What the model does meet are the **piece** schemas, `outlineNodeSchema`, `referenceSchema`,
+and `sourceSchema`, reused inside a Proposal's op payloads.
+
+Four invariants sit above the object shape, checked in the same parse:
+
+1. A Section id is unique among Sections.
+2. A Reference id is unique among References.
+3. No two References were copied from one Offer.
+4. A placed Reference names a node that exists.
+
+The last one means an op that deletes a node unplaces its References in the same Proposal,
+because the Plan is written whole and validated whole.
+
+## Size
+
+A normal Plan runs about 40 KB. The soft ceiling is around 100 KB, where re-broadcasting on
+every write gets noticeable; the hard wall is 2 MB, the Durable Object limit on a single row
+or value. Growth comes from References carrying long passages. The relief valve is moving
+References into SQLite rows, which is the phase 2 move anyway. **Debounce `setState` while
+the writer types**, or 40 KB goes over the wire per keystroke.
+
+## Proposal shape
+
+A list of ops, applied all-or-nothing.
+
+```
+proposal: [
+  { op: 'createNode', parentId, beforeId, node: { id, title, intent, children: [] } },
+  { op: 'setTarget',  nodeId, expected: null, value: 400 },
+]
+```
+
+- **`expected` is content-addressed staleness** — it names the value the Proposal thinks is
+  there, not a version. Compared **whole-field**, because Plan fields are short.
+- **Structural ops anchor on IDs and carry no `expected`.** Exactly one of `afterId` or
+  `beforeId`, so the model anchors to whichever neighbour its insertion relates to: a Section
+  leading into §3 says `before: §3` and survives §2 being deleted. `afterId: null` means
+  first child, `beforeId: null` means last child.
+- **If any op's `expected` fails, the whole Proposal is Stale.** Whole-field comparison is
+  conservative and will refuse a Proposal against a field the writer has since touched, so
+  the card says why — [`ui.md`](./ui.md).
+
+**Staleness is not a multi-client problem.** It comes from the gap between generating a
+Proposal and applying it, and inference is slower than typing, so it exists with one writer
+in one tab. We are strict about marking Proposals Stale today, and heuristics that forgive
+more are open.
+
+## The ops
+
+**Thirteen**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
+`deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
+`placeReference`, `createReference`, `deleteReference`, `setReference`.
+
+**The Chat is offered ten of them.** The three Reference ops are how the writer pastes a
+Reference in themselves, and `chatProposalSchema` leaves them out of the tool the model
+sees — research reaches the Plan by being Accepted from an Offer, and handing a model
+`createReference` would be a way round the Ledger. The applier takes all thirteen, because
+the writer's own paste goes through it too.
+
+A content op reads `nodeId: null` as the Article Scope, so setting the Article's Voice and
+setting one node's Voice are one op rather than two. Two ops carry a consequence worth
+stating:
+
+- **`deleteNode` unplaces every Reference placed at the node it removes or at any node
+  below it**, because the Plan is written whole and a Reference naming a node that is gone
+  does not parse.
+- **`mergeNodes` keeps the target's own fields**, moving the source's children and placed
+  References onto it, so a Proposal that wants the source's intent note carried over says so
+  with a `setIntent` op in the same batch.
+
+**The op payloads are strict, and a rejected tool call retries with the validation error.**
+The piece schemas the payloads reuse are `strictObject`, so a model that adds one field
+fails the whole tool call rather than having the field stripped. Stripping would produce a
+Proposal the model did not make, and the writer would rule on it without seeing what was
+dropped. The cost is real: a model that adds the same field every time thrashes the retry
+instead of converging, and the answer to that is naming the field in the schema, not
+loosening every payload to strip.
+
+## The applier refuses with a reason
+
+`applyProposal` in `src/shared/plan/apply.ts` returns either a new Plan or a refusal naming
+which op failed, its position in the Proposal, and what it expected against what it found.
+It sorts refusals into four types, listed on `RefusalType` where they cannot drift away from
+the union. It also parses the Plan it produces, so a Proposal the Article Agent would reject
+is refused here, where there is a reason to show, rather than there, where there is none.
+
+**A refusal has two readers, the LLM and the human.** `refusal.message` is for the model's:
+a Declined Proposal sends it back, so it names the op and the ids and may run long. The
+writer's sentence is built at the edge from `refusal.reason` — a closed code naming exactly
+what went wrong — plus the records it is about, in `src/client/plan/refusalText.ts`. The
+Panel that shows it holds the Plan, so it can name a Section the way the Outline numbers it,
+where the applier only has an id.
+
+Two things follow. **One English string lives in `src/shared`**, aimed at an LLM. The
+writer's half is a table over a closed union, so a second language would be a second table
+rather than a sweep through the applier. `refusalText.ts` is total over `RefusalReason`, so
+a new refusal site stops it compiling until it says what the new one reads as.
+
+## The client's own edits
+
+**The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
+in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
+`expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to
+`setState`. One write path means the Panel cannot make a change the applier would refuse,
+and a structural edit gets the consequences the ops already state — deleting a Section
+unplaces its References. The writer's own edits do not go Stale: staleness is the gap
+between generating a Proposal and applying it, and there is no gap here.
+
+**One writer holds the Plan and the debounce**, in `src/client/plan/writer.ts`. It applies
+each edit locally, sends after a pause for the four ops a keystroke produces, and sends at
+once for everything else. An update arriving from the Article Agent over an unsent edit is
+the echo of an older write and is dropped — the client is the Plan's only writer, so there
+is nothing else it can be.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,15 +1,7 @@
 # The Plan
 
-The Plan is one JSON blob in Article Agent state. This file is the module: the shape,
-the ops that change it, and the applier that refuses a bad change. The cross-module
-rules — who may write the blob, and how a Proposal reaches it — are
-[`architecture.md`](./architecture.md). The decision record is
-[ADR 0002](./adr/0002-the-plan-data-model.md).
-
-The code is `src/shared/plan/` (schema, ops, applier, Scope resolver, word-count
-arithmetic) and `src/client/plan/` (the edits, the writer, the refusal text).
-
-## Shape
+One JSON blob in Article Agent state. Code in `src/shared/plan/` and `src/client/plan/`;
+decision record in [ADR 0002](./adr/0002-the-plan-data-model.md).
 
 ```
 plan: {
@@ -20,69 +12,75 @@ plan: {
 }
 ```
 
-- **The Outline is a nested tree**, sibling order carried by array position, every Section
-  with a stable ID that stays put for the life of the Section. What the writer reads is that
-  position, worked out in `outlineEntries`: the bare `ordinal` for a gutter of them and for a
-  phrase that composes one ("Section 2"), and `sectionLabel` for the standalone form ("§2").
-  Both come from the one walk, so no two Panels can number a Section differently.
-- **References are flat with an optional `nodeId`**, so an Accepted Reference can sit at a
-  Section or nowhere yet.
-- **References are type Link or Quote**, and Reference is the umbrella over either type. The
-  type is **assigned, not derived from the contents**, so an Offer and the Reference it was
-  Accepted into carry the same `type`. Amended in
-  [ADR 0002](./adr/0002-the-plan-data-model.md).
-- **Voice cascades; Adjectives compose.** Both resolve down the same path — House, then
-  Article, then Section, **at read time** — and they differ when two Scopes each state one.
-  The nearest Voice wins outright. Adjectives accumulate instead: a "slow" Section inside a
-  "fast" Article carries both, and the resolved list runs widest first, so the nearest lands
-  last and reads as the strongest. Restating a term moves it to the end, which lets the
-  writer say it again for emphasis.
-- **The word-count total is stored rather than derived/summed.** The parts may disagree with
-  the whole; the gap is information about under/over allocation.
+## Shape
+
+The Outline is a nested tree. Array position carries sibling order, and every Section keeps a
+stable ID for its lifetime. `outlineEntries` walks the tree once and produces both forms the
+writer reads: `ordinal` for a gutter and for a composed phrase ("Section 2"), and
+`sectionLabel` for the standalone form ("§2"). One walk means two Panels cannot number a
+Section differently.
+
+References are flat and carry an optional `nodeId`, so an Accepted Reference can sit at a
+Section or nowhere yet.
+
+A Reference has type Link or Quote. We assign the type rather than deriving it from the
+contents, so an Offer and the Reference it becomes carry the same `type`. Amended in
+[ADR 0002](./adr/0002-the-plan-data-model.md).
+
+Voice cascades and Adjectives compose. Both resolve at read time down the same path — House,
+then Article, then Section. The nearest Voice wins outright. Adjectives accumulate instead, so
+a "slow" Section inside a "fast" Article carries both; the resolved list runs widest first, so
+the nearest term lands last and reads as the strongest. Restating a term moves it to the end,
+which lets the writer repeat it for emphasis.
+
+We store the word-count total rather than summing it. The parts may disagree with the whole,
+and that gap tells the writer about under- or over-allocation.
 
 ## One spelling per state
 
 A field that may be absent says "nothing here" by being absent, and not also by an empty
-string or an empty list. The blob is written whole, compared whole-field by a Proposal's
-`expected`, and sent whole in every prompt pack, so two Plans that mean the same thing
-should be the same, field for field. The schema enforces this today: an empty `adjectives`
-on a Section is refused.
+string or an empty list. Two Plans that mean the same thing must match field for field,
+because we write the blob whole, compare it whole-field against a Proposal's `expected`, and
+send it whole in every prompt pack. The schema enforces this today by refusing an empty
+`adjectives` on a Section.
 
-Some fields always carry their key and indicate "nothing here" with a value; others are
-absent when empty. **Choosing for a new field: a question the record is always asked carries
-its key and answers with a value, and a Section's own refinement is absent until it is set.**
-`nodeId`, `totalTarget`, and `children` are the first kind — every Reference has a placement
-even when unplaced. `intent`, `target`, and `voice` are the second. Read which one a field
-takes off `src/shared/plan/schema.ts` rather than from a list here.
+Some fields always carry their key and answer with a value; others are absent until set. To
+choose for a new field: a question the record is always asked carries its key, and a Section's
+own refinement stays absent until the writer sets it. `nodeId`, `totalTarget`, and `children`
+take the first form, because every Reference has a placement even when unplaced. `intent`,
+`target`, and `voice` take the second. Read `src/shared/plan/schema.ts` for which form a field
+takes.
 
-## The schema guards client writes
+## Validation
 
-`validateStateChange` parses the whole Plan on every write. The model's outputs do not go
-through it — the Chat proposes and the client applies, so the blob holds client writes only.
-What the model does meet are the **piece** schemas, `outlineNodeSchema`, `referenceSchema`,
-and `sourceSchema`, reused inside a Proposal's op payloads.
+`validateStateChange` parses the whole Plan on every client write. Model output never reaches
+it, because the Chat proposes and the client applies. The model meets the piece schemas
+instead — `outlineNodeSchema`, `referenceSchema`, and `sourceSchema` — which a Proposal's op
+payloads reuse.
 
-Four invariants sit above the object shape, checked in the same parse:
+The same parse checks four invariants above the object shape:
 
 1. A Section id is unique among Sections.
 2. A Reference id is unique among References.
 3. No two References were copied from one Offer.
 4. A placed Reference names a node that exists.
 
-The last one means an op that deletes a node unplaces its References in the same Proposal,
-because the Plan is written whole and validated whole.
+Invariant 4 means an op that deletes a node must unplace its References in the same Proposal,
+because we write and validate the Plan whole.
 
 ## Size
 
-A normal Plan runs about 40 KB. The soft ceiling is around 100 KB, where re-broadcasting on
-every write gets noticeable; the hard wall is 2 MB, the Durable Object limit on a single row
-or value. Growth comes from References carrying long passages. The relief valve is moving
-References into SQLite rows, which is the phase 2 move anyway. **Debounce `setState` while
-the writer types**, or 40 KB goes over the wire per keystroke.
+A normal Plan runs about 40 KB. Above roughly 100 KB, re-broadcasting on every write gets
+noticeable. The hard wall is 2 MB, the Durable Object limit on one row or value. Growth comes
+from References carrying long passages, and the relief valve is moving References into SQLite
+rows, which is the phase 2 move anyway.
 
-## Proposal shape
+`setState` is debounced while the writer types. Without that, 40 KB goes over the wire per
+keystroke.
 
-A list of ops, applied all-or-nothing.
+## Proposals
+
+A Proposal is a list of ops, applied all-or-nothing.
 
 ```
 proposal: [
@@ -91,84 +89,74 @@ proposal: [
 ]
 ```
 
-- **`expected` is content-addressed staleness** — it names the value the Proposal thinks is
-  there, not a version. Compared **whole-field**, because Plan fields are short.
-- **Structural ops anchor on IDs and carry no `expected`.** Exactly one of `afterId` or
-  `beforeId`, so the model anchors to whichever neighbour its insertion relates to: a Section
-  leading into §3 says `before: §3` and survives §2 being deleted. `afterId: null` means
-  first child, `beforeId: null` means last child.
-- **If any op's `expected` fails, the whole Proposal is Stale.** Whole-field comparison is
-  conservative and will refuse a Proposal against a field the writer has since touched, so
-  the card says why — [`ui.md`](./ui.md).
+`expected` names the value the Proposal thinks is in the field, rather than a version. We
+compare it whole-field, because Plan fields are short. If any op's `expected` fails, the whole
+Proposal is Stale, and the card says why ([`ui.md`](./ui.md)).
 
-**Staleness is not a multi-client problem.** It comes from the gap between generating a
-Proposal and applying it, and inference is slower than typing, so it exists with one writer
-in one tab. We are strict about marking Proposals Stale today, and heuristics that forgive
-more are open.
+Structural ops anchor on IDs and carry no `expected`. Each takes exactly one of `afterId` or
+`beforeId`, so the model anchors to whichever neighbour its insertion relates to: a Section
+leading into §3 says `before: §3` and survives §2 being deleted. `afterId: null` means first
+child; `beforeId: null` means last child.
+
+Staleness comes from the gap between generating a Proposal and applying it. Inference is
+slower than typing, so staleness exists with one writer in one tab and is not a multi-client
+problem. We are strict about it today, and more forgiving heuristics are open.
 
 ## The ops
 
-**Thirteen**, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`,
-`deleteNode`, `setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`,
-`placeReference`, `createReference`, `deleteReference`, `setReference`.
+Thirteen, in `src/shared/plan/ops.ts`: `createNode`, `moveNode`, `mergeNodes`, `deleteNode`,
+`setTitle`, `setIntent`, `setTarget`, `setVoice`, `setAdjectives`, `placeReference`,
+`createReference`, `deleteReference`, `setReference`.
 
-**The Chat is offered ten of them.** The three Reference ops are how the writer pastes a
-Reference in themselves, and `chatProposalSchema` leaves them out of the tool the model
-sees — research reaches the Plan by being Accepted from an Offer, and handing a model
-`createReference` would be a way round the Ledger. The applier takes all thirteen, because
-the writer's own paste goes through it too.
+`chatProposalSchema` offers the model ten of them. It withholds `createReference`,
+`deleteReference`, and `setReference`, which are how the writer pastes a Reference in
+themselves, so that research reaches the Plan only by being Accepted from an Offer. The
+applier takes all thirteen, because the writer's own paste goes through it.
 
 A content op reads `nodeId: null` as the Article Scope, so setting the Article's Voice and
-setting one node's Voice are one op rather than two. Two ops carry a consequence worth
-stating:
+setting one node's Voice use one op rather than two.
 
-- **`deleteNode` unplaces every Reference placed at the node it removes or at any node
-  below it**, because the Plan is written whole and a Reference naming a node that is gone
-  does not parse.
-- **`mergeNodes` keeps the target's own fields**, moving the source's children and placed
-  References onto it, so a Proposal that wants the source's intent note carried over says so
-  with a `setIntent` op in the same batch.
+Two ops carry a consequence worth stating. `deleteNode` unplaces every Reference placed at the
+node it removes or at any node below it, because a Reference naming a deleted node does not
+parse. `mergeNodes` keeps the target's own fields and moves the source's children and placed
+References onto it, so a Proposal that wants the source's intent note must add a `setIntent`
+op to the same batch.
 
-**The op payloads are strict, and a rejected tool call retries with the validation error.**
-The piece schemas the payloads reuse are `strictObject`, so a model that adds one field
-fails the whole tool call rather than having the field stripped. Stripping would produce a
-Proposal the model did not make, and the writer would rule on it without seeing what was
-dropped. The cost is real: a model that adds the same field every time thrashes the retry
-instead of converging, and the answer to that is naming the field in the schema, not
-loosening every payload to strip.
+The op payloads are `strictObject`. A model that invents one field fails the whole tool call
+and retries with the validation error. Stripping the field instead would hand the writer a
+Proposal the model did not make, with no sign of what was dropped. The cost is real: a model
+that adds the same field every time thrashes the retry rather than converging, and the fix
+for that is naming the field in the schema, not loosening every payload.
 
-## The applier refuses with a reason
+## Refusals
 
 `applyProposal` in `src/shared/plan/apply.ts` returns either a new Plan or a refusal naming
-which op failed, its position in the Proposal, and what it expected against what it found.
-It sorts refusals into four types, listed on `RefusalType` where they cannot drift away from
-the union. It also parses the Plan it produces, so a Proposal the Article Agent would reject
-is refused here, where there is a reason to show, rather than there, where there is none.
+the op that failed, its position in the Proposal, and what it expected against what it found.
+`RefusalType` lists the four kinds, in the union so they cannot drift. `applyProposal` also
+parses the Plan it produces, so a Proposal the Article Agent would reject gets refused here,
+where there is a reason to show.
 
-**A refusal has two readers, the LLM and the human.** `refusal.message` is for the model's:
-a Declined Proposal sends it back, so it names the op and the ids and may run long. The
-writer's sentence is built at the edge from `refusal.reason` — a closed code naming exactly
-what went wrong — plus the records it is about, in `src/client/plan/refusalText.ts`. The
-Panel that shows it holds the Plan, so it can name a Section the way the Outline numbers it,
-where the applier only has an id.
+One refusal serves two readers. `refusal.message` goes back to the model with a Decline, so it
+names the op and the ids and may run long. `src/client/plan/refusalText.ts` builds the writer's
+sentence from `refusal.reason` — a closed code — plus the records it names. The Panel holds
+the Plan, so it can name a Section the way the Outline numbers it, where the applier has only
+an id.
 
-Two things follow. **One English string lives in `src/shared`**, aimed at an LLM. The
-writer's half is a table over a closed union, so a second language would be a second table
-rather than a sweep through the applier. `refusalText.ts` is total over `RefusalReason`, so
-a new refusal site stops it compiling until it says what the new one reads as.
+So `src/shared` carries one English string, aimed at the model, and the writer's half is a
+table over a closed union. A second language would be a second table rather than a sweep
+through the applier. `refusalText.ts` is total over `RefusalReason`, so a new refusal site
+stops it compiling until it says what the new one reads as.
 
 ## The client's own edits
 
-**The Plan Panel's edits are ops, and the applier applies them.** A field the writer types
-in builds the same op a Proposal would carry, `src/client/plan/edits.ts` reads its
-`expected` out of the Plan on screen, and `applyProposal` produces the Plan that goes to
-`setState`. One write path means the Panel cannot make a change the applier would refuse,
-and a structural edit gets the consequences the ops already state — deleting a Section
-unplaces its References. The writer's own edits do not go Stale: staleness is the gap
-between generating a Proposal and applying it, and there is no gap here.
+A field the writer types builds the same op a Proposal would carry.
+`src/client/plan/edits.ts` reads `expected` from the Plan on screen, and `applyProposal`
+produces the Plan that goes to `setState`. One write path means the Panel cannot make a change
+the applier would refuse, and a structural edit gets the consequences the ops already state.
+The writer's own edits never go Stale, because there is no gap between generating and applying
+them.
 
-**One writer holds the Plan and the debounce**, in `src/client/plan/writer.ts`. It applies
-each edit locally, sends after a pause for the four ops a keystroke produces, and sends at
-once for everything else. An update arriving from the Article Agent over an unsent edit is
-the echo of an older write and is dropped — the client is the Plan's only writer, so there
-is nothing else it can be.
+`src/client/plan/writer.ts` holds the Plan and the debounce. It applies each edit locally,
+sends after a pause for the four ops a keystroke produces, and sends at once for everything
+else. It drops an update that arrives from the Article Agent over an unsent edit, because the
+client is the Plan's only writer and that update can only be an echo of an older write.

--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -1,9 +1,5 @@
 # Reviews and Notes
 
-What the feature is and how it behaves. The cross-module rules it has to obey
-are [`architecture.md`](./architecture.md), the sync it rides is
-[`sync.md`](./sync.md), and the words are [`context.md`](./context.md).
-
 ## The loop
 
 The writer types what a Review should look for and runs it. The Guide reads the

--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -75,35 +75,32 @@ The Draft as it was last saved. The Draft's flush lives inside the Draft Panel,
 so a Review run mid-keystroke can miss the last sentence. The Notes Panel numbers
 its anchors off the same read, so "¶3" on a card is the paragraph the model saw.
 
-## The Article Agent runs the Review, and the client does not
+## The Article Agent runs the Review, not the client
 
-A Review is long-running and produces a batch, so a client-run one is lost the
-moment the writer closes the tab — issue #11. `startReview` writes a Round row,
-answers with it, and carries on under `waitUntil`. Two things follow:
+A Review runs long and produces a batch, so a client-run Review would be lost the moment the
+writer closed the tab (issue #11). `startReview` writes a Round row, answers with it, and
+carries on under `waitUntil`. Two rules follow.
 
-- **`state` is a column.** `running` has to survive the writer leaving, and a
-  Review that fails with nobody connected has to leave its reason on the row
-  rather than on a call. A `running` row seen at wake is one a restart cut off —
-  the Review itself holds the Agent awake — so `onStart` fails it, freeing the
-  guard below.
-- **One Review at a time per Article**, guarded by the running row and enforced
-  by the table: a partial unique index allows at most one `running` row. The
-  pre-check in `startReview` gives the friendly refusal; the index holds when two
-  calls interleave across an `await` (#9), which a field could not — in-memory
-  state does not survive hibernation, and a check-then-write races itself.
+First, `state` is a column rather than a field. `running` has to survive the writer leaving,
+and a Review that fails with nobody connected has to leave its reason on the row rather than
+on a call. A `running` row seen at wake belongs to a Review a restart cut off — the Review
+itself holds the Agent awake — so `onStart` fails it and frees the guard below.
 
-**A Note's anchor is settled once, at write time**, against the Plan and Draft
-the model was shown. An anchor the client cannot resolve reads as the whole piece
-and breaks nothing, so the write is taken and the anchor settled rather than the
-Note refused — issue #42's line, applied where nothing is load-bearing.
+Second, one Review runs at a time per Article. A partial unique index allows at most one
+`running` row. The pre-check in `startReview` gives the friendly refusal, and the index holds
+when two calls interleave across an `await` (#9). A field could not do this: in-memory state
+does not survive hibernation, and a check-then-write races itself.
+
+A Note's anchor is settled once, at write time, against the Plan and Draft the model was
+shown. An anchor the client cannot resolve reads as the whole piece and breaks nothing, so we
+take the write and settle the anchor rather than refusing the Note (issue #42).
 
 ## Not built
 
-**A Review does not stream, and it is the thing that should.** Its Notes arrive
-live as rows, but the Round's prose lands whole; the streaming version is
-`streamObject` over the Agent's `onRequest` — issue #77. The cost is smaller than
-it looks, because the Round is durable: the wait is a row rather than a call being
-held open.
+A Review does not stream, and it should. Its Notes arrive live as rows, but the Round's prose
+lands whole. The streaming version is `streamObject` over the Agent's `onRequest` (issue #77),
+and it costs less than it looks, because the Round is durable — the wait is a row rather than
+a call held open.
 
-Also open: scoping a Review to one Section (#78), notes drawn beside the prose
-(#81), the last-save gap (#82), and grouping the queue by Section (#83).
+Also open: scoping a Review to one Section (#78), notes drawn beside the prose (#81), the
+last-save gap (#82), and grouping the queue by Section (#83).

--- a/docs/reviews.md
+++ b/docs/reviews.md
@@ -1,8 +1,8 @@
 # Reviews and Notes
 
 What the feature is and how it behaves. The cross-module rules it has to obey
-are [`architecture.md`](./architecture.md) §12; the words are
-[`context.md`](./context.md).
+are [`architecture.md`](./architecture.md), the sync it rides is
+[`sync.md`](./sync.md), and the words are [`context.md`](./context.md).
 
 ## The loop
 
@@ -75,7 +75,35 @@ The Draft as it was last saved. The Draft's flush lives inside the Draft Panel,
 so a Review run mid-keystroke can miss the last sentence. The Notes Panel numbers
 its anchors off the same read, so "¶3" on a card is the paragraph the model saw.
 
+## The Article Agent runs the Review, and the client does not
+
+A Review is long-running and produces a batch, so a client-run one is lost the
+moment the writer closes the tab — issue #11. `startReview` writes a Round row,
+answers with it, and carries on under `waitUntil`. Two things follow:
+
+- **`state` is a column.** `running` has to survive the writer leaving, and a
+  Review that fails with nobody connected has to leave its reason on the row
+  rather than on a call. A `running` row seen at wake is one a restart cut off —
+  the Review itself holds the Agent awake — so `onStart` fails it, freeing the
+  guard below.
+- **One Review at a time per Article**, guarded by the running row and enforced
+  by the table: a partial unique index allows at most one `running` row. The
+  pre-check in `startReview` gives the friendly refusal; the index holds when two
+  calls interleave across an `await` (#9), which a field could not — in-memory
+  state does not survive hibernation, and a check-then-write races itself.
+
+**A Note's anchor is settled once, at write time**, against the Plan and Draft
+the model was shown. An anchor the client cannot resolve reads as the whole piece
+and breaks nothing, so the write is taken and the anchor settled rather than the
+Note refused — issue #42's line, applied where nothing is load-bearing.
+
 ## Not built
 
-Streaming (#77), scoping a Review to one Section (#78), notes drawn beside the
-prose (#81), the last-save gap (#82), and grouping the queue by Section (#83).
+**A Review does not stream, and it is the thing that should.** Its Notes arrive
+live as rows, but the Round's prose lands whole; the streaming version is
+`streamObject` over the Agent's `onRequest` — issue #77. The cost is smaller than
+it looks, because the Round is durable: the wait is a row rather than a call being
+held open.
+
+Also open: scoping a Review to one Section (#78), notes drawn beside the prose
+(#81), the last-save gap (#82), and grouping the queue by Section (#83).

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,99 +1,88 @@
 # Sync
 
-How party-db runs inside the Article Agent, and what a caller has to do to get a write onto
-every connected client. The rules that bind other modules to this one are
-[`architecture.md`](./architecture.md); the features that ride it are
-[`reviews.md`](./reviews.md) and [`chat.md`](./chat.md). Issue #92 is the pilot that set
-these.
-
-party-db is `mhsnook/party-db`, checked out at `~/code/party-db`.
+party-db (`mhsnook/party-db`, checked out at `~/code/party-db`) runs inside the Article Agent
+and serves the `note`, `round` and `offer` collections. Issue #92 set these rules.
 
 ## Hosting
 
-**Notes, Rounds and Offers are party-db collections, hosted by the Article Agent itself.**
-This is #84's hosting question, answered: the Agent cannot subclass `PartyDbServer` — it
-already extends `AIChatAgent` — so it holds a `PartyDbCore` built over its own SQLite
-(party-db#43). No room Durable Object sits beside it. The House at 1b gets a room of its own.
+The Article Agent cannot subclass `PartyDbServer`, because it already extends `AIChatAgent`.
+It holds a `PartyDbCore` built over its own SQLite instead (party-db#43), so no room Durable
+Object sits beside it. The House gets a room of its own at 1b.
 
-The composition is four seams, all keyed on party-db's own `?proto=party-db` marker:
+Four seams hold that composition together, all keyed on party-db's `?proto=party-db` marker:
 
-- **A second socket, not a shared one.** `partyTransport` connects to the same Durable
-  Object over partyserver's `/parties/article-agent/:name` route, beside the `useAgent`
-  socket. A reconnecting client passes `?since` and gets the delta it missed; a fresh one
-  gets a snapshot.
-- **Marked connects go to the core and skip the Agents SDK handshake** —
-  `shouldSendProtocolMessages` turns the identity/state/MCP frames off for them.
-- **Every broadcast leaves sync subscribers out.** The Agent overrides `broadcast`, which is
-  the one path the SDK's own frames (state sync, Chat streams) and the app's
-  (`plan_refused`) all pass through. A sync subscriber hears `SequencedBatch` frames and
-  nothing else.
-- **The client write path is closed.** A party-db write POST answers 403: rulings are
-  server-side state-machine moves, and party-db has no per-row policy layer to hold their
-  guards yet (party-db#33). Forwarding to `handleWrite` is the whole change when a
-  client-authored collection arrives.
+- `partyTransport` opens a second socket to the same Durable Object over partyserver's
+  `/parties/article-agent/:name` route, beside the `useAgent` socket. A reconnecting client
+  passes `?since` and gets the delta it missed; a fresh one gets a snapshot.
+- `shouldSendProtocolMessages` turns the identity, state, and MCP frames off for marked
+  connects, so those go to the core and skip the Agents SDK handshake.
+- The Agent overrides `broadcast` to exclude sync subscribers. `broadcast` is the one path the
+  SDK's own frames (state sync, Chat streams) and the app's (`plan_refused`) both take, so a
+  sync subscriber hears `SequencedBatch` frames and nothing else.
+- `onRequest` answers a party-db write POST with 403. Rulings are server-side state-machine
+  moves, and party-db has no per-row policy layer to hold their guards yet (party-db#33).
+  Forwarding to `handleWrite` is the whole change when a client-authored collection arrives.
 
 ## Writing
 
-**Every server write to a synced table goes through `commit()` rather than raw SQL.** A raw
-write reaches a fresh snapshot and never an already-connected client, because only the oplog
-feeds the stream. Reads stay plain SQL — the fingerprint dedupe in `recordOffers` among
-them — because the oplog carries writes.
+To reach an already-connected client, a server write to a synced table must go through
+`commit()`. Only the oplog feeds the stream, so a raw write reaches a fresh snapshot and
+nothing else. Reads stay plain SQL — including the fingerprint dedupe in `recordOffers` —
+because the oplog carries writes.
 
 Batch what a subscriber should see together. The Guide writes a Round's Notes and its settle
-in one commit, and a research turn commits its Offers in one too: a subscriber that hears
-the Round settle already holds its Notes, and a turn that found seventeen things costs one
-batch rather than seventeen.
+in one commit, so a subscriber that hears the Round settle already holds its Notes. A research
+turn commits its Offers in one batch, so a turn that found seventeen things costs one batch
+rather than seventeen.
 
-Rulings stay `@callable` RPC for their guards on all three types, implemented over `commit()`
-so the ruled row syncs. Nothing announces a Review settling or a turn recording any more —
-the rows landing is the announcement, which is what deleted the `review_finished` frame, the
-Notes Panel's poll, its reload counter, and the Ledger's.
+Rulings stay on `@callable` RPC, because that is where their guards live, and they call
+`commit()` so the ruled row syncs. The rows landing is the announcement, which is why we
+deleted the `review_finished` frame, the Notes Panel's poll and reload counter, and the
+Ledger's.
 
-**One call is one transaction, so a batch recovers whole and not by the row.** party-db runs
-a call's ops in one transaction, with the oplog's compaction inside it, so the oplog never
-has a torn floor — a half-landed batch would leave a subscriber's delta describing rows the
-table does not have. The cost falls on the two batched writes above: one refused row takes
-the call's other rows with it, so a caller that meets a rejection re-decides the whole batch.
-`recordOffers` re-dedupes against what landed and commits the remainder. Per-op rejection in
-party-db would make that loop a catch again.
+party-db runs one call's ops in a single transaction, with the oplog's compaction inside it,
+so the oplog never has a torn floor. A half-landed batch would leave a subscriber's delta
+describing rows the table does not have. The cost falls on the two batched writes above: one
+refused row takes the call's other rows with it, so a caller that meets a rejection re-decides
+the whole batch. `recordOffers` re-dedupes against what landed and commits the remainder.
+Per-op rejection in party-db would turn that loop back into a catch.
 
-**A refused commit is re-read, not parsed.** `commit()` throws the adapter's error as it
-comes — party-db classifies rejections only on its HTTP write path, and its embedded SQLite
-adapter implements none of the optional `classifyError` hook the Postgres one fills in. The
-alternative is matching a SQLite message string in app code, which changes with the adapter.
-So `recordOffers` and `createRound` both re-read and let the table say who won, and so
-should the next guard. A typed rejection out of `commit()` retires this.
+A refused commit gets re-read rather than parsed. `commit()` throws the adapter's error as it
+comes, because party-db classifies rejections only on its HTTP write path and its embedded
+SQLite adapter implements none of the optional `classifyError` hook that the Postgres one
+fills in. Matching a SQLite message string in app code would break when the adapter changes.
+So `recordOffers` and `createRound` both re-read and let the table say who won, and so should
+the next guard. A typed rejection out of `commit()` retires this.
 
-## The wire rows are the table rows
+## Schemas
 
-`src/shared/sync.ts` declares the three collections' schemas as the columns stand —
-snake_case, JSON columns as the text they store — and owns the one mapping to the shapes the
-app reads. JSON-typed fields would arrive unparsed anyway: party-db's column codec reads Zod
-v3 internals and this repo is on Zod v4 (party-db#45).
+`src/shared/sync.ts` declares the three collections as the columns stand — snake_case, and
+JSON columns as the text they store — and owns the one mapping to the shapes the app reads.
+JSON-typed fields would arrive unparsed anyway, because party-db's column codec reads Zod v3
+internals and this repo is on Zod v4 (party-db#45).
 
 ## Migrations
 
-**A Durable Object's SQLite migrates on the wake.** `migrations_dir` in `wrangler.jsonc`
-belongs to the D1 binding, and there are as many Article databases as there are Articles. No
-wrangler mechanism reaches inside one, so `onStart` is the only code that runs against them
-all — and it runs on every wake, which is what makes a new column need a `pragma_table_info`
-guard where a new table needs only `IF NOT EXISTS`.
+A Durable Object's SQLite migrates on the wake. `migrations_dir` in `wrangler.jsonc` belongs
+to the D1 binding, and there are as many Article databases as there are Articles, so no
+wrangler mechanism reaches inside one. `onStart` is the only code that runs against them all,
+and it runs on every wake. A new table therefore needs only `IF NOT EXISTS`, while a new
+column needs a `pragma_table_info` guard.
 
 ## Settings and carries
 
-- **Set `oplogRetention` low, around 200** against its default of 10,000. For a hot row the
-  reconnect delta measured 400× the snapshot, and party-db has no large-delta bail-out. Low
-  retention pushes a returning client onto the cheap snapshot path. The Article Agent's core
-  sets 200; the House's room should too.
-- **The per-Article sync client is cached for the session, and its collections are pinned.**
-  party-db exposes no way to close a transport (party-db#46), and a collection that restarts
-  after TanStack DB's GC gets no second snapshot (party-db#47) — so `articleSync` holds one
-  client per Article and a standing subscription per collection. Both carries undo when the
-  upstream teardown lands.
-- **party-db does not compare `previousValue`.** Any concurrent write clobbers the whole row.
+- Set `oplogRetention` to about 200, against a default of 10,000. For a hot row the reconnect
+  delta measured 400× the snapshot, and party-db has no large-delta bail-out, so low retention
+  pushes a returning client onto the cheap snapshot path. The Article Agent's core sets 200,
+  and the House's room should too.
+- `articleSync` caches one client per Article for the session and holds a standing
+  subscription per collection. party-db exposes no way to close a transport (party-db#46), and
+  a collection that restarts after TanStack DB's GC gets no second snapshot (party-db#47).
+  Both carries undo when the upstream teardown lands.
+- party-db does not compare `previousValue`, so any concurrent write clobbers the whole row.
   The Block shape limits the blast radius; nothing removes it.
-- **party-db has no per-row access control.** `src/server/access.ts` warns that `access` and
-  `ownerColumn` are unenforced (party-db#33). Survivable while both people may read
-  everything, and not survivable the moment that stops being true.
-- **An expired Access session answers with a redirect rather than a 1008 close**, so
-  party-db's client reconnect-loops instead of firing `onAuthError`.
+- party-db has no per-row access control. `src/server/access.ts` warns that `access` and
+  `ownerColumn` are unenforced (party-db#33). This survives while both people may read
+  everything, and stops surviving the moment that changes.
+- An expired Access session answers with a redirect rather than a 1008 close, so party-db's
+  client reconnect-loops instead of firing `onAuthError`.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,99 @@
+# Sync
+
+How party-db runs inside the Article Agent, and what a caller has to do to get a write onto
+every connected client. The rules that bind other modules to this one are
+[`architecture.md`](./architecture.md); the features that ride it are
+[`reviews.md`](./reviews.md) and [`chat.md`](./chat.md). Issue #92 is the pilot that set
+these.
+
+party-db is `mhsnook/party-db`, checked out at `~/code/party-db`.
+
+## Hosting
+
+**Notes, Rounds and Offers are party-db collections, hosted by the Article Agent itself.**
+This is #84's hosting question, answered: the Agent cannot subclass `PartyDbServer` — it
+already extends `AIChatAgent` — so it holds a `PartyDbCore` built over its own SQLite
+(party-db#43). No room Durable Object sits beside it. The House at 1b gets a room of its own.
+
+The composition is four seams, all keyed on party-db's own `?proto=party-db` marker:
+
+- **A second socket, not a shared one.** `partyTransport` connects to the same Durable
+  Object over partyserver's `/parties/article-agent/:name` route, beside the `useAgent`
+  socket. A reconnecting client passes `?since` and gets the delta it missed; a fresh one
+  gets a snapshot.
+- **Marked connects go to the core and skip the Agents SDK handshake** —
+  `shouldSendProtocolMessages` turns the identity/state/MCP frames off for them.
+- **Every broadcast leaves sync subscribers out.** The Agent overrides `broadcast`, which is
+  the one path the SDK's own frames (state sync, Chat streams) and the app's
+  (`plan_refused`) all pass through. A sync subscriber hears `SequencedBatch` frames and
+  nothing else.
+- **The client write path is closed.** A party-db write POST answers 403: rulings are
+  server-side state-machine moves, and party-db has no per-row policy layer to hold their
+  guards yet (party-db#33). Forwarding to `handleWrite` is the whole change when a
+  client-authored collection arrives.
+
+## Writing
+
+**Every server write to a synced table goes through `commit()` rather than raw SQL.** A raw
+write reaches a fresh snapshot and never an already-connected client, because only the oplog
+feeds the stream. Reads stay plain SQL — the fingerprint dedupe in `recordOffers` among
+them — because the oplog carries writes.
+
+Batch what a subscriber should see together. The Guide writes a Round's Notes and its settle
+in one commit, and a research turn commits its Offers in one too: a subscriber that hears
+the Round settle already holds its Notes, and a turn that found seventeen things costs one
+batch rather than seventeen.
+
+Rulings stay `@callable` RPC for their guards on all three types, implemented over `commit()`
+so the ruled row syncs. Nothing announces a Review settling or a turn recording any more —
+the rows landing is the announcement, which is what deleted the `review_finished` frame, the
+Notes Panel's poll, its reload counter, and the Ledger's.
+
+**One call is one transaction, so a batch recovers whole and not by the row.** party-db runs
+a call's ops in one transaction, with the oplog's compaction inside it, so the oplog never
+has a torn floor — a half-landed batch would leave a subscriber's delta describing rows the
+table does not have. The cost falls on the two batched writes above: one refused row takes
+the call's other rows with it, so a caller that meets a rejection re-decides the whole batch.
+`recordOffers` re-dedupes against what landed and commits the remainder. Per-op rejection in
+party-db would make that loop a catch again.
+
+**A refused commit is re-read, not parsed.** `commit()` throws the adapter's error as it
+comes — party-db classifies rejections only on its HTTP write path, and its embedded SQLite
+adapter implements none of the optional `classifyError` hook the Postgres one fills in. The
+alternative is matching a SQLite message string in app code, which changes with the adapter.
+So `recordOffers` and `createRound` both re-read and let the table say who won, and so
+should the next guard. A typed rejection out of `commit()` retires this.
+
+## The wire rows are the table rows
+
+`src/shared/sync.ts` declares the three collections' schemas as the columns stand —
+snake_case, JSON columns as the text they store — and owns the one mapping to the shapes the
+app reads. JSON-typed fields would arrive unparsed anyway: party-db's column codec reads Zod
+v3 internals and this repo is on Zod v4 (party-db#45).
+
+## Migrations
+
+**A Durable Object's SQLite migrates on the wake.** `migrations_dir` in `wrangler.jsonc`
+belongs to the D1 binding, and there are as many Article databases as there are Articles. No
+wrangler mechanism reaches inside one, so `onStart` is the only code that runs against them
+all — and it runs on every wake, which is what makes a new column need a `pragma_table_info`
+guard where a new table needs only `IF NOT EXISTS`.
+
+## Settings and carries
+
+- **Set `oplogRetention` low, around 200** against its default of 10,000. For a hot row the
+  reconnect delta measured 400× the snapshot, and party-db has no large-delta bail-out. Low
+  retention pushes a returning client onto the cheap snapshot path. The Article Agent's core
+  sets 200; the House's room should too.
+- **The per-Article sync client is cached for the session, and its collections are pinned.**
+  party-db exposes no way to close a transport (party-db#46), and a collection that restarts
+  after TanStack DB's GC gets no second snapshot (party-db#47) — so `articleSync` holds one
+  client per Article and a standing subscription per collection. Both carries undo when the
+  upstream teardown lands.
+- **party-db does not compare `previousValue`.** Any concurrent write clobbers the whole row.
+  The Block shape limits the blast radius; nothing removes it.
+- **party-db has no per-row access control.** `src/server/access.ts` warns that `access` and
+  `ownerColumn` are unenforced (party-db#33). Survivable while both people may read
+  everything, and not survivable the moment that stops being true.
+- **An expired Access session answers with a redirect rather than a 1008 close**, so
+  party-db's client reconnect-loops instead of firing `onAuthError`.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -53,3 +53,36 @@ Three decisions worth keeping:
 It costs about 50 kB gzipped on the Article route's chunk, which is what a real markdown
 parser weighs. `streamdown` is the same idea packaged whole, and it was passed over
 because it hard-depends on Mermaid and ships its own Tailwind palette.
+
+## The four Panels
+
+**The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
+narrow screen. Each is more or less its own little interface, with specific and explicit,
+user-gated interactions between them.
+
+`usePanels` holds which are open, keeps them in the one order, drawn by a `Rail` component in
+the navbar. It also sets how wide each one gets: Notes takes a fixed slice as the margin
+rail, and the Draft takes twice what a supporting Panel does out of what is left, so the
+prose keeps the room whatever is beside it.
+
+## Use Loading states rather than drawing empty values
+
+An empty title, a zero count and four empty columns are answers, and a screen that puts one
+on the page before it has read anything has said something untrue. Whatever is still coming
+says so — `Skeleton` where the shape is known, a sentence like "Opening the Plan…" where it
+is not, and a route's `pendingComponent` where the whole screen is waiting.
+
+This is why the Article bar takes `title: string | null`: `''` is the title the writer
+cleared, and it cannot also mean "not read yet".
+
+## Navigation is a `Link`
+
+TanStack Router's component, with `defaultPreload: 'intent'`, which lets a hover trigger
+work such as waking a different Article Agent's Durable Object to improve loading times.
+
+## A Stale Proposal says why
+
+Whole-field comparison is conservative and will refuse a Proposal against a field the writer
+has since touched ([`plan.md`](./plan.md)), so a card the writer cannot Accept explains
+itself rather than greying out. The same goes for a refused Accept: the card stays open with
+the applier's sentence on it, and the writer may fix the Plan and Accept again.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -56,33 +56,33 @@ because it hard-depends on Mermaid and ships its own Tailwind palette.
 
 ## The four Panels
 
-**The Article screen has four Panels** — Chat, Plan, Draft, Notes — which become tabs on a
-narrow screen. Each is more or less its own little interface, with specific and explicit,
-user-gated interactions between them.
+The Article screen shows four Panels — Chat, Plan, Draft, and Notes — which become tabs on a
+narrow screen. Each is its own small interface, and the interactions between them are
+specific, explicit, and user-gated.
 
-`usePanels` holds which are open, keeps them in the one order, drawn by a `Rail` component in
-the navbar. It also sets how wide each one gets: Notes takes a fixed slice as the margin
-rail, and the Draft takes twice what a supporting Panel does out of what is left, so the
-prose keeps the room whatever is beside it.
+`usePanels` holds which Panels are open and keeps them in one order, drawn by a `Rail`
+component in the navbar. It also sets the widths: Notes takes a fixed slice as the margin
+rail, and the Draft takes twice what a supporting Panel does out of what remains, so the prose
+keeps its room whatever sits beside it.
 
-## Use Loading states rather than drawing empty values
+## Show a Loading state rather than an empty value
 
-An empty title, a zero count and four empty columns are answers, and a screen that puts one
-on the page before it has read anything has said something untrue. Whatever is still coming
-says so — `Skeleton` where the shape is known, a sentence like "Opening the Plan…" where it
-is not, and a route's `pendingComponent` where the whole screen is waiting.
+An empty title, a zero count, and four empty columns are answers. A screen that shows one
+before it has read anything has said something untrue. Use `Skeleton` where the shape is
+known, a sentence like "Opening the Plan…" where it is not, and a route's `pendingComponent`
+where the whole screen is waiting.
 
-This is why the Article bar takes `title: string | null`: `''` is the title the writer
-cleared, and it cannot also mean "not read yet".
+This is why the Article bar takes `title: string | null`. `''` is the title the writer
+cleared, so it cannot also mean "not read yet".
 
-## Navigation is a `Link`
+## Navigate with `Link`
 
-TanStack Router's component, with `defaultPreload: 'intent'`, which lets a hover trigger
-work such as waking a different Article Agent's Durable Object to improve loading times.
+TanStack Router's `Link`, with `defaultPreload: 'intent'`. A hover then triggers work such as
+waking a different Article Agent's Durable Object, which improves loading times.
 
-## A Stale Proposal says why
+## A card the writer cannot Accept explains itself
 
-Whole-field comparison is conservative and will refuse a Proposal against a field the writer
-has since touched ([`plan.md`](./plan.md)), so a card the writer cannot Accept explains
-itself rather than greying out. The same goes for a refused Accept: the card stays open with
-the applier's sentence on it, and the writer may fix the Plan and Accept again.
+Whole-field comparison is conservative, so it refuses a Proposal against any field the writer
+has since touched ([`plan.md`](./plan.md)). A Stale card therefore says why rather than
+greying out. A refused Accept behaves the same way: the card stays open with the applier's
+sentence, and the writer can fix the Plan and Accept again.

--- a/src/client/article/ArticlePanels.tsx
+++ b/src/client/article/ArticlePanels.tsx
@@ -9,7 +9,7 @@ import { ArticlePlanPanel } from '../plan/ArticlePlanPanel'
 import { panelShare } from './usePanels'
 
 /**
- * The four Panels of the Article screen — architecture.md §8. This row is what
+ * The four Panels of the Article screen — `docs/ui.md`. This row is what
  * gives them a height to scroll their own Y within.
  *
  * How wide each one gets is `panelShare`, which reads the whole open set: the

--- a/src/client/article/title.ts
+++ b/src/client/article/title.ts
@@ -9,7 +9,7 @@ import type { PlanConnection } from '../plan/usePlan'
 
 /**
  * An Article's title, across the two places it lives. The Plan is written first
- * and the index copy follows it — docs/architecture.md §9.
+ * and the index copy follows it — docs/architecture.md §4.6.
  */
 
 /**

--- a/src/client/article/usePanels.ts
+++ b/src/client/article/usePanels.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 
 import { PANELS, type PanelId } from '../components/PanelRail'
 
-/** Which Panels the Article screen shows, and the tabs a narrow one gets — §8. */
+/** Which Panels the Article screen shows, and the tabs a narrow one gets — `docs/ui.md`. */
 
 /** Below the md breakpoint (`--breakpoint-md`, theme.css) the rail shows one
  * Panel at a time. The query is the complement of Tailwind's `md:`. */

--- a/src/client/articles/api.ts
+++ b/src/client/articles/api.ts
@@ -6,7 +6,7 @@ import {
 } from '../../shared/article'
 
 /**
- * The article index over HTTP — the one store that is not reactive (§8).
+ * The article index over HTTP — the one store that is not reactive (`docs/articles.md`).
  *
  * Answers are parsed rather than asserted, so a route that drifts from the
  * shared schema fails here with a sentence rather than rendering half a row.
@@ -21,7 +21,8 @@ export async function fetchArticles(): Promise<ArticleEntry[]> {
 }
 
 /** Untitled: the name travels into the Article screen and reaches the index as a
- * copy of the Plan's, so nothing may name a row ahead of the Plan (§9). */
+ * copy of the Plan's, so nothing may name a row ahead of the Plan
+ * (architecture.md §4.6). */
 export async function createArticle(): Promise<ArticleEntry> {
 	const answer = await send(base, 'POST', {})
 

--- a/src/client/articles/useArticles.ts
+++ b/src/client/articles/useArticles.ts
@@ -12,7 +12,7 @@ import { failureText } from '../lib/failure'
 import { editArticle, fetchArticles } from './api'
 
 /**
- * The article index through TanStack Query — §8. One key holds the whole table:
+ * The article index through TanStack Query — `docs/articles.md`. One key holds the whole table:
  * one Team's index is small enough to send whole, and both Views read it.
  */
 

--- a/src/client/articles/useNewArticle.tsx
+++ b/src/client/articles/useNewArticle.tsx
@@ -31,7 +31,7 @@ declare module '@tanstack/react-router' {
  * the dialog asks what to call it while that request is still in flight.
  *
  * The typed title goes to the caller rather than to the index — writing it here
- * would put the index copy in front of the Plan it copies (§9) — and the caller
+ * would put the index copy in front of the Plan it copies (architecture.md §4.6) — and the caller
  * navigates, so this module stays as router-free as the rest of `articles/`.
  */
 

--- a/src/client/chat/ArticleChatPanel.tsx
+++ b/src/client/chat/ArticleChatPanel.tsx
@@ -10,7 +10,7 @@ import { OfferLedgerDrawer } from './OfferLedgerDrawer'
 import { useArticleChat } from './useArticleChat'
 
 /** Drives `ChatPanel` from one Article Agent. Takes the socket rather than
- * opening one — §8. */
+ * opening one — architecture.md §4.4. */
 
 export interface ArticleChatPanelProps {
 	agent: ArticleSocket

--- a/src/client/chat/ChatPanel.tsx
+++ b/src/client/chat/ChatPanel.tsx
@@ -27,7 +27,7 @@ import { readWebSearch, searchNote } from './search'
  * The Chat Panel takes a transcript & rulings; `ArticleChatPanel` drives it from
  * the Article Agent — the same split as `PlanPanel` and `ArticlePlanPanel`. A turn
  * can return Proposals and Offers; each gets its own card. Proposals suspend and
- * wait for the writer (§6), but Offers just accumulate in the Ledger.
+ * wait for the writer (`docs/chat.md`), but Offers just accumulate in the Ledger.
  */
 
 export interface ChatPanelProps {
@@ -39,7 +39,7 @@ export interface ChatPanelProps {
 	busy: boolean
 	/** Cancels the turn. */
 	onStop?: () => void
-	/** Proposals nobody has ruled on; above zero the turn is parked — §11. */
+	/** Proposals nobody has ruled on; above zero the turn is parked — `docs/carries.md`. */
 	waiting: number
 	refusals: Refusals
 	offers: readonly Offer[]
@@ -241,7 +241,7 @@ function useFootOfTranscript(): [
 }
 
 /** Why the composer will not send, and null when it will. Nothing expires an
- * unruled call, so the writer has to be told to go and rule on it — §11. */
+ * unruled call, so the writer has to be told to go and rule on it — `docs/carries.md`. */
 function parked(waiting: number): string | null {
 	if (waiting === 0) return null
 	if (waiting === 1) {

--- a/src/client/chat/ProposalCard.tsx
+++ b/src/client/chat/ProposalCard.tsx
@@ -6,7 +6,7 @@ import { refusalText } from '../plan/refusalText'
 import { changeCount, ProposalChanges } from './ProposalChanges'
 import { describeProposal, type ProposalCall } from './proposals'
 
-/** One suspended Proposal to Accept or Decline — §6. Renders its ops as
+/** One suspended Proposal to Accept or Decline — `docs/chat.md`. Renders its ops as
  * sentences, and the refusal if an Accept was turned down. */
 
 export interface ProposalCardProps {

--- a/src/client/chat/ProposalChanges.tsx
+++ b/src/client/chat/ProposalChanges.tsx
@@ -7,7 +7,7 @@ import { unreadableText } from '../plan/refusalText'
 export interface ProposalChangesProps {
 	/** One sentence per op, out of `describeProposal`. */
 	changes: readonly string[]
-	/** Why the ops could not be read, and null where they could — §6. */
+	/** Why the ops could not be read, and null where they could — `docs/chat.md`. */
 	unreadable?: string | null
 	className?: string
 }

--- a/src/client/chat/RuledProposal.tsx
+++ b/src/client/chat/RuledProposal.tsx
@@ -4,7 +4,7 @@ import { changeCount, ProposalChanges } from './ProposalChanges'
 import { describeProposal, type ProposalCall } from './proposals'
 
 /**
- * A Proposal the writer has already ruled on — §6. Shut, it is the one-line note
+ * A Proposal the writer has already ruled on — `docs/chat.md`. Shut, it is the one-line note
  * the transcript used to carry; open, it prints the same sentences the card
  * offered, so the writer can read back what they Accepted.
  *

--- a/src/client/chat/offers.ts
+++ b/src/client/chat/offers.ts
@@ -8,7 +8,7 @@ import {
 
 /**
  * Reading a research turn's result out of the transcript. `recordOffers`
- * resolves server-side and hands back ids, not rows — §5.
+ * resolves server-side and hands back ids, not rows — `docs/chat.md`.
  */
 
 /** What one `recordOffers` call turned up, or null for a part that is not one. */

--- a/src/client/chat/proposals.ts
+++ b/src/client/chat/proposals.ts
@@ -15,7 +15,7 @@ import { referenceName } from '../plan/references'
 /**
  * Reading Proposals out of a Chat transcript, ruling on one, and wording what a
  * card says. A Proposal is a suspended tool call: input present, no output,
- * parked until the writer rules — §6.
+ * parked until the writer rules — `docs/chat.md`.
  *
  * No socket and no React here, so a test drives it with a transcript and a Plan.
  */
@@ -31,11 +31,11 @@ type AnyToolPart = ToolUIPart | DynamicToolUIPart
 
 /**
  * How many Proposals have their input complete and no output sent, which is what
- * parks a turn — §11.
+ * parks a turn — `docs/carries.md`.
  *
  * **Only the Proposal tool counts.** It is the one with no `execute`, so it
  * suspends for the writer and nothing expires it; the research tool resolves
- * inside the turn (§5) and its call sits at `input-available` meanwhile.
+ * inside the turn (`docs/chat.md`) and its call sits at `input-available` meanwhile.
  */
 export function waitingCount(messages: readonly UIMessage[]): number {
 	let waiting = 0
@@ -52,7 +52,7 @@ export function waitingCount(messages: readonly UIMessage[]): number {
 }
 
 /** Reads the ops off a suspended call. A payload that fails here has already
- * survived the schema's own retries (§6), so the card reports it. */
+ * survived the schema's own retries (`docs/plan.md`), so the card reports it. */
 export function readProposal(part: AnyToolPart): ProposalCall {
 	const parsed = proposePlanChangeInput.safeParse(part.input)
 	if (!parsed.success) {
@@ -66,7 +66,7 @@ export function readProposal(part: AnyToolPart): ProposalCall {
 	return { toolCallId: part.toolCallId, ops: parsed.data.ops, unreadable: null }
 }
 
-/** The `is_error: true` content a Decline sends back — §6. A refused Accept
+/** The `is_error: true` content a Decline sends back — `docs/chat.md`. A refused Accept
  * sends the refusal, so the model learns the Plan moved under it. */
 export function declineReason(call: ProposalCall, refusal: Refusal | null): string {
 	if (call.unreadable !== null) {
@@ -88,7 +88,7 @@ export function acceptReason(ops: Proposal): string {
 }
 
 /** What the tool call is answered with. An `errorText` is the `is_error: true`
- * half — §6. */
+ * half — `docs/chat.md`. */
 export type ToolAnswer = { output: string } | { errorText: string }
 
 /** Refusals by tool call, since a transcript can carry several open Proposals. */

--- a/src/client/chat/useArticleChat.ts
+++ b/src/client/chat/useArticleChat.ts
@@ -16,7 +16,8 @@ import {
 } from './proposals'
 
 /**
- * One Chat on the socket the Plan already holds — §6 and §8. A ruling applies
+ * One Chat on the socket the Plan already holds — `docs/chat.md` and
+ * architecture.md §4.4. A ruling applies
  * the ops through `edit` and then answers the tool call.
  *
  * Three SDK traps sit under this. `addToolResult` is deprecated in favour of
@@ -34,7 +35,7 @@ export type ChatHandle = {
 	busy: boolean
 	/** Cancels the turn, on the server as well as here. */
 	stop: () => void
-	/** Proposals nobody has ruled on; above zero the turn is parked — §11. */
+	/** Proposals nobody has ruled on; above zero the turn is parked — `docs/carries.md`. */
 	waiting: number
 	refusals: Refusals
 	ledger: OfferLedgerHandle
@@ -50,7 +51,7 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 	const [refusals, setRefusals] = useState<Refusals>({})
 
 	// A ref, because the body is built when the turn is sent rather than when
-	// this renders. The Plan goes in `body` and not `metadata` — §6.
+	// this renders. The Plan goes in `body` and not `metadata` — `docs/chat.md`.
 	const held = useRef<Plan | null>(connection.plan)
 	useEffect(() => {
 		held.current = connection.plan
@@ -89,7 +90,7 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 
 	return {
 		messages,
-		// A turn sent over an unanswered call is refused server-side — §11.
+		// A turn sent over an unanswered call is refused server-side — `docs/carries.md`.
 		send: (text: string) => {
 			const said = text.trim()
 			if (said !== '' && waiting === 0) chat.sendMessage({ text: said })
@@ -99,7 +100,7 @@ export function useArticleChat(agent: ArticleSocket): ChatHandle {
 
 		// **A parked Proposal is not the guide answering.** A suspended call holds
 		// the turn open, so the SDK reports it as streaming until the client
-		// answers (§6) — but the writer is the one being waited on there, and the
+		// answers (`docs/chat.md`) — but the writer is the one being waited on there, and the
 		// Proposal card and the composer say so themselves.
 		busy: running && waiting === 0,
 		stop: () => void chat.stop(),

--- a/src/client/components/Chat.tsx
+++ b/src/client/components/Chat.tsx
@@ -43,7 +43,7 @@ export interface ChatComposerProps {
 	/** Absent on the wireframe screens, which render a still frame. */
 	onSend?: (text: string) => void
 	/** Why the composer will not send, and null when it will. A Proposal nobody
-	 * ruled on is the case worth wording — nothing expires it (§11). */
+	 * ruled on is the case worth wording — nothing expires it (`docs/carries.md`). */
 	blocked?: string | null
 	/** A turn is in flight. The field stays open; send becomes stop. */
 	busy?: boolean

--- a/src/client/draft/DraftPanel.tsx
+++ b/src/client/draft/DraftPanel.tsx
@@ -25,7 +25,7 @@ export interface DraftPanelProps {
  * change; loading and saving are `ArticleDraftPanel`'s.
  *
  * Who may write here, and why the writer places their own headings and section
- * breaks, is docs/architecture.md §3 and §10.
+ * breaks, is architecture.md §3 and `docs/draft.md`.
  */
 export function DraftPanel({
 	blocks,

--- a/src/client/draft/useDraft.ts
+++ b/src/client/draft/useDraft.ts
@@ -23,7 +23,7 @@ export type DraftConnection = {
 /**
  * Reads the Draft once and writes it back as the writer types — §3, rule 2.
  *
- * Nothing reloads it: §3 leaves this client as the Blocks' only writer, so a
+ * Nothing reloads it: `docs/draft.md` leaves this client as the Blocks' only writer, so a
  * second read could only replace what is on screen with an older copy of it.
  */
 export function useDraft(store: DraftStore): DraftConnection {

--- a/src/client/lib/queryClient.ts
+++ b/src/client/lib/queryClient.ts
@@ -1,7 +1,7 @@
 import { QueryClient } from '@tanstack/react-query'
 
 /**
- * One client. The article index is all it serves (§8). Refetch-on-focus is left
+ * One client. The article index is all it serves (`docs/articles.md`). Refetch-on-focus is left
  * on: it is what makes an Article opened on the other machine turn up here.
  */
 export const queryClient = new QueryClient({

--- a/src/client/lib/sync.ts
+++ b/src/client/lib/sync.ts
@@ -9,8 +9,8 @@ import {
 } from '../../shared/sync'
 
 /**
- * One party-db connection per Article — the second socket of architecture.md
- * §12, carrying the `note`, `round` and `offer` collections.
+ * One party-db connection per Article — the second socket of `docs/sync.md`,
+ * carrying the `note`, `round` and `offer` collections.
  */
 
 export type ArticleSync = {

--- a/src/client/lib/useArticleAgent.ts
+++ b/src/client/lib/useArticleAgent.ts
@@ -14,8 +14,8 @@ import { articleSync, retainArticleSync } from './sync'
 /**
  * Opens one Article Agent and hands out the three things that ride its one
  * multiplexed socket: the Plan channel, an Offer store over `@callable` RPC, and
- * the client itself for `useAgentChat` — §8. A second socket would mean a second
- * Plan writer, which §3 rule 1 forbids.
+ * the client itself for `useAgentChat` — architecture.md §4.4. A second socket would mean a second
+ * Plan writer, which architecture.md §3 rule 1 rules out.
  */
 
 export type ArticleSocket = ReturnType<typeof useAgent<Plan>>

--- a/src/client/lib/useOfferLedger.ts
+++ b/src/client/lib/useOfferLedger.ts
@@ -11,7 +11,7 @@ import { failureText } from './failure'
 
 /**
  * The Offer ledger, live: a live query over the synced `offer` collection,
- * writes over RPC — architecture.md §12.
+ * writes over RPC — `docs/sync.md`.
  */
 
 export type OfferLedgerHandle = {
@@ -48,7 +48,7 @@ export function useOfferLedger(): OfferLedgerHandle {
 		loading: !rows.isReady,
 		failure,
 
-		// Two writes against two stores, decoupled — §5, which says why this
+		// Two writes against two stores, decoupled — `docs/chat.md`, which says why this
 		// order and not the other. The Plan goes first because the copy is built
 		// from what the Offer says and needs nothing the ruling returns, and a
 		// refused copy stops the ruling rather than sending it anyway.

--- a/src/client/notes/NotesPanel.tsx
+++ b/src/client/notes/NotesPanel.tsx
@@ -155,7 +155,7 @@ export function NotesPanel({
 }
 
 /** The list, and what stands in for it when there is none. Loading and empty
- * are told apart rather than both drawing nothing — §8. */
+ * are told apart rather than both drawing nothing — `docs/ui.md`. */
 function Queue({
 	queue,
 	view,

--- a/src/client/notes/useNotes.ts
+++ b/src/client/notes/useNotes.ts
@@ -17,7 +17,7 @@ import type { NoteActions } from './actions'
 import { type AnchorNaming, anchorNaming } from './anchors'
 
 /** The Notes Panel's half of one Article Agent: live queries over the synced
- * collections, writes over RPC — architecture.md §12. */
+ * collections, writes over RPC — `docs/sync.md`. */
 
 export type NotesHandle = {
 	queue: NotesQueue
@@ -126,7 +126,7 @@ export function useNotes(): NotesHandle {
 				.startReview({
 					prompt: asked,
 					depth,
-					// May be newer than the Plan the Article Agent has stored — §6.
+					// May be newer than the Plan the Article Agent has stored — `docs/chat.md`.
 					...(connection.plan === null ? {} : { plan: connection.plan }),
 				})
 				.catch((error: unknown) =>

--- a/src/client/plan/ReferenceForm.tsx
+++ b/src/client/plan/ReferenceForm.tsx
@@ -161,7 +161,7 @@ export function ReferenceForm({
 
 type SourceDraft = Record<'title' | 'author' | 'publication' | 'year' | 'url', string>
 
-/** A field the writer left empty is a field the Reference does not carry — §4's
+/** A field the writer left empty is a field the Reference does not carry — `docs/plan.md`'s
  * one spelling per state. */
 function stated(key: 'text' | 'note', value: string) {
 	return value.trim() === '' ? {} : { [key]: value.trim() }

--- a/src/client/plan/ReferenceList.tsx
+++ b/src/client/plan/ReferenceList.tsx
@@ -16,7 +16,7 @@ import { attribution, referenceEntries, referenceMark, referenceName } from './r
 
 /**
  * The Plan's References: items Accepted from the Chat or added by hand by the
- * writer. Follows architecture §4.
+ * writer. Follows `docs/plan.md`.
  *
  * The type is read off the record, never derived from whether a text is
  * present: a Reference may carry a passage without being a Quote.

--- a/src/client/plan/ToneFields.tsx
+++ b/src/client/plan/ToneFields.tsx
@@ -10,7 +10,7 @@ import { cx } from '../lib/cx'
  * time and the nearest Scope wins outright, while Adjectives accumulate — so
  * what this Scope states is editable here, and what it inherits is shown
  * beside it, dimmed, and edited where it was said. Resolution runs at read
- * time, and nothing here stores a resolved value — docs/architecture.md §4.
+ * time, and nothing here stores a resolved value — `docs/plan.md`.
  */
 
 export interface ToneFieldsProps {

--- a/src/client/plan/WordCount.tsx
+++ b/src/client/plan/WordCount.tsx
@@ -5,7 +5,7 @@ import { TextField } from '../components/Field'
 /**
  * The word-count target on screen. The total is stored and nothing derives it,
  * so the parts are allowed to disagree with the whole and the gap is
- * information rather than an error — docs/architecture.md §4.
+ * information rather than an error — `docs/plan.md`.
  */
 
 export interface TargetFieldProps {

--- a/src/client/plan/edits.ts
+++ b/src/client/plan/edits.ts
@@ -12,7 +12,7 @@ import { placementOf } from './outline'
 
 /**
  * The writer's edits, written in the op vocabulary the Chat proposes in and
- * applied by the same applier — docs/architecture.md §6. One path into the Plan
+ * applied by the same applier — `docs/plan.md`. One path into the Plan
  * means the Panel cannot make a change the applier would refuse, and a
  * structural edit carries the consequences the ops already state: deleting a
  * Section unplaces the References placed at it.
@@ -27,7 +27,7 @@ import { placementOf } from './outline'
  * control rather than sending an op the applier would refuse.
  */
 
-/** Which Scope a content op acts on. null is the Article — §6. */
+/** Which Scope a content op acts on. null is the Article — `docs/plan.md`. */
 export type Scope = string | null
 
 /** Where a new Section goes: whose child it is, and which neighbour it anchors
@@ -142,7 +142,7 @@ export function liftSection(plan: Plan, nodeId: string): ProposalInput | null {
 /**
  * A Reference the writer pasted in themselves, which is what its Provenance
  * says. The ones that arrive from the Chat are Accepted from an Offer and carry
- * that Offer's id instead — architecture §5.
+ * that Offer's id instead — `docs/chat.md`.
  */
 export function addReference(
 	content: ReferenceContent,
@@ -158,7 +158,7 @@ export function addReference(
 }
 
 /**
- * The same op as `addReference`, carrying the Offer's Provenance — §5. Null
+ * The same op as `addReference`, carrying the Offer's Provenance — `docs/chat.md`. Null
  * where the Plan already holds a copy, so a second Accept builds nothing. The
  * Offer is the one `setOfferDisposition` returned.
  */

--- a/src/client/plan/map.ts
+++ b/src/client/plan/map.ts
@@ -136,7 +136,7 @@ export function planMap(plan: Plan, options: MapOptions = {}): PlanMap {
 	}
 
 	// Numbered off the walk the Panel reads, not counted again here —
-	// architecture.md §4.
+	// `docs/plan.md`.
 	const ordinals = new Map(
 		outlineEntries(plan.outline).map((entry) => [entry.node.id, entry.ordinal]),
 	)

--- a/src/client/plan/names.ts
+++ b/src/client/plan/names.ts
@@ -5,14 +5,14 @@ import { referenceEntries, referenceMark, referenceName } from './references'
 /**
  * Names one record in the Plan the way the writer would say it, for the places
  * that put a record in a sentence — a Proposal card, a refusal. Sections come
- * out of the same walk the Outline numbers by (§4), and nothing here reads an id
+ * out of the same walk the Outline numbers by (`docs/plan.md`), and nothing here reads an id
  * aloud: the writer never saw one.
  */
 
 export type PlanNames = {
 	/** "§2 Who actually pays", or "§2" where the Section is untitled. */
 	section: (nodeId: string) => string
-	/** The Article for a null Scope — §6. */
+	/** The Article for a null Scope — `docs/plan.md`. */
 	scope: (nodeId: string | null) => string
 	/** Its passage or its title, the way the References list has it. */
 	reference: (referenceId: string) => string
@@ -24,7 +24,7 @@ export type PlanNames = {
 }
 
 export function planNames(plan: Plan): PlanNames {
-	// Both forms out of the one walk — §4.
+	// Both forms out of the one walk — `docs/plan.md`.
 	const numbered = new Map(
 		outlineEntries(plan.outline).map((entry) => {
 			const label = sectionLabel(entry)

--- a/src/client/plan/refusalText.ts
+++ b/src/client/plan/refusalText.ts
@@ -3,7 +3,7 @@ import { planNames, type PlanNames } from './names'
 
 /**
  * What a refused edit reads as on screen. `refusal.message` is the applier's
- * sentence for the model and names ops and ids (§6); this is the other reader,
+ * sentence for the model and names ops and ids (`docs/plan.md`); this is the other reader,
  * a writer mid-task who has seen neither. The table below is the only English
  * in the path — swap it to swap the language — and it is total over
  * `RefusalReason`, so a new refusal site will not compile until it is worded.

--- a/src/client/plan/writer.ts
+++ b/src/client/plan/writer.ts
@@ -8,7 +8,7 @@ import { applyProposal } from '../../shared/plan'
  *
  * **It debounces while the writer types.** The Plan is one blob re-serialised
  * and broadcast on every write, so an un-debounced intent-note field sends
- * about 40 KB per keystroke — §4.
+ * about 40 KB per keystroke — `docs/plan.md`.
  *
  * There is no React in here, which is what lets the debounce be tested against
  * a clock rather than against a rendered field.

--- a/src/client/styles/theme.css
+++ b/src/client/styles/theme.css
@@ -185,7 +185,7 @@
 		margin-top: 0;
 	}
 
-	/* The section break the writer places — §10. */
+	/* The section break the writer places — docs/draft.md. */
 	.prose-draft hr {
 		margin: 1.75em 0;
 		border-top: 1px solid var(--color-edge);

--- a/src/server/article-agent.ts
+++ b/src/server/article-agent.ts
@@ -101,12 +101,12 @@ export type RecordedOffer = { offer: Offer; duplicate: boolean }
  * One Article Agent per Article — docs/architecture.md §2, and §3 for what goes
  * in the state blob against what goes in its SQLite. `AIChatAgent` adds the
  * Chat: it keeps the transcript in its own SQLite tables, which nothing
- * mirrors, and routes a turn to `onChatMessage` below (§6).
+ * mirrors, and routes a turn to `onChatMessage` below (`docs/chat.md`).
  */
 export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	initialState = emptyPlan()
 
-	/** The party-db core composed into this Agent — architecture.md §12. Built
+	/** The party-db core composed into this Agent — `docs/sync.md`. Built
 	 * on every wake in `onStart`, which partyserver runs before any connect,
 	 * request, or RPC reaches this class — so the `!` holds. */
 	db!: PartyDbCore
@@ -137,7 +137,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 			)
 		`
 
-		// At most one row may carry a given fingerprint — §12 for the argument.
+		// At most one row may carry a given fingerprint — `docs/chat.md` for the argument.
 		this.sql`
 			CREATE UNIQUE INDEX IF NOT EXISTS offer_one_per_fingerprint
 			ON offer (fingerprint)
@@ -161,8 +161,8 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 		// One row per Review. `seq` is what the writer reads as "Round 3", and
 		// `state` is why the row exists at all: the Article Agent runs the Review,
 		// so a writer can start one and close the tab, and both "still running" and
-		// "failed while nobody was watching" have to survive them leaving (§3,
-		// rule 4).
+		// "failed while nobody was watching" have to survive them leaving
+		// (`docs/reviews.md`).
 		this.sql`
 			CREATE TABLE IF NOT EXISTS round (
 				seq INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -196,7 +196,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 		`
 		this.sql`CREATE INDEX IF NOT EXISTS note_by_round ON note (round_id)`
 
-		// At most one row may read `running` (§12). The pre-check in
+		// At most one row may read `running` (`docs/reviews.md`). The pre-check in
 		// `startReview` gives the worded refusal; this index closes the race
 		// when two calls interleave across `commit`'s await.
 		this.sql`
@@ -204,9 +204,9 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 			ON round (state) WHERE state = 'running'
 		`
 
-		// The party-db core (§12). The tables above are this class's DDL; the
+		// The party-db core (`docs/sync.md`). The tables above are this class's DDL; the
 		// core CRUDs over them, adds its `_oplog`, and fans committed batches
-		// out to the tagged connections. `oplogRetention` per §11.
+		// out to the tagged connections. `oplogRetention` per `docs/sync.md`.
 		const engine: SqlEngine = {
 			exec: (query, ...bindings) => this.ctx.storage.sql.exec(query, ...bindings),
 			transaction: (fn) => this.ctx.storage.transactionSync(fn),
@@ -242,7 +242,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * ALTER would need a default for the rows already there, and an Article
 	 * carrying the double-record the column exists to stop could not take the
 	 * index at all — so the null case would reach the dedupe and every reader
-	 * past it. The migration pays that instead, once (§12).
+	 * past it. The migration pays that instead, once (`docs/sync.md`).
 	 */
 	private drainOldOfferTable(): OfferRow[] {
 		// `pragma_table_info` answers nothing for a table that does not exist,
@@ -272,7 +272,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * its twin is gone rather than carried as a case the dedupe has to know
 	 * about.
 	 *
-	 * Raw SQL against a synced table, which §12 forbids the app: this runs
+	 * Raw SQL against a synced table, which `docs/sync.md` keeps the app out of: this runs
 	 * before the party-db core is built, and every row it writes is one the
 	 * oplog already announced when the Guide first recorded it. `seq` is not
 	 * carried — the table assigns fresh ones in the same order, and nothing
@@ -303,7 +303,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 		return !isPartyDbRequest(ctx.request)
 	}
 
-	/** Leaves party-db connections out of every broadcast (§12). The SDK's own
+	/** Leaves party-db connections out of every broadcast (`docs/sync.md`). The SDK's own
 	 * frames — state sync, Chat streams — route through this method too, so
 	 * one override covers them all. */
 	broadcast(message: string | ArrayBuffer | ArrayBufferView, without?: string[]): void {
@@ -327,7 +327,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 
 	/**
 	 * Refuses party-db write POSTs: no collection takes client writes, and
-	 * the ruling guards live on the `@callable` methods — §12. Opening the
+	 * the ruling guards live on the `@callable` methods — `docs/sync.md`. Opening the
 	 * client write path means forwarding these to `this.db.handleWrite`.
 	 */
 	async onRequest(request: Request): Promise<Response> {
@@ -344,7 +344,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	}
 
 	/** The model a Chat turn runs on — one model currently serves every call
-	 * (§7). `llm/model.ts` is the boundary; this reads it so a workerd test,
+	 * (`docs/llm.md`). `llm/model.ts` is the boundary; this reads it so a workerd test,
 	 * which has no Workers AI binding to reach, can put a scripted model behind
 	 * it. */
 	chatModel(): LanguageModel {
@@ -386,7 +386,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	/**
 	 * The Plan the turn is about. The client sends it in `body`, never in
 	 * `metadata`, which persists on the `UIMessage` and re-rides every turn
-	 * (§6).
+	 * (`docs/chat.md`).
 	 *
 	 * **The body wins over state, and the two can disagree.** A client that
 	 * applies a Proposal and sends the next turn before its `setState` lands
@@ -439,7 +439,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * across local writes, so a research turn that records four Offers stamps
 	 * them with one or two milliseconds between them.
 	 *
-	 * Not `@callable` — a client reads its synced collection (§12); this reader
+	 * Not `@callable` — a client reads its synced collection (`docs/sync.md`); this reader
 	 * serves this class and its tests. */
 	listOffers(): Offer[] {
 		return this.offerRows().map(toOffer)
@@ -454,14 +454,15 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 
 	/**
 	 * One research turn. An entry this Article already carries comes back as it
-	 * stands, keeping the disposition the writer gave it — §5.
+	 * stands, keeping the disposition the writer gave it — `docs/chat.md`.
 	 *
 	 * The map below gives that answer, and `offer_one_per_fingerprint` is what
 	 * makes it hold when two turns of one step read before either committed. The
-	 * loop is the recovery a whole-call transaction forces — §12 for both.
+	 * loop is the recovery a whole-call transaction forces — `docs/chat.md` and
+	 * `docs/sync.md` for both.
 	 *
 	 * Not `@callable`: the research tool is the only caller and it runs inside
-	 * this Agent (§3, rule 4).
+	 * this Agent (`docs/chat.md`).
 	 */
 	async recordOffers(batch: unknown): Promise<RecordedOffer[]> {
 		const found = offerBatchSchema.parse(batch)
@@ -500,7 +501,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 			} catch (error) {
 				// A fingerprint this pass tried to write that the table now holds
 				// is another turn committing across the await. Re-reading is how
-				// the table says so, rather than the rejection's wording (§12).
+				// the table says so, rather than the rejection's wording (`docs/sync.md`).
 				const taken = new Set(this.offerRows().map((row) => row.fingerprint))
 				const lost = ops.some((op) => taken.has(op.value.fingerprint))
 
@@ -570,7 +571,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 * Block it has already seen, so a second tab's paragraph is not something
 	 * this one can delete.
 	 *
-	 * The content is stored, not inspected — §3 leaves the client as the Draft's
+	 * The content is stored, not inspected — `docs/draft.md` leaves the client as the Draft's
 	 * only writer, and reading the document here would put the editor's schema in
 	 * the Worker. Size is checked, because that is the failure the writer cannot
 	 * see coming.
@@ -607,7 +608,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	/** Every Round on this Article, oldest first. `seq` orders it and numbers it,
 	 * for the reason `listOffers` gives: a Worker's clock barely moves across
 	 * local writes. Not `@callable` — a client reads its synced collection
-	 * (§12); this reader serves this class and its tests. */
+	 * (`docs/sync.md`); this reader serves this class and its tests. */
 	listRounds(): Round[] {
 		return this.sql<RoundRow>`SELECT * FROM round ORDER BY seq`.map(toRound)
 	}
@@ -623,7 +624,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	 *
 	 * The Article Agent runs it, not the client: this returns as soon as the
 	 * row exists, the model call carries on under `waitUntil`, and one Review
-	 * runs at a time, guarded by the running row — §12 for the full argument.
+	 * runs at a time, guarded by the running row — `docs/reviews.md` for the full argument.
 	 */
 	@callable()
 	async startReview(request: unknown): Promise<Round> {
@@ -716,7 +717,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	/**
 	 * The response, as rows. One `commit` for the Notes and the settled Round,
 	 * so a subscriber that hears the Round settle already holds its Notes.
-	 * Each Note keeps the id its passage names it by — §12.
+	 * Each Note keeps the id its passage names it by — `docs/sync.md`.
 	 */
 	private async writeReview(
 		round: Round,
@@ -778,7 +779,7 @@ export class ArticleAgent extends AIChatAgent<Env, Plan> {
 	}
 
 	/** A Review that threw. The reason goes on the row because the writer may
-	 * have left, and a thrown call has nowhere to land — §12. A commit that
+	 * have left, and a thrown call has nowhere to land — `docs/reviews.md`. A commit that
 	 * fails here has no row left to land on either, so log it rather than
 	 * throw into `waitUntil`. */
 	private async failRound(id: string, failure: string): Promise<void> {
@@ -872,7 +873,7 @@ function offerRow(content: ReferenceContent): OfferRow {
 }
 
 /** One Note as a row, ready to commit. Starts proposed; the anchor is settled
- * here, once, against what the Review was shown (§12). */
+ * here, once, against what the Review was shown (`docs/reviews.md`). */
 function noteRow(
 	roundId: string,
 	content: NoteContent,

--- a/src/server/article-index.ts
+++ b/src/server/article-index.ts
@@ -10,11 +10,11 @@ import {
 } from '../shared/article'
 
 /**
- * The article index, over D1 — docs/architecture.md §9. Nothing here reaches
+ * The article index, over D1 — `docs/articles.md`. Nothing here reaches
  * into an Article Agent, so removing a row leaves one exactly as it was.
  *
  * Nothing parses a token either: Access gates the Worker at the edge, and 1a may
- * not require the Cf-Access-Jwt-Assertion header (§9).
+ * not require the Cf-Access-Jwt-Assertion header (architecture.md §4.8).
  */
 
 /** `status` is stated as what the write routes parsed rather than checked again

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,5 +1,5 @@
 // Nothing here parses a token, and nothing may require the
-// Cf-Access-Jwt-Assertion header — docs/architecture.md §9.
+// Cf-Access-Jwt-Assertion header — docs/architecture.md §4.8.
 
 import { routeAgentRequest } from 'agents'
 import { Hono } from 'hono'
@@ -15,7 +15,7 @@ const app = new Hono<{ Bindings: Env }>()
 
 app.get('/api/health', (c) => c.json({ ok: true }))
 
-// The article index, over D1 — architecture.md §9. Mounted ahead of the
+// The article index, over D1 — `docs/articles.md`. Mounted ahead of the
 // catch-all below, which Hono would otherwise match first.
 app.route('/api/articles', articleIndex)
 
@@ -26,7 +26,7 @@ app.all('/agents/*', async (c) => {
 	return response ?? c.text('No such Agent route', 404)
 })
 
-// The party-db sync socket — architecture.md §12. routePartykitRequest maps
+// The party-db sync socket — `docs/sync.md`. routePartykitRequest maps
 // /parties/article-agent/:name onto the same ArticleAgent binding the route
 // above serves.
 app.all('/parties/*', async (c) => {

--- a/src/server/llm/chat-turn.ts
+++ b/src/server/llm/chat-turn.ts
@@ -47,7 +47,7 @@ export async function chatTurn({
 }: ChatTurn): Promise<Response> {
 	const result = streamText({
 		model,
-		// Rules, then conversation and Plan, per Architecture §7
+		// Rules, then conversation and Plan, per `docs/llm.md`
 		system: chatSystemPrompt(search !== undefined),
 		messages: chatPackMessages(await convertToModelMessages(messages), plan),
 		tools: chatTools(search),
@@ -75,7 +75,7 @@ export async function chatTurn({
 	// internals to a browser it does not trust, and this one is the writer's own
 	// app: what it would hide is the schema's reason for refusing the model's
 	// tool call, which is exactly what the writer needs to see when a model
-	// thrashes the retry (§6). The same argument as `plan_refused` in
+	// thrashes the retry (`docs/plan.md`). The same argument as `plan_refused` in
 	// `src/shared/plan/refusal.ts`.
 	return result.toUIMessageStreamResponse({
 		onError: reasonFor,

--- a/src/server/llm/model.ts
+++ b/src/server/llm/model.ts
@@ -2,7 +2,7 @@ import type { LanguageModel } from 'ai'
 import { createWorkersAI } from 'workers-ai-provider'
 
 /**
- * The whole model boundary — `docs/architecture.md` §7. One model serves every
+ * The whole model boundary — `docs/llm.md`. One model serves every
  * call, and this is the only place it is named: swapping the string below is
  * the entire swap. Do not wrap this in `complete()` / `stream()` /
  * `structured()`. AI SDK v7 already provides those as `generateText`,

--- a/src/server/llm/prompt.ts
+++ b/src/server/llm/prompt.ts
@@ -4,7 +4,7 @@ import type { Plan } from '../../shared/plan'
 
 /**
  * The Chat turn's prompt pack — The pack is the conversation plus the Plan,
- * in roughly that order. See Architecture §7.
+ * in roughly that order. See `docs/llm.md`.
  */
 
 /**
@@ -116,7 +116,7 @@ export function planMessage(plan: Plan): ModelMessage {
 
 /**
  * The conversation with the Plan in it — in front of the writer's last message,
- * so the writer's words are the last thing the model reads, per Architecture §7.
+ * so the writer's words are the last thing the model reads, per `docs/llm.md`.
  */
 export function chatPackMessages(
 	conversation: ModelMessage[],
@@ -128,7 +128,7 @@ export function chatPackMessages(
 }
 
 /**
- * Calculates where the Plan goes, per Architecture §7.
+ * Calculates where the Plan goes, per `docs/llm.md`.
  */
 function planSlot(conversation: ModelMessage[]): number {
 	const last = conversation.length - 1

--- a/src/server/llm/repair.ts
+++ b/src/server/llm/repair.ts
@@ -7,7 +7,7 @@ import {
 
 /**
  * One retry of a tool call the schema refused, carrying the validation error
- * back to the model — `docs/architecture.md` §6 and §7.
+ * back to the model — `docs/plan.md` and `docs/llm.md`.
  *
  * The op payloads are strict, so a model that adds one field fails the whole
  * call rather than having the field stripped: stripping would produce a
@@ -20,7 +20,7 @@ import {
  * budget. Returning null gives up and lets the turn carry the error.
  *
  * The tools come from the callback rather than from an import, so this belongs
- * to no one pack — §7 lists four, and each of them wants the same retry.
+ * to no one pack — `docs/llm.md` lists four, and each of them wants the same retry.
  */
 export function repairToolCall(model: LanguageModel): ToolCallRepairFunction<ToolSet> {
 	return async ({ system, messages, toolCall, tools, error }) => {

--- a/src/server/llm/review-pack.ts
+++ b/src/server/llm/review-pack.ts
@@ -7,7 +7,7 @@ import type { ReviewDepth } from '../../shared/review'
 import { judgeAgainstThePlan, planMessage } from './prompt'
 
 /**
- * The Review's prompt pack — `docs/architecture.md` §7, and issue #16 for the
+ * The Review's prompt pack — `docs/llm.md`, and issue #16 for the
  * contents: the Plan, then the Draft, then the Notes already in play, and
  * **no Chat**. Research reaches a Review only by having been Accepted into the
  * Plan, so the Ledger is the bridge and curation is forced rather than assumed.

--- a/src/server/llm/review.ts
+++ b/src/server/llm/review.ts
@@ -21,7 +21,7 @@ import { reviewPackMessages, type ReviewPack, reviewSystemPrompt } from './revie
  * The answer is **prose inside a structure**: the model writes the passages the
  * writer reads, and the schema is what carries each one's Notes and their
  * anchors. Nothing here parses prose to find them. One retry carries the
- * validation error back — `docs/architecture.md` §7.
+ * validation error back — `docs/llm.md`.
  */
 
 export type ReviewTurn = {

--- a/src/server/llm/search.ts
+++ b/src/server/llm/search.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 /**
- * Web search, over Exa's `POST /search` — `docs/architecture.md` §7. The only
+ * Web search, over Exa's `POST /search` — `docs/llm.md`. The only
  * place a search provider is named.
  *
  * The tool's schemas live here rather than in `src/shared`: the Chat Panel
@@ -10,7 +10,7 @@ import { z } from 'zod'
  */
 
 /** What the model fills in to search. Strict like the Proposal's input, so an
- * invented field is refused and retried rather than stripped — §6. */
+ * invented field is refused and retried rather than stripped — `docs/plan.md`. */
 export const webSearchInput = z.strictObject({
 	query: z.string().min(1),
 	/** Published on or after this date, as YYYY-MM-DD. */
@@ -56,7 +56,7 @@ export type WebSearch = (
 ) => Promise<WebSearchOutput>
 
 /** Undefined where no key is set, which is what gives a deployment with no key
- * no search tool rather than one that always fails — §7. */
+ * no search tool rather than one that always fails — `docs/llm.md`. */
 export function webSearch(env: Env): WebSearch | undefined {
 	const key = env.EXA_API_KEY
 	if (!key) return undefined

--- a/src/server/llm/tools.ts
+++ b/src/server/llm/tools.ts
@@ -22,14 +22,14 @@ import { type WebSearch, webSearchInput, webSearchOutput } from './search'
  *
  * The Proposal tool is **`execute`-less**: a tool with no `execute` suspends
  * for the client, and that suspension is the Proposal the writer rules on —
- * `docs/architecture.md` §6. It writes nothing, because the Chat proposes and
- * the client applies (§3, rule 4).
+ * `docs/chat.md`. It writes nothing, because the Chat proposes and
+ * the client applies (architecture.md §4.1).
  *
  * Do not reach for `needsApproval` or `toolApproval`. Both gate a server-side
  * `execute` this product does not have.
  *
  * The Offer tool below carries an `execute` instead, because an Offer is a row
- * the writer rules on later rather than mid-turn — §5. So does the search
+ * the writer rules on later rather than mid-turn — `docs/chat.md`. So does the search
  * tool: a search result is not something the writer rules on at all.
  */
 

--- a/src/shared/article.ts
+++ b/src/shared/article.ts
@@ -3,7 +3,7 @@ import { z } from 'zod'
 /**
  * The article index: one row per Article, and the only record of an Article that
  * lives outside its Article Agent. What it may and may not carry, and why the
- * title lives in two places, is docs/architecture.md §9.
+ * title lives in two places, is docs/architecture.md §4.6.
  */
 
 /** Nothing infers this — 1a has no Draft to measure, so the writer sets it. */

--- a/src/shared/chat.ts
+++ b/src/shared/chat.ts
@@ -21,11 +21,11 @@ export const proposePlanChangeTool = 'proposePlanChange'
  * What the model fills in to make a Proposal, and what the client reads off
  * the suspended call. Strict, like the op payloads inside it: a model that
  * adds a field fails the whole call and retries with the validation error
- * rather than having the field silently stripped — `docs/architecture.md` §6.
+ * rather than having the field silently stripped — `docs/plan.md`.
  *
  * `chatProposalSchema` rather than `proposalSchema`: the applier understands
  * three more ops, and they are the writer's own References. Research reaches
- * the Plan through the Ledger (§5), so the model is never offered a way round
+ * the Plan through the Ledger (`docs/chat.md`), so the model is not offered a way round
  * it.
  */
 export const proposePlanChangeInput = z.strictObject({ ops: chatProposalSchema })
@@ -56,7 +56,7 @@ export type RecordedOffers = z.infer<typeof recordedOffersOutput>
 /**
  * What the client sends alongside the messages. The Plan rides here because
  * `body` is request-only, where `metadata` persists on the `UIMessage` and
- * re-rides every turn (§6).
+ * re-rides every turn (`docs/chat.md`).
  *
  * Not strict: the Agents SDK hands the turn every body key it did not consume
  * itself, and this schema speaks for one of them.

--- a/src/shared/ledger.ts
+++ b/src/shared/ledger.ts
@@ -2,7 +2,7 @@ import type { Disposition, Offer } from './offer'
 import type { Plan, Reference } from './plan'
 
 /**
- * The Offer ledger — docs/architecture.md §5. The View reads Offers and nothing
+ * The Offer ledger — `docs/chat.md`. The View reads Offers and nothing
  * else, because the Ledger belongs to the Chat Panel and what the Plan did with
  * a copy is the Plan Panel's. The two below are the copy Accepting sends across,
  * which is the one thing that does travel between them.
@@ -22,10 +22,10 @@ export function referenceForOffer(plan: Plan, offerId: string): Reference | unde
 	return plan.references.find((reference) => reference.provenance.offerId === offerId)
 }
 
-/** Copied rather than moved — §3, rule 5. It reads what the Offer says and not
+/** Copied rather than moved — architecture.md §4.5. It reads what the Offer says and not
  * what the writer ruled, so the copy can be built before the ruling is sent. */
 export function referenceFromOffer(offer: Offer, id: string): Reference {
-	// Absent rather than undefined — §4.
+	// Absent rather than undefined — `docs/plan.md`.
 	const reference: Reference = {
 		id,
 		type: offer.type,

--- a/src/shared/notes-queue.ts
+++ b/src/shared/notes-queue.ts
@@ -1,7 +1,7 @@
 import type { Note, NoteDisposition } from './note'
 
 /** The View the Notes Panel reads — a query over Notes, the way the Offer
- * ledger is a query over Offers (§5). */
+ * ledger is a query over Offers (`docs/chat.md`). */
 
 export type QueueView = {
 	acceptedOnly: boolean

--- a/src/shared/plan/apply.ts
+++ b/src/shared/plan/apply.ts
@@ -8,7 +8,7 @@ import { planSchema, referenceContent } from './schema'
 /**
  * The client-side applier, working on a copy so that the first op to refuse
  * throws the whole Proposal away. What the ops mean is `docs/architecture.md`
- * §6, and the vocabulary is ops.ts.
+ * `docs/plan.md`, and the vocabulary is ops.ts.
  */
 
 /**
@@ -78,7 +78,7 @@ export type Refusal = {
 	/** The second record a reason names — a merge target, the Section an anchor
 	 * was sought in — and null for the reasons that name one. */
 	other: RefusalSubject | null
-	/** One sentence for the model, which a Declined Proposal sends back (§6), so
+	/** One sentence for the model, which a Declined Proposal sends back (`docs/plan.md`), so
 	 * it names the op and the ids and may run long. The writer's sentence is
 	 * built from the fields above, in `src/client/plan/refusalText.ts`. */
 	message: string
@@ -92,7 +92,7 @@ const articleSubject: RefusalSubject = { of: 'article' }
 const sectionSubject = (id: string): RefusalSubject => ({ of: 'section', id })
 const referenceSubject = (id: string): RefusalSubject => ({ of: 'reference', id })
 
-/** A content op reads `nodeId: null` as the Article — §6. */
+/** A content op reads `nodeId: null` as the Article — `docs/plan.md`. */
 const scopeSubject = (nodeId: string | null): RefusalSubject =>
 	nodeId === null ? articleSubject : sectionSubject(nodeId)
 
@@ -289,7 +289,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			if (site === null) return absent('noSection', sectionSubject(op.nodeId))
 
 			// The unplacing lands in this op or nowhere: the Plan is written whole,
-			// and a Reference naming a node that is gone does not parse — §4.
+			// and a Reference naming a node that is gone does not parse — `docs/plan.md`.
 			const gone = new Set(subtreeIds(site.siblings[site.index]))
 			site.siblings.splice(site.index, 1)
 			for (const reference of plan.references) {
@@ -432,7 +432,7 @@ function applyOp(plan: Plan, op: ProposalOp, index: number): Refusal | null {
 			}
 
 			// The content is replaced whole, so a field the op leaves out is a
-			// field the Reference no longer carries — §4's one spelling per state.
+			// field the Reference no longer carries — `docs/plan.md`, one spelling per state.
 			delete reference.text
 			delete reference.source
 			delete reference.note
@@ -496,7 +496,7 @@ function subtreeIds(node: Pick<OutlineNode, 'id' | 'children'>): string[] {
 }
 
 /** The payload of a createNode op may state an empty Adjectives list where the
- * Plan says absent — §4. */
+ * Plan says absent — `docs/plan.md`. */
 function dropEmptyAdjectives(node: OutlineNode) {
 	if (node.adjectives?.length === 0) delete node.adjectives
 	node.children.forEach(dropEmptyAdjectives)

--- a/src/shared/plan/ops.ts
+++ b/src/shared/plan/ops.ts
@@ -15,7 +15,7 @@ import {
 /**
  * The op vocabulary a Proposal is written in. What the ops mean, how strict the
  * payloads are, and what to do when a model fights that strictness are all
- * `docs/architecture.md` §6. The applier is apply.ts.
+ * `docs/plan.md`. The applier is apply.ts.
  */
 
 /** Nullable and optional say different things: `afterId: null` is first child,
@@ -145,7 +145,7 @@ export const placeReferenceOpSchema = z.strictObject({
  *
  * The applier understanding an op does not mean the Chat may propose it. What
  * the model is offered is the tool schema, and research reaches the Plan
- * through the Ledger — architecture §5. Leave these out of that schema.
+ * through the Ledger — `docs/chat.md`. Leave these out of that schema.
  */
 export const createReferenceOpSchema = z.strictObject({
 	op: z.literal('createReference'),
@@ -197,7 +197,7 @@ export const proposalSchema = z.array(proposalOpSchema).min(1)
  * What the Chat may propose, against `proposalSchema`, which is everything the
  * applier understands. The Reference ops are left out: research reaches the
  * Plan by being Accepted from an Offer, and the Ledger is that bridge —
- * `docs/architecture.md` §5. A model handed `createReference` could put a
+ * `docs/chat.md`. A model handed `createReference` could put a
  * source in the Plan that the writer never ruled on.
  *
  * This is the schema the Proposal tool declares, in `src/shared/chat.ts`.

--- a/src/shared/plan/schema.ts
+++ b/src/shared/plan/schema.ts
@@ -2,12 +2,12 @@ import { z } from 'zod'
 
 /**
  * The Plan's schema, parsed whole on every write. The data model it enforces is
- * `docs/architecture.md` §4, who may write it is §3, and the reasoning behind
+ * `docs/plan.md`, who may write it is `docs/architecture.md` §3, and the reasoning behind
  * both is docs/adr/0002-the-plan-data-model.md.
  */
 
 // `.min(1)` throughout, so that a field carries one spelling of "nothing here"
-// rather than two — §4. A title is the exception below and carries no floor: it
+// rather than two — `docs/plan.md`. A title is the exception below and carries no floor: it
 // is empty from the moment a node is made until the writer types into it.
 export const idSchema = z.string().min(1)
 export const voiceSchema = z.string().min(1)
@@ -173,7 +173,7 @@ function checkIds(plan: Plan, ctx: z.RefinementCtx) {
 	plan.references.forEach((reference, index) => {
 		claim(referenceIds, reference.id, ['references', index, 'id'], 'References')
 
-		// One Offer becomes one Reference — §5.
+		// One Offer becomes one Reference — `docs/chat.md`.
 		const { offerId } = reference.provenance
 		if (offerId !== undefined) {
 			if (offerIds.has(offerId)) {

--- a/src/shared/review.ts
+++ b/src/shared/review.ts
@@ -4,7 +4,7 @@ import { noteContentSchema } from './note'
 import { planSchema } from './plan'
 
 /** A Review and the Round it produces — `docs/reviews.md` for what they are,
- * `docs/architecture.md` §12 for who writes them. */
+ * `docs/sync.md` for who writes them. */
 
 /** How hard one Review works — `docs/reviews.md`. */
 export const reviewDepths = ['quick', 'thorough'] as const
@@ -12,7 +12,7 @@ export type ReviewDepth = (typeof reviewDepths)[number]
 
 /**
  * What the writer asks for. The Plan rides here for the same reason it rides in
- * a Chat turn's `body` (§6): the client may hold a newer one than the Article
+ * a Chat turn's `body` (`docs/chat.md`): the client may hold a newer one than the Article
  * Agent has stored. Absent is ordinary, and state is then the only Plan there
  * is.
  */
@@ -69,7 +69,7 @@ export type Round = {
 	finishedAt: number | null
 }
 
-/** One Review at a time per Article — §12 for why the guard is the row. */
+/** One Review at a time per Article — `docs/reviews.md` for why the guard is the row. */
 export function reviewAlreadyRunning(round: Round): Error {
 	return new Error(`Round ${round.ordinal} is still running on this Article.`)
 }

--- a/src/shared/sync.ts
+++ b/src/shared/sync.ts
@@ -8,7 +8,7 @@ import { reviewDepths, type Round, type RoundPassage, roundStates } from './revi
 
 /**
  * The `note`, `round` and `offer` party-db collections — docs/architecture.md
- * §12.
+ * `docs/sync.md`.
  *
  * The schemas spell the columns as the tables do: snake_case names, JSON
  * columns (`anchor`, `passages`, `source`) as the text they store. `z.string()`
@@ -62,7 +62,7 @@ export const offerRowSchema = z.object({
 	source: z.string().nullable(),
 	note: z.string().nullable(),
 	/** Under a UNIQUE index, so the table itself refuses a second row for one
-	 * source — §12. `fromOffer` is where every row gets one. */
+	 * source — `docs/chat.md`. `fromOffer` is where every row gets one. */
 	fingerprint: z.string(),
 	created_at: z.number(),
 	decided_at: z.number().nullable(),

--- a/test/client/chat-offers.test.ts
+++ b/test/client/chat-offers.test.ts
@@ -5,7 +5,7 @@ import { proposePlanChangeTool, recordOffersTool } from '../../src/shared/chat'
 import { toolPart } from './chat-fixtures'
 
 /** Reading a research turn's result, which is what the transcript's Offer cards
- * are drawn from. The rows themselves arrive through the sync — §12. */
+ * are drawn from. The rows themselves arrive through the sync — `docs/sync.md`. */
 
 const part = (state: string, extra: Record<string, unknown> = {}) =>
 	toolPart(recordOffersTool, state, { input: { offers: [] }, ...extra })

--- a/test/client/chat-proposals.test.ts
+++ b/test/client/chat-proposals.test.ts
@@ -72,7 +72,7 @@ describe('reading a transcript', () => {
 		expect(waitingCount(messages)).toBe(0)
 	})
 
-	/** The research tool resolves inside the turn (§5), so its call sits at
+	/** The research tool resolves inside the turn (`docs/chat.md`), so its call sits at
 	 * `input-available` for as long as the lookup takes. */
 	it('leaves out a research call, which nobody has to rule on', () => {
 		const messages = transcript(

--- a/test/client/plan-edits.test.ts
+++ b/test/client/plan-edits.test.ts
@@ -81,7 +81,7 @@ describe('the fields', () => {
 		const described = applied(spoken, setAdjectives(spoken, 'a', ['wry', 'somber']))
 		expect(described.outline[0].adjectives).toEqual(['wry', 'somber'])
 
-		// A Section states no Adjectives by carrying no key at all — §4.
+		// A Section states no Adjectives by carrying no key at all — `docs/plan.md`.
 		const emptied = applied(described, setAdjectives(described, 'a', []))
 		expect('adjectives' in emptied.outline[0]).toBe(false)
 	})

--- a/test/shared/plan-ops.test.ts
+++ b/test/shared/plan-ops.test.ts
@@ -107,7 +107,7 @@ describe('what the Chat may propose', () => {
 	})
 
 	// Research reaches the Plan by being Accepted from an Offer, and the Ledger
-	// is that bridge — docs/architecture.md §5. The applier still understands
+	// is that bridge — `docs/chat.md`. The applier still understands
 	// the op, because the writer's own paste goes through it.
 	it('refuses the Reference ops, which the applier understands', () => {
 		expect(chatProposalSchema.safeParse([createReference]).success).toBe(false)

--- a/test/shared/plan-schema.test.ts
+++ b/test/shared/plan-schema.test.ts
@@ -245,7 +245,7 @@ describe('the Reference invariant', () => {
 		expect(result.success).toBe(true)
 	})
 
-	// One Offer becomes one Reference — §5.
+	// One Offer becomes one Reference — `docs/chat.md`.
 	it('refuses two References copied from one Offer', () => {
 		const twice = makePlan({
 			references: [

--- a/test/worker/agent-socket.ts
+++ b/test/worker/agent-socket.ts
@@ -79,7 +79,7 @@ export async function openAgentSocket(name: string) {
 		 *
 		 * The Plan rides in `body`, which is request-only, and never in
 		 * `metadata`, which persists on the `UIMessage` and re-rides every turn
-		 * — docs/architecture.md §6. */
+		 * — `docs/chat.md`. */
 		async chat(text: string, body: Record<string, unknown> = {}): Promise<Frame[]> {
 			const id = crypto.randomUUID()
 			const message = {

--- a/test/worker/article-agent.test.ts
+++ b/test/worker/article-agent.test.ts
@@ -25,7 +25,7 @@ async function createOffer(name: string, content: ReferenceContent): Promise<Off
 }
 
 /** Every Offer, read inside the Agent. `listOffers` is not `@callable`: a
- * client reads its synced `offer` collection (§12), which `sync.test.ts`
+ * client reads its synced `offer` collection (`docs/sync.md`), which `sync.test.ts`
  * covers. */
 function listOffers(name: string): Promise<Offer[]> {
 	return inAgent(name, (agent) => agent.listOffers())
@@ -33,7 +33,7 @@ function listOffers(name: string): Promise<Offer[]> {
 
 /** The `offer` table as it stood before the fingerprint column, so a test can
  * wake an Agent onto the shape a deployed Article has. Raw SQL against a synced
- * table, which §12 forbids the app — this stands a schema up rather than writing
+ * table, which `docs/sync.md` keeps the app out of — this stands a schema up rather than writing
  * a row the app would write. */
 function toOldOfferTable(name: string): Promise<void> {
 	return inAgent(name, (agent) => {
@@ -140,7 +140,7 @@ describe('Offers in the Article Agent', () => {
 		// of adding a method: `recordOffers` stays off it, because the Guide
 		// writes Offers and the writer never authors one.
 		// `listNotes`, `listRounds` and `listOffers` are off it too — a client
-		// reads all three from its synced collections (§12), not over RPC.
+		// reads all three from its synced collections (`docs/sync.md`), not over RPC.
 		expect(methods.sort()).toEqual([
 			'listBlocks',
 			'resolveNote',

--- a/test/worker/article-index.test.ts
+++ b/test/worker/article-index.test.ts
@@ -163,7 +163,7 @@ describe('discarding a row', () => {
 })
 
 describe('the index against the Article Agent', () => {
-	// The index is a list, not a store — architecture.md §9.
+	// The index is a list, not a store — `docs/articles.md`.
 	it('leaves the Article Agent alone when its row is removed', async () => {
 		const article = await createdArticle({ title: 'Held elsewhere' })
 

--- a/test/worker/chat-tools.test.ts
+++ b/test/worker/chat-tools.test.ts
@@ -33,7 +33,7 @@ describe('the Proposal tool', () => {
 	})
 
 	// The other half of the same rule. Research reaches the Plan by the writer
-	// Accepting an Offer — architecture §5 — so the ops that put a Reference in
+	// Accepting an Offer — `docs/chat.md` — so the ops that put a Reference in
 	// the Plan are neither offered nor described.
 	it('teaches no op it does not offer', () => {
 		for (const op of ['createReference', 'deleteReference', 'setReference']) {

--- a/test/worker/chat-turn.test.ts
+++ b/test/worker/chat-turn.test.ts
@@ -12,7 +12,7 @@ import { type Frame, openAgentSocket } from './agent-socket'
 import { calledATool, noUsage, scriptModel, scriptSearch, stopped } from './scripted'
 
 /**
- * The server side of a Chat turn — docs/architecture.md §6 and §7.
+ * The server side of a Chat turn — `docs/chat.md` and `docs/llm.md`.
  *
  * No test calls a model: Workers AI is a remote-only binding and
  * `vitest.config.ts` keeps remote bindings off, so a fresh clone can run
@@ -199,7 +199,7 @@ describe('a Chat turn', () => {
 	})
 
 	// The transcript is append-only and the Plan is not, so the Plan follows the
-	// conversation — §7. It goes in front of the last message rather than after
+	// conversation — `docs/llm.md`. It goes in front of the last message rather than after
 	// it, so the writer's own words stay the last thing the model reads.
 	it('packs the guide rules, then the conversation, then the Plan', async () => {
 		const writer = await openAgentSocket('chat-pack')
@@ -376,7 +376,7 @@ describe('a Chat turn', () => {
 	})
 
 	// The op payloads are strict, so a model that adds a field fails the whole
-	// call rather than having the field stripped — docs/architecture.md §6.
+	// call rather than having the field stripped — `docs/plan.md`.
 	it('retries a refused tool call, carrying the validation error back', async () => {
 		const writer = await openAgentSocket('chat-retry')
 		const withExtraField = JSON.stringify({
@@ -400,7 +400,7 @@ describe('a Chat turn', () => {
 		})
 	})
 
-	// The failure mode §6 names as the cost of strict payloads: a model that
+	// The failure mode `docs/plan.md` names as the cost of strict payloads: a model that
 	// adds the same field every time thrashes the retry instead of converging.
 	// One retry is the whole budget, so the second refusal ends the turn.
 	it('gives up when the retry is refused too, and says so', async () => {
@@ -443,7 +443,7 @@ describe('a Chat turn', () => {
 })
 
 /**
- * Where the Plan lands, read off `chatPackMessages` directly — §7.
+ * Where the Plan lands, read off `chatPackMessages` directly — `docs/llm.md`.
  *
  * The turns above drive the two transcripts the product actually produces: one
  * ending on the writer's message, and one ending on a settled tool result. The

--- a/test/worker/review.test.ts
+++ b/test/worker/review.test.ts
@@ -7,8 +7,8 @@ import { answers, ask, response, settled } from './review-fixtures'
 import { inAgent, scriptModel } from './scripted'
 
 /**
- * The Review, end to end inside the Article Agent — `docs/architecture.md` §3,
- * §7, and §12. What these drive is `reviewModel()`, replaced with a scripted
+ * The Review, end to end inside the Article Agent — architecture.md §3,
+ * `docs/llm.md`, and `docs/sync.md`. What these drive is `reviewModel()`, replaced with a scripted
  * one — `scripted.ts` for why no test calls a real model.
  */
 

--- a/test/worker/scripted.ts
+++ b/test/worker/scripted.ts
@@ -42,7 +42,7 @@ export function inAgent<T>(
  * Put a scripted model behind one of the Article Agent's model boundaries.
  *
  * The method is named rather than assumed, because the Chat and the Review each
- * read their own (§7 leaves room for them to differ), and a test that scripts
+ * read their own (`docs/llm.md` leaves room for them to differ), and a test that scripts
  * the wrong one passes for the wrong reason.
  */
 export function scriptModel(

--- a/test/worker/smoke.test.ts
+++ b/test/worker/smoke.test.ts
@@ -26,7 +26,7 @@ describe('the Worker', () => {
 		})
 	})
 
-	// No Cf-Access-Jwt-Assertion header, per architecture.md §9.
+	// No Cf-Access-Jwt-Assertion header, per architecture.md §4.8.
 	it('answers the health route rather than the SPA fallback', async () => {
 		const response = await SELF.fetch('https://harness.test/api/health')
 

--- a/test/worker/sync-socket.ts
+++ b/test/worker/sync-socket.ts
@@ -3,7 +3,7 @@ import { PROTO_PARAM, PROTO_VALUE, type SequencedBatch } from 'party-db'
 
 /**
  * A test client on the Article Agent's party-db socket — the second socket of
- * architecture.md §12. The real client is `partyTransport`, which the browser
+ * `docs/sync.md`. The real client is `partyTransport`, which the browser
  * runs; a workerd test connects the same way it does: the partyserver route,
  * `?proto=party-db`, and `?since` for a reconnect.
  */

--- a/test/worker/sync.test.ts
+++ b/test/worker/sync.test.ts
@@ -8,7 +8,7 @@ import { inAgent, scriptModel } from './scripted'
 import { isBatch, openSyncSocket, postWrite } from './sync-socket'
 
 /**
- * The party-db room composed into the Article Agent — architecture.md §12: a
+ * The party-db room composed into the Article Agent — `docs/sync.md`: a
  * subscriber sees Notes, Rounds and Offers land as the Guide commits them and
  * nothing else, an app socket sees no batches, a reconnect catches up from
  * `?since`, and a client collection write is refused.

--- a/test/worker/web-search.test.ts
+++ b/test/worker/web-search.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { webSearch, type WebSearchInput } from '../../src/server/llm/search'
 
 /**
- * The search boundary — `docs/architecture.md` §7. No test reaches the
+ * The search boundary — `docs/llm.md`. No test reaches the
  * provider: `fetch` is stubbed, and what is under test is the request built,
  * the response read, and the rule that a failure answers rather than throws.
  */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,19 @@ export default defineConfig({
 		// build, so the Worker is untouched.
 		babel({ presets: [reactCompilerPreset()] }),
 		tailwindcss(),
-		// Cloudflare's workaround for `@callable` support in Vite 8.
+		// Cloudflare's workaround for `@callable` support in Vite 8. Vite 8
+		// transpiles with oxc, which does not implement TC39 decorators
+		// (oxc#9170) and emits the `@` syntax verbatim, so the Worker fails to
+		// parse with "SyntaxError: Invalid or unexpected token". This plugin
+		// lowers them through Babel.
+		//
+		// `experimentalDecorators` is not the fix: the SDK uses standard
+		// decorators, and the legacy convention hands `callable()` the prototype
+		// instead of the method, so nothing registers and every RPC call is
+		// refused at runtime with "is not callable" — a silent failure where the
+		// missing plugin is a loud one.
+		//
+		// `vitest.config.ts` names it separately; the two files share no plugins.
 		forStorybook ? [] : agents(),
 		// Runs the Worker in workerd beside the client, so `pnpm dev` serves both.
 		forStorybook

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,7 +45,10 @@ export default defineConfig({
 			},
 			{
 				plugins: [
-					// Cloudflare's workaround for `@callable` support in Vite 8.
+					// Cloudflare's workaround for `@callable` support in Vite 8 —
+					// `vite.config.ts` carries the reasoning. A worker test builds the
+					// Article Agent, and the two files share no plugins, so it is named
+					// in both.
 					agents(),
 					// `cloudflareTest` is the current API. Most docs still show
 					// `defineWorkersConfig` with `poolOptions.workers`, which no longer

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -39,7 +39,7 @@
       "new_sqlite_classes": ["ArticleAgent"],
     },
   ],
-  // The article index — architecture.md §9. Its schema lives in ./migrations;
+  // The article index — docs/articles.md. Its schema lives in ./migrations;
   // `pnpm db:migrate` applies it locally and `db:migrate:remote` to the deploy.
   // database_id is what binds; database_name is a label.
   "d1_databases": [


### PR DESCRIPTION
`architecture.md` had grown to 747 lines, too long to skim at the start of a thread. Most of
that length described a single module's internals, which a reader met whether or not they
were working on that module. This branch splits it and rewrites what is left.

Read the commits in order. Commit 1 adds the new files, commit 2 shrinks `architecture.md`,
and commit 5 rewrites everything in plain technical English.

## What moved where

| Content | Now in |
| --- | --- |
| The Plan's shape, spelling rules, ops, applier, refusals | `plan.md` |
| The Chat, the Offers Ledger, the Proposal tool machinery | `chat.md` |
| party-db's four seams, `commit()`, wire rows, migrations | `sync.md` |
| The model boundary, search, the prompt packs | `llm.md` |
| Draft storage, the editor, the guide loop | `draft.md` |
| The article index and both Views | `articles.md` |
| Settings we hold and defects we work around | `carries.md` |
| Panel widths, Loading states, Stale-card wording | `ui.md` (expanded) |
| The Review's `state` column and one-at-a-time guard | `reviews.md` (expanded) |
| The `agents/vite` decorator reasoning | a comment in `vite.config.ts` |

`architecture.md` keeps the rules that bind more than one module: Scale, Shape, Where writes
go, and nine Seams. A rule belongs there if it takes the form "P does Q, because R requires
S", so that when R changes the rule is up for review.

## What was cut, not moved

- **The build order table.** Stages are project management. They already live as issues —
  1a as the closed #21 to #29 series, 1b as #53, phase 2 as #54 — and section 1 points there.
- **The doc map table**, now one line of links in the opening paragraph.
- **A four-paragraph account of what would happen if Accepting ruled the Offer before writing
  the Plan.** The order is still fixed and still load-bearing, so three sentences say so in
  `chat.md`. Verified against `src/client/lib/useOfferLedger.ts:55` before cutting.
- **The paragraph about pasting a Reference by hand**, which described a visible feature
  rather than a constraint.
- **Section 3's old rule 4, "the Guide writes only Notes."** That was false — the Guide
  already wrote Offers and Rounds. Commit 8 restores it as a corrected observation that names
  the one thing resting on it.

## The prose rewrite

Commit 5 is the largest single change and touches every file. The first pass wrote headlines
rather than sentences: a bolded claim opening each paragraph, counts whose members were never
named ("two writes against two stores"), and headings built by word association
("`src/shared` is the contract, and it imports neither side").

Every paragraph now leads with its subject and states relevance first. Where a sentence
counts things, the next clause names them. Headings name a subject. No paragraph opens with a
bolded lede.

The ten docs total 7,903 words against 8,948 in the three files they replace.

## Changes outside this diff

Eleven issue bodies cite `architecture.md` by section number, and the renumbering broke most
of those citations. I edited the bodies to name the file that now holds each rule, and posted
no comments: #40, #42, #53, #54, #72, #77, #78, #80, #92, #96, #97.

Two in #40 were content fixes rather than citation fixes, and are worth a look:

- It claimed the article index lives in `localStorage`, so an Article made on one machine does
  not appear on the other. #29 shipped it as a D1 table, so that was the opposite of true.
- It cited the "Guide writes only Notes" rule this branch removed. The bullet now states what
  the Guide writes and records that the rule went, and why.

It also carries a dated status note, because every timing premise in its "After 1a, Before 1b"
argument has resolved. The reasoning is left standing as the record of why the call was made.

Every citation left in the repo and in every open issue now names a section that exists.

## Checks

`pnpm typecheck` fails on `EXA_API_KEY`, and 2 of 508 tests fail in
`test/worker/chat-turn.test.ts`. Both failures are on `main` and predate this branch. Every
source change here is comment-only — `git diff -U0 main..HEAD -- src/` filtered to
non-comment lines is empty — so neither failure comes from this work. Neither is fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4jgHeeQC2J2cis3xaYanB
